### PR TITLE
Test adata.prsrc() with device layer

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/80fd13f21d6ec05a76a82d714a3dc6783ed0525a.zip",
-            "hash": "1220b7325d36ffc41a0efdcd8581e3dc18460326096bfa2be7d2b01d05ee52180096"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f9afd63ed7f5e1d4c03b4ec87b75059e5fa9e98b.zip",
+            "hash": "122072bc0ff0f8c92c01ab590a5bb9cde5188e3144be147691f4d289f98af53876ef"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2225dd6ccc16eea587637d72b509e5b064f03ed3.zip",
-            "hash": "122034e30e8754a7950a346c90946a50b8d715461f63c28251dcf96d804c1bd80cf4"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/b2ad5e34b31d717758a7f1721a41f552b3b9d607.zip",
+            "hash": "1220d300b3e642069f1cfd8e4e8f3edf15b8e4109df8c6be89aaf9838dbe9d0e6e03"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f9afd63ed7f5e1d4c03b4ec87b75059e5fa9e98b.zip",
-            "hash": "122072bc0ff0f8c92c01ab590a5bb9cde5188e3144be147691f4d289f98af53876ef"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/4b3f97a84fcebdda32dfbe3646f453bc979e81c4.zip",
+            "hash": "12203ff3e6a0b8fc8182a89554f401e0b937ebe0e2449f8e9b75329b8a0363b58b86"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/b2ad5e34b31d717758a7f1721a41f552b3b9d607.zip",
-            "hash": "1220d300b3e642069f1cfd8e4e8f3edf15b8e4109df8c6be89aaf9838dbe9d0e6e03"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/a334bd82ac34f937289bbda73f47991142431d23.zip",
+            "hash": "12205e9fd7d3544821610c28fa0321bccf07f0de15d14f86c669b658f0363ec615f6"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/80fd13f21d6ec05a76a82d714a3dc6783ed0525a.zip",
-            "hash": "1220b7325d36ffc41a0efdcd8581e3dc18460326096bfa2be7d2b01d05ee52180096"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f9afd63ed7f5e1d4c03b4ec87b75059e5fa9e98b.zip",
+            "hash": "122072bc0ff0f8c92c01ab590a5bb9cde5188e3144be147691f4d289f98af53876ef"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2225dd6ccc16eea587637d72b509e5b064f03ed3.zip",
-            "hash": "122034e30e8754a7950a346c90946a50b8d715461f63c28251dcf96d804c1bd80cf4"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/b2ad5e34b31d717758a7f1721a41f552b3b9d607.zip",
+            "hash": "1220d300b3e642069f1cfd8e4e8f3edf15b8e4109df8c6be89aaf9838dbe9d0e6e03"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f9afd63ed7f5e1d4c03b4ec87b75059e5fa9e98b.zip",
-            "hash": "122072bc0ff0f8c92c01ab590a5bb9cde5188e3144be147691f4d289f98af53876ef"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/4b3f97a84fcebdda32dfbe3646f453bc979e81c4.zip",
+            "hash": "12203ff3e6a0b8fc8182a89554f401e0b937ebe0e2449f8e9b75329b8a0363b58b86"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/b2ad5e34b31d717758a7f1721a41f552b3b9d607.zip",
-            "hash": "1220d300b3e642069f1cfd8e4e8f3edf15b8e4109df8c6be89aaf9838dbe9d0e6e03"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/a334bd82ac34f937289bbda73f47991142431d23.zip",
+            "hash": "12205e9fd7d3544821610c28fa0321bccf07f0de15d14f86c669b658f0363ec615f6"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
+++ b/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
@@ -23,6 +23,19 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv4/unicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv4/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -48,6 +61,19 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topo
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry:
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry(topology_name=n.get_str('topology-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv4/multicast/topologies/topology')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology({repr(self.topology_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv4/multicast/topologies/topology'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry]
@@ -118,6 +144,26 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(yang.
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv4/multicast/topologies')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies()')
+        leaves = []
+        _topology = self.topology
+        for _element in _topology.elements:
+            res.append('')
+            res.append(f"# List /address-family/ipv4/multicast/topologies/topology element: {_element.to_gdata().key_str(['topology-name'])}")
+            list_elem = f'topology_element = {self_name}.topology.create({repr(_element.topology_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'topology_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv4/multicast/topologies'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -144,6 +190,22 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(yang.adata.MNode)
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies.from_gdata(n.get_opt_container('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv4/multicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast()')
+        leaves = []
+        _topologies = self.topologies
+        if _topologies is not None:
+            res.extend(_topologies.prsrc(f'{self_name}.topologies', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv4/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -182,6 +244,28 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast.from_gdata(n.get_opt_container('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv4')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /address-family/ipv4/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -206,6 +290,19 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv6/unicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv6/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(node: xml.Node) -> yang.gdata.Container:
@@ -232,6 +329,19 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topo
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry:
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry(topology_name=n.get_str('topology-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv6/multicast/topologies/topology')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology({repr(self.topology_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv6/multicast/topologies/topology'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry]
@@ -302,6 +412,26 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(yang.
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv6/multicast/topologies')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies()')
+        leaves = []
+        _topology = self.topology
+        for _element in _topology.elements:
+            res.append('')
+            res.append(f"# List /address-family/ipv6/multicast/topologies/topology element: {_element.to_gdata().key_str(['topology-name'])}")
+            list_elem = f'topology_element = {self_name}.topology.create({repr(_element.topology_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'topology_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv6/multicast/topologies'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -328,6 +458,22 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(yang.adata.MNode)
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies.from_gdata(n.get_opt_container('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv6/multicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast()')
+        leaves = []
+        _topologies = self.topologies
+        if _topologies is not None:
+            res.extend(_topologies.prsrc(f'{self_name}.topologies', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv6/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -366,6 +512,28 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast.from_gdata(n.get_opt_container('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family/ipv6')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /address-family/ipv6/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -399,6 +567,25 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.extend(_ipv4.prsrc(f'{self_name}.ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.extend(_ipv6.prsrc(f'{self_name}.ipv6', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family(node: xml.Node) -> yang.gdata.Container:
@@ -448,6 +635,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt({repr(self.as_number)}, {repr(self.index)}, {repr(self.stitching)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -528,6 +728,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts()')
+        leaves = []
+        _two_byte_as_rt = self.two_byte_as_rt
+        for _element in _two_byte_as_rt.elements:
+            res.append('')
+            res.append(f"# List /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt element: {_element.to_gdata().key_str(['as-number', 'index', 'stitching'])}")
+            list_elem = f'two_byte_as_rt_element = {self_name}.two_byte_as_rt.create({repr(_element.as_number)}, {repr(_element.index)}, {repr(_element.stitching)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'two_byte_as_rt_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -555,6 +775,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/import/route-target')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target()')
+        leaves = []
+        _two_byte_as_rts = self.two_byte_as_rts
+        if _two_byte_as_rts is not None:
+            res.extend(_two_byte_as_rts.prsrc(f'{self_name}.two_byte_as_rts', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/import/route-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -581,6 +817,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/import')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import()')
+        leaves = []
+        _route_target = self.route_target
+        if _route_target is not None:
+            res.extend(_route_target.prsrc(f'{self_name}.route_target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/import'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(node: xml.Node) -> yang.gdata.Container:
@@ -625,6 +877,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt({repr(self.as_number)}, {repr(self.index)}, {repr(self.stitching)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -705,6 +970,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts()')
+        leaves = []
+        _two_byte_as_rt = self.two_byte_as_rt
+        for _element in _two_byte_as_rt.elements:
+            res.append('')
+            res.append(f"# List /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt element: {_element.to_gdata().key_str(['as-number', 'index', 'stitching'])}")
+            list_elem = f'two_byte_as_rt_element = {self_name}.two_byte_as_rt.create({repr(_element.as_number)}, {repr(_element.index)}, {repr(_element.stitching)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'two_byte_as_rt_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -732,6 +1017,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/export/route-target')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target()')
+        leaves = []
+        _two_byte_as_rts = self.two_byte_as_rts
+        if _two_byte_as_rts is not None:
+            res.extend(_two_byte_as_rts.prsrc(f'{self_name}.two_byte_as_rts', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/export/route-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -758,6 +1059,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast/export')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export()')
+        leaves = []
+        _route_target = self.route_target
+        if _route_target is not None:
+            res.extend(_route_target.prsrc(f'{self_name}.route_target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast/export'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(node: xml.Node) -> yang.gdata.Container:
@@ -791,6 +1108,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(yang.ada
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import.from_gdata(n.get_opt_container('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export.from_gdata(n.get_opt_container('export')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/unicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast()')
+        leaves = []
+        _import_ = self.import_
+        if _import_ is not None:
+            res.extend(_import_.prsrc(f'{self_name}.import_', False).splitlines())
+        _export = self.export
+        if _export is not None:
+            res.extend(_export.prsrc(f'{self_name}.export', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -816,6 +1152,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(yang.a
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/multicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -836,6 +1185,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(yang.ad
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4/flowspec')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4/flowspec'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(node: xml.Node) -> yang.gdata.Container:
@@ -887,6 +1249,37 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast.from_gdata(n.get_opt_container('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec.from_gdata(n.get_opt_container('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv4')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv4/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv4/multicast')
+            res.append(f'multicast = {self_name}.create_multicast()')
+            res.extend(_multicast.prsrc('multicast', False).splitlines())
+        _flowspec = self.flowspec
+        if _flowspec is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv4/flowspec')
+            res.append(f'flowspec = {self_name}.create_flowspec()')
+            res.extend(_flowspec.prsrc('flowspec', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -934,6 +1327,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt({repr(self.as_number)}, {repr(self.index)}, {repr(self.stitching)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -1014,6 +1420,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/import/route-target/two-byte-as-rts')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts()')
+        leaves = []
+        _two_byte_as_rt = self.two_byte_as_rt
+        for _element in _two_byte_as_rt.elements:
+            res.append('')
+            res.append(f"# List /vrfs/vrf/address-family/ipv6/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt element: {_element.to_gdata().key_str(['as-number', 'index', 'stitching'])}")
+            list_elem = f'two_byte_as_rt_element = {self_name}.two_byte_as_rt.create({repr(_element.as_number)}, {repr(_element.index)}, {repr(_element.stitching)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'two_byte_as_rt_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/import/route-target/two-byte-as-rts'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1041,6 +1467,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/import/route-target')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target()')
+        leaves = []
+        _two_byte_as_rts = self.two_byte_as_rts
+        if _two_byte_as_rts is not None:
+            res.extend(_two_byte_as_rts.prsrc(f'{self_name}.two_byte_as_rts', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/import/route-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1067,6 +1509,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/import')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import()')
+        leaves = []
+        _route_target = self.route_target
+        if _route_target is not None:
+            res.extend(_route_target.prsrc(f'{self_name}.route_target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/import'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(node: xml.Node) -> yang.gdata.Container:
@@ -1111,6 +1569,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt({repr(self.as_number)}, {repr(self.index)}, {repr(self.stitching)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -1191,6 +1662,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/export/route-target/two-byte-as-rts')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts()')
+        leaves = []
+        _two_byte_as_rt = self.two_byte_as_rt
+        for _element in _two_byte_as_rt.elements:
+            res.append('')
+            res.append(f"# List /vrfs/vrf/address-family/ipv6/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt element: {_element.to_gdata().key_str(['as-number', 'index', 'stitching'])}")
+            list_elem = f'two_byte_as_rt_element = {self_name}.two_byte_as_rt.create({repr(_element.as_number)}, {repr(_element.index)}, {repr(_element.stitching)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'two_byte_as_rt_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/export/route-target/two-byte-as-rts'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1218,6 +1709,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/export/route-target')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target()')
+        leaves = []
+        _two_byte_as_rts = self.two_byte_as_rts
+        if _two_byte_as_rts is not None:
+            res.extend(_two_byte_as_rts.prsrc(f'{self_name}.two_byte_as_rts', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/export/route-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1244,6 +1751,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast/export')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export()')
+        leaves = []
+        _route_target = self.route_target
+        if _route_target is not None:
+            res.extend(_route_target.prsrc(f'{self_name}.route_target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast/export'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(node: xml.Node) -> yang.gdata.Container:
@@ -1277,6 +1800,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(yang.ada
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import.from_gdata(n.get_opt_container('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export.from_gdata(n.get_opt_container('export')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/unicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast()')
+        leaves = []
+        _import_ = self.import_
+        if _import_ is not None:
+            res.extend(_import_.prsrc(f'{self_name}.import_', False).splitlines())
+        _export = self.export
+        if _export is not None:
+            res.extend(_export.prsrc(f'{self_name}.export', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1302,6 +1844,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(yang.a
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/multicast')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1322,6 +1877,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(yang.ad
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6/flowspec')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6/flowspec'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(node: xml.Node) -> yang.gdata.Container:
@@ -1373,6 +1941,37 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast.from_gdata(n.get_opt_container('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec.from_gdata(n.get_opt_container('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family/ipv6')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv6/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv6/multicast')
+            res.append(f'multicast = {self_name}.create_multicast()')
+            res.extend(_multicast.prsrc('multicast', False).splitlines())
+        _flowspec = self.flowspec
+        if _flowspec is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/address-family/ipv6/flowspec')
+            res.append(f'flowspec = {self_name}.create_flowspec()')
+            res.extend(_flowspec.prsrc('flowspec', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1409,6 +2008,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.extend(_ipv4.prsrc(f'{self_name}.ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.extend(_ipv6.prsrc(f'{self_name}.ipv6', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1433,6 +2051,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/mode/big')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/mode/big'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(node: xml.Node) -> yang.gdata.Container:
@@ -1464,6 +2095,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(big=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big.from_gdata(n.get_opt_container('big')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/mode')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode()')
+        leaves = []
+        _big = self.big
+        if _big is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/mode/big')
+            res.append(f'big = {self_name}.create_big()')
+            res.extend(_big.prsrc('big', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/mode'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1494,6 +2144,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(id=n.get_opt_str('id'))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/vpn')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn()')
+        leaves = []
+        _id = self.id
+        if _id is not None:
+            leaves.append(f'{self_name}.id = {repr(_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1519,6 +2185,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(yang.a
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/remote-route-filtering/disable')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/remote-route-filtering/disable'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(node: xml.Node) -> yang.gdata.Container:
@@ -1549,6 +2228,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(yang.adata.MNod
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(disable=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable.from_gdata(n.get_opt_container('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/remote-route-filtering')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/remote-route-filtering/disable')
+            res.append(f'disable = {self_name}.create_disable()')
+            res.extend(_disable.prsrc('disable', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/remote-route-filtering'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(node: xml.Node) -> yang.gdata.Container:
@@ -1591,6 +2289,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/rd/two-byte-as')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/rd/two-byte-as'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1631,6 +2348,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/rd/four-byte-as')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/rd/four-byte-as'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1670,6 +2406,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/rd/ip-address')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address()')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/rd/ip-address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(node: xml.Node) -> yang.gdata.Container:
@@ -1724,6 +2479,37 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(two_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_container('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_container('four-byte-as')), ip_address=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_container('ip-address')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf/rd')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd()')
+        leaves = []
+        _two_byte_as = self.two_byte_as
+        if _two_byte_as is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/rd/two-byte-as')
+            res.append(f'two_byte_as = {self_name}.create_two_byte_as()')
+            res.extend(_two_byte_as.prsrc('two_byte_as', False).splitlines())
+        _four_byte_as = self.four_byte_as
+        if _four_byte_as is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/rd/four-byte-as')
+            res.append(f'four_byte_as = {self_name}.create_four_byte_as()')
+            res.extend(_four_byte_as.prsrc('four_byte_as', False).splitlines())
+        _ip_address = self.ip_address
+        if _ip_address is not None:
+            res.append('')
+            res.append('# P-container: /vrfs/vrf/rd/ip-address')
+            res.append(f'ip_address = {self_name}.create_ip_address()')
+            res.extend(_ip_address.prsrc('ip_address', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf/rd'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(node: xml.Node) -> yang.gdata.Container:
@@ -1788,6 +2574,40 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'), address_family=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family.from_gdata(n.get_opt_container('address-family')), mode=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode.from_gdata(n.get_opt_container('mode')), vpn=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn.from_gdata(n.get_opt_container('vpn')), description=n.get_opt_str('description'), remote_route_filtering=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering.from_gdata(n.get_opt_container('remote-route-filtering')), fallback_vrf=n.get_opt_str('fallback-vrf'), rd=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd.from_gdata(n.get_opt_container('rd')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs/vrf')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf({repr(self.vrf_name)})')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            res.extend(_address_family.prsrc(f'{self_name}.address_family', False).splitlines())
+        _mode = self.mode
+        if _mode is not None:
+            res.extend(_mode.prsrc(f'{self_name}.mode', False).splitlines())
+        _vpn = self.vpn
+        if _vpn is not None:
+            res.extend(_vpn.prsrc(f'{self_name}.vpn', False).splitlines())
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _remote_route_filtering = self.remote_route_filtering
+        if _remote_route_filtering is not None:
+            res.extend(_remote_route_filtering.prsrc(f'{self_name}.remote_route_filtering', False).splitlines())
+        _fallback_vrf = self.fallback_vrf
+        if _fallback_vrf is not None:
+            leaves.append(f'{self_name}.fallback_vrf = {repr(_fallback_vrf)}')
+        _rd = self.rd
+        if _rd is not None:
+            res.extend(_rd.prsrc(f'{self_name}.rd', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs/vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry]
@@ -1872,6 +2692,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrfs')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrfs()')
+        leaves = []
+        _vrf = self.vrf
+        for _element in _vrf.elements:
+            res.append('')
+            res.append(f"# List /vrfs/vrf element: {_element.to_gdata().key_str(['vrf-name'])}")
+            list_elem = f'vrf_element = {self_name}.vrf.create({repr(_element.vrf_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrfs'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1894,6 +2734,19 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(yang.adata.MNode)
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /selective-vrf-download/disable')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /selective-vrf-download/disable'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(node: xml.Node) -> yang.gdata.Container:
@@ -1924,6 +2777,25 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(disable=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable.from_gdata(n.get_opt_container('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /selective-vrf-download')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            res.append('')
+            res.append('# P-container: /selective-vrf-download/disable')
+            res.append(f'disable = {self_name}.create_disable()')
+            res.extend(_disable.prsrc('disable', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /selective-vrf-download'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(node: xml.Node) -> yang.gdata.Container:
@@ -1968,6 +2840,25 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(srlg_name=n.get_str('srlg-name'), value=n.get_opt_int('value'), description=n.get_opt_str('description'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/names/name')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__names__name({repr(self.srlg_name)})')
+        leaves = []
+        _value = self.value
+        if _value is not None:
+            leaves.append(f'{self_name}.value = {repr(_value)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/names/name'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry]
@@ -2042,6 +2933,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__names()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/names')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__names()')
+        leaves = []
+        _name = self.name
+        for _element in _name.elements:
+            res.append('')
+            res.append(f"# List /srlg/names/name element: {_element.to_gdata().key_str(['srlg-name'])}")
+            list_elem = f'name_element = {self_name}.name.create({repr(_element.srlg_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'name_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/names'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2074,6 +2985,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(yang
         if n != None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(priority=n.get_opt_str('priority'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/include-optical')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/include-optical'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(node: xml.Node) -> yang.gdata.Container:
@@ -2118,6 +3045,25 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/indexes/index')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index({repr(self.index_number)})')
+        leaves = []
+        _value = self.value
+        if _value is not None:
+            leaves.append(f'{self_name}.value = {repr(_value)}')
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/indexes/index'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry]
@@ -2192,6 +3138,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(yang.adata.M
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/indexes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes()')
+        leaves = []
+        _index = self.index
+        for _element in _index.elements:
+            res.append('')
+            res.append(f"# List /srlg/interfaces/interface/indexes/index element: {_element.to_gdata().key_str(['index-number'])}")
+            list_elem = f'index_element = {self_name}.index.create({repr(_element.index_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'index_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/indexes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2219,6 +3185,19 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(ya
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(srlg_name=n.get_str('srlg-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/names/name')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name({repr(self.srlg_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/names/name'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry]
@@ -2289,6 +3268,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(yang.adata.MNo
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/names')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names()')
+        leaves = []
+        _name = self.name
+        for _element in _name.elements:
+            res.append('')
+            res.append(f"# List /srlg/interfaces/interface/names/name element: {_element.to_gdata().key_str(['srlg-name'])}")
+            list_elem = f'name_element = {self_name}.name.create({repr(_element.srlg_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'name_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/names'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2324,6 +3323,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(index_number=n.get_int('index-number'), group_name=n.get_opt_str('group-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/groups/group')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group({repr(self.index_number)})')
+        leaves = []
+        _group_name = self.group_name
+        if _group_name is not None:
+            leaves.append(f'{self_name}.group_name = {repr(_group_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry]
@@ -2396,6 +3411,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(yang.adata.MN
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group.from_gdata(n.get_opt_list('group')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface/groups')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /srlg/interfaces/interface/groups/group element: {_element.to_gdata().key_str(['index-number'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.index_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2450,6 +3485,37 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(interface_name=n.get_str('interface-name'), include_optical=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical.from_gdata(n.get_opt_container('include-optical')), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes.from_gdata(n.get_opt_container('indexes')), names=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names.from_gdata(n.get_opt_container('names')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups.from_gdata(n.get_opt_container('groups')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces/interface')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface({repr(self.interface_name)})')
+        leaves = []
+        _include_optical = self.include_optical
+        if _include_optical is not None:
+            res.append('')
+            res.append('# P-container: /srlg/interfaces/interface/include-optical')
+            res.append(f'include_optical = {self_name}.create_include_optical()')
+            res.extend(_include_optical.prsrc('include_optical', False).splitlines())
+        _indexes = self.indexes
+        if _indexes is not None:
+            res.extend(_indexes.prsrc(f'{self_name}.indexes', False).splitlines())
+        _names = self.names
+        if _names is not None:
+            res.extend(_names.prsrc(f'{self_name}.names', False).splitlines())
+        _groups = self.groups
+        if _groups is not None:
+            res.append('')
+            res.append('# P-container: /srlg/interfaces/interface/groups')
+            res.append(f'groups = {self_name}.create_groups()')
+            res.extend(_groups.prsrc('groups', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry]
@@ -2528,6 +3594,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(interface=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/interfaces')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /srlg/interfaces/interface element: {_element.to_gdata().key_str(['interface-name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.interface_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2574,6 +3660,25 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(yang.ad
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/groups/group/indexes/index')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index({repr(self.index_number)})')
+        leaves = []
+        _value = self.value
+        if _value is not None:
+            leaves.append(f'{self_name}.value = {repr(_value)}')
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/groups/group/indexes/index'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry]
@@ -2648,6 +3753,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/groups/group/indexes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes()')
+        leaves = []
+        _index = self.index
+        for _element in _index.elements:
+            res.append('')
+            res.append(f"# List /srlg/groups/group/indexes/index element: {_element.to_gdata().key_str(['index-number'])}")
+            list_elem = f'index_element = {self_name}.index.create({repr(_element.index_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'index_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/groups/group/indexes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2677,6 +3802,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(group_name=n.get_str('group-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes.from_gdata(n.get_opt_container('indexes')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/groups/group')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group({repr(self.group_name)})')
+        leaves = []
+        _indexes = self.indexes
+        if _indexes is not None:
+            res.extend(_indexes.prsrc(f'{self_name}.indexes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry]
@@ -2749,6 +3890,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group.from_gdata(n.get_opt_list('group')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/groups')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /srlg/groups/group element: {_element.to_gdata().key_str(['group-name'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2795,6 +3956,25 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/inherit-locations/inherit-location/indexes/index')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index({repr(self.index_number)})')
+        leaves = []
+        _value = self.value
+        if _value is not None:
+            leaves.append(f'{self_name}.value = {repr(_value)}')
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/inherit-locations/inherit-location/indexes/index'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry]
@@ -2869,6 +4049,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/inherit-locations/inherit-location/indexes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes()')
+        leaves = []
+        _index = self.index
+        for _element in _index.elements:
+            res.append('')
+            res.append(f"# List /srlg/inherit-locations/inherit-location/indexes/index element: {_element.to_gdata().key_str(['index-number'])}")
+            list_elem = f'index_element = {self_name}.index.create({repr(_element.index_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'index_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/inherit-locations/inherit-location/indexes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2898,6 +4098,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(y
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(location_name=n.get_str('location-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes.from_gdata(n.get_opt_container('indexes')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/inherit-locations/inherit-location')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location({repr(self.location_name)})')
+        leaves = []
+        _indexes = self.indexes
+        if _indexes is not None:
+            res.extend(_indexes.prsrc(f'{self_name}.indexes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/inherit-locations/inherit-location'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry]
@@ -2970,6 +4186,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(inherit_location=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location.from_gdata(n.get_opt_list('inherit-location')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg/inherit-locations')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations()')
+        leaves = []
+        _inherit_location = self.inherit_location
+        for _element in _inherit_location.elements:
+            res.append('')
+            res.append(f"# List /srlg/inherit-locations/inherit-location element: {_element.to_gdata().key_str(['location-name'])}")
+            list_elem = f'inherit_location_element = {self_name}.inherit_location.create({repr(_element.location_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'inherit_location_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg/inherit-locations'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3012,6 +4248,31 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg(names=Cisco_IOS_XR_um_vrf_cfg__srlg__names.from_gdata(n.get_opt_container('names')), interfaces=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces.from_gdata(n.get_opt_container('interfaces')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__groups.from_gdata(n.get_opt_container('groups')), inherit_locations=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations.from_gdata(n.get_opt_container('inherit-locations')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /srlg')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__srlg()')
+        leaves = []
+        _names = self.names
+        if _names is not None:
+            res.extend(_names.prsrc(f'{self_name}.names', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        _inherit_locations = self.inherit_locations
+        if _inherit_locations is not None:
+            res.extend(_inherit_locations.prsrc(f'{self_name}.inherit_locations', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /srlg'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3048,6 +4309,19 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(yang.adata
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrf-groups/vrf-group/vrfs/vrf')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf({repr(self.vrf_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrf-groups/vrf-group/vrfs/vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry]
@@ -3118,6 +4392,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrf-groups/vrf-group/vrfs')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs()')
+        leaves = []
+        _vrf = self.vrf
+        for _element in _vrf.elements:
+            res.append('')
+            res.append(f"# List /vrf-groups/vrf-group/vrfs/vrf element: {_element.to_gdata().key_str(['vrf-name'])}")
+            list_elem = f'vrf_element = {self_name}.vrf.create({repr(_element.vrf_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrf-groups/vrf-group/vrfs'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3147,6 +4441,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(group_name=n.get_str('group-name'), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs.from_gdata(n.get_opt_container('vrfs')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrf-groups/vrf-group')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group({repr(self.group_name)})')
+        leaves = []
+        _vrfs = self.vrfs
+        if _vrfs is not None:
+            res.extend(_vrfs.prsrc(f'{self_name}.vrfs', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrf-groups/vrf-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry]
@@ -3219,6 +4529,26 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups(vrf_group=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group.from_gdata(n.get_opt_list('vrf-group')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /vrf-groups')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_vrf_cfg__vrf_groups()')
+        leaves = []
+        _vrf_group = self.vrf_group
+        for _element in _vrf_group.elements:
+            res.append('')
+            res.append(f"# List /vrf-groups/vrf-group element: {_element.to_gdata().key_str(['group-name'])}")
+            list_elem = f'vrf_group_element = {self_name}.vrf_group.create({repr(_element.group_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /vrf-groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3252,6 +4582,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__n
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry(net_id=n.get_str('net-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/nets/net')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net({repr(self.net_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/nets/net'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry]
@@ -3322,6 +4665,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(ya
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(net=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net.from_gdata(n.get_opt_list('net')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/nets')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets()')
+        leaves = []
+        _net = self.net
+        for _element in _net.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/nets/net element: {_element.to_gdata().key_str(['net-id'])}")
+            list_elem = f'net_element = {self_name}.net.create({repr(_element.net_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'net_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/nets'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3358,6 +4721,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(sr_prefer=n.get_opt_bool('sr-prefer'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/segment-routing/mpls')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls()')
+        leaves = []
+        _sr_prefer = self.sr_prefer
+        if _sr_prefer is not None:
+            leaves.append(f'{self_name}.sr_prefer = {repr(_sr_prefer)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/segment-routing/mpls'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3385,6 +4764,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(mpls=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls.from_gdata(n.get_opt_container('mpls')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/segment-routing')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing()')
+        leaves = []
+        _mpls = self.mpls
+        if _mpls is not None:
+            res.extend(_mpls.prsrc(f'{self_name}.mpls', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/segment-routing'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3408,6 +4803,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/narrow')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/narrow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3429,6 +4837,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/wide')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/wide'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3449,6 +4870,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/transition')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/transition'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition(node: xml.Node) -> yang.gdata.Container:
@@ -3474,6 +4908,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/narrow')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/narrow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3495,6 +4942,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/wide')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/wide'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3515,6 +4975,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/transition')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/transition'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition(node: xml.Node) -> yang.gdata.Container:
@@ -3568,6 +5041,37 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry(level_id=n.get_int('level-id'), narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow.from_gdata(n.get_opt_container('narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide.from_gdata(n.get_opt_container('wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition.from_gdata(n.get_opt_container('transition')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/levels/level')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level({repr(self.level_id)})')
+        leaves = []
+        _narrow = self.narrow
+        if _narrow is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/narrow')
+            res.append(f'narrow = {self_name}.create_narrow()')
+            res.extend(_narrow.prsrc('narrow', False).splitlines())
+        _wide = self.wide
+        if _wide is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/wide')
+            res.append(f'wide = {self_name}.create_wide()')
+            res.extend(_wide.prsrc('wide', False).splitlines())
+        _transition = self.transition
+        if _transition is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level/transition')
+            res.append(f'transition = {self_name}.create_transition()')
+            res.extend(_transition.prsrc('transition', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/levels/level'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry]
@@ -3644,6 +5148,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style/levels')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels()')
+        leaves = []
+        _level = self.level
+        for _element in _level.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/address-families/address-family/metric-style/levels/level element: {_element.to_gdata().key_str(['level-id'])}")
+            list_elem = f'level_element = {self_name}.level.create({repr(_element.level_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'level_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style/levels'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3701,6 +5225,40 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow.from_gdata(n.get_opt_container('narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide.from_gdata(n.get_opt_container('wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition.from_gdata(n.get_opt_container('transition')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels.from_gdata(n.get_opt_container('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family/metric-style')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style()')
+        leaves = []
+        _narrow = self.narrow
+        if _narrow is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/narrow')
+            res.append(f'narrow = {self_name}.create_narrow()')
+            res.extend(_narrow.prsrc('narrow', False).splitlines())
+        _wide = self.wide
+        if _wide is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/wide')
+            res.append(f'wide = {self_name}.create_wide()')
+            res.extend(_wide.prsrc('wide', False).splitlines())
+        _transition = self.transition
+        if _transition is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/address-families/address-family/metric-style/transition')
+            res.append(f'transition = {self_name}.create_transition()')
+            res.extend(_transition.prsrc('transition', False).splitlines())
+        _levels = self.levels
+        if _levels is not None:
+            res.extend(_levels.prsrc(f'{self_name}.levels', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family/metric-style'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3746,6 +5304,25 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry(af_name=n.get_str('af-name'), saf_name=n.get_str('saf-name'), segment_routing=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing.from_gdata(n.get_opt_container('segment-routing')), metric_style=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style.from_gdata(n.get_opt_container('metric-style')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family({repr(self.af_name)}, {repr(self.saf_name)})')
+        leaves = []
+        _segment_routing = self.segment_routing
+        if _segment_routing is not None:
+            res.extend(_segment_routing.prsrc(f'{self_name}.segment_routing', False).splitlines())
+        _metric_style = self.metric_style
+        if _metric_style is not None:
+            res.extend(_metric_style.prsrc(f'{self_name}.metric_style', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry]
@@ -3825,6 +5402,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/address-families/address-family element: {_element.to_gdata().key_str(['af-name', 'saf-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)}, {repr(_element.saf_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3854,6 +5451,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/point-to-point')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/point-to-point'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3875,6 +5485,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv4')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3895,6 +5518,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv6')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6(node: xml.Node) -> yang.gdata.Container:
@@ -3935,6 +5571,31 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(ipv4=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/bfd/fast-detect')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv4')
+            res.append(f'ipv4 = {self_name}.create_ipv4()')
+            res.extend(_ipv4.prsrc('ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/bfd/fast-detect/ipv6')
+            res.append(f'ipv6 = {self_name}.create_ipv6()')
+            res.extend(_ipv6.prsrc('ipv6', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/bfd/fast-detect'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(node: xml.Node) -> yang.gdata.Container:
@@ -3981,6 +5642,28 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(fast_detect=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect.from_gdata(n.get_opt_container('fast-detect')), minimum_interval=n.get_opt_int('minimum-interval'), multiplier=n.get_opt_int('multiplier'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/bfd')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd()')
+        leaves = []
+        _fast_detect = self.fast_detect
+        if _fast_detect is not None:
+            res.extend(_fast_detect.prsrc(f'{self_name}.fast_detect', False).splitlines())
+        _minimum_interval = self.minimum_interval
+        if _minimum_interval is not None:
+            leaves.append(f'{self_name}.minimum_interval = {repr(_minimum_interval)}')
+        _multiplier = self.multiplier
+        if _multiplier is not None:
+            leaves.append(f'{self_name}.multiplier = {repr(_multiplier)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/bfd'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4007,6 +5690,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/passive')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/passive'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive(node: xml.Node) -> yang.gdata.Container:
@@ -4038,6 +5734,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/maximum')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/maximum'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4064,6 +5773,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level/maximum')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level/maximum'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum(node: xml.Node) -> yang.gdata.Container:
@@ -4102,6 +5824,28 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry(level_id=n.get_int('level-id'), default_metric=n.get_opt_int('default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum.from_gdata(n.get_opt_container('maximum')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level({repr(self.level_id)})')
+        leaves = []
+        _default_metric = self.default_metric
+        if _default_metric is not None:
+            leaves.append(f'{self_name}.default_metric = {repr(_default_metric)}')
+        _maximum = self.maximum
+        if _maximum is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level/maximum')
+            res.append(f'maximum = {self_name}.create_maximum()')
+            res.extend(_maximum.prsrc('maximum', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry]
@@ -4176,6 +5920,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels()')
+        leaves = []
+        _level = self.level
+        for _element in _level.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: {_element.to_gdata().key_str(['level-id'])}")
+            list_elem = f'level_element = {self_name}.level.create({repr(_element.level_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'level_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4218,6 +5982,31 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(default_metric=n.get_opt_int('default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum.from_gdata(n.get_opt_container('maximum')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels.from_gdata(n.get_opt_container('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric()')
+        leaves = []
+        _default_metric = self.default_metric
+        if _default_metric is not None:
+            leaves.append(f'{self_name}.default_metric = {repr(_default_metric)}')
+        _maximum = self.maximum
+        if _maximum is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/maximum')
+            res.append(f'maximum = {self_name}.create_maximum()')
+            res.extend(_maximum.prsrc('maximum', False).splitlines())
+        _levels = self.levels
+        if _levels is not None:
+            res.extend(_levels.prsrc(f'{self_name}.levels', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/metric'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4252,6 +6041,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(sid_index=n.get_opt_int('sid-index'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid/index')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index()')
+        leaves = []
+        _sid_index = self.sid_index
+        if _sid_index is not None:
+            leaves.append(f'{self_name}.sid_index = {repr(_sid_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid/index'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4284,6 +6089,25 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(index=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index.from_gdata(n.get_opt_container('index')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid()')
+        leaves = []
+        _index = self.index
+        if _index is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid/index')
+            res.append(f'index = {self_name}.create_index()')
+            res.extend(_index.prsrc('index', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4315,6 +6139,25 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid.from_gdata(n.get_opt_container('sid')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid()')
+        leaves = []
+        _sid = self.sid
+        if _sid is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid/sid')
+            res.append(f'sid = {self_name}.create_sid()')
+            res.extend(_sid.prsrc('sid', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family/prefix-sid'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(node: xml.Node) -> yang.gdata.Container:
@@ -4355,6 +6198,25 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry(af_name=n.get_str('af-name'), saf_name=n.get_str('saf-name'), metric=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric.from_gdata(n.get_opt_container('metric')), prefix_sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid.from_gdata(n.get_opt_container('prefix-sid')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family({repr(self.af_name)}, {repr(self.saf_name)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            res.extend(_metric.prsrc(f'{self_name}.metric', False).splitlines())
+        _prefix_sid = self.prefix_sid
+        if _prefix_sid is not None:
+            res.extend(_prefix_sid.prsrc(f'{self_name}.prefix_sid', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry]
@@ -4434,6 +6296,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/interfaces/interface/address-families/address-family element: {_element.to_gdata().key_str(['af-name', 'saf-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)}, {repr(_element.saf_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4493,6 +6375,40 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry(interface_name=n.get_str('interface-name'), circuit_type=n.get_opt_str('circuit-type'), point_to_point=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point.from_gdata(n.get_opt_container('point-to-point')), bfd=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd.from_gdata(n.get_opt_container('bfd')), passive=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive.from_gdata(n.get_opt_container('passive')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families.from_gdata(n.get_opt_container('address-families')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces/interface')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface({repr(self.interface_name)})')
+        leaves = []
+        _circuit_type = self.circuit_type
+        if _circuit_type is not None:
+            leaves.append(f'{self_name}.circuit_type = {repr(_circuit_type)}')
+        _point_to_point = self.point_to_point
+        if _point_to_point is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/point-to-point')
+            res.append(f'point_to_point = {self_name}.create_point_to_point()')
+            res.extend(_point_to_point.prsrc('point_to_point', False).splitlines())
+        _bfd = self.bfd
+        if _bfd is not None:
+            res.extend(_bfd.prsrc(f'{self_name}.bfd', False).splitlines())
+        _passive = self.passive
+        if _passive is not None:
+            res.append('')
+            res.append('# P-container: /router/isis/processes/process/interfaces/interface/passive')
+            res.append(f'passive = {self_name}.create_passive()')
+            res.extend(_passive.prsrc('passive', False).splitlines())
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry]
@@ -4573,6 +6489,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(interface=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process/interfaces')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process/interfaces/interface element: {_element.to_gdata().key_str(['interface-name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.interface_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process/interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4617,6 +6553,31 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(ya
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(process_id=n.get_str('process-id'), is_type=n.get_opt_str('is-type'), nets=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets.from_gdata(n.get_opt_container('nets')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families.from_gdata(n.get_opt_container('address-families')), interfaces=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces.from_gdata(n.get_opt_container('interfaces')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes/process')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process({repr(self.process_id)})')
+        leaves = []
+        _is_type = self.is_type
+        if _is_type is not None:
+            leaves.append(f'{self_name}.is_type = {repr(_is_type)}')
+        _nets = self.nets
+        if _nets is not None:
+            res.extend(_nets.prsrc(f'{self_name}.nets', False).splitlines())
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes/process'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry]
@@ -4695,6 +6656,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(yang.adata.MNode)
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(process=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process.from_gdata(n.get_opt_list('process')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis/processes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes()')
+        leaves = []
+        _process = self.process
+        for _element in _process.elements:
+            res.append('')
+            res.append(f"# List /router/isis/processes/process element: {_element.to_gdata().key_str(['process-id'])}")
+            list_elem = f'process_element = {self_name}.process.create({repr(_element.process_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'process_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis/processes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4721,6 +6702,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis(processes=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes.from_gdata(n.get_opt_container('processes')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/isis')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router__isis()')
+        leaves = []
+        _processes = self.processes
+        if _processes is not None:
+            res.extend(_processes.prsrc(f'{self_name}.processes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/isis'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis(node: xml.Node) -> yang.gdata.Container:
@@ -4749,6 +6746,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_isis_cfg__router(isis=Cisco_IOS_XR_um_router_isis_cfg__router__isis.from_gdata(n.get_opt_container('isis')))
         return Cisco_IOS_XR_um_router_isis_cfg__router()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_isis_cfg__router()')
+        leaves = []
+        _isis = self.isis
+        if _isis is not None:
+            res.extend(_isis.prsrc(f'{self_name}.isis', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4772,6 +6785,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /as-format/asdot')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /as-format/asdot'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4792,6 +6818,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /as-format/asplain')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /as-format/asplain'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(node: xml.Node) -> yang.gdata.Container:
@@ -4833,6 +6872,31 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format(asdot=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot.from_gdata(n.get_opt_container('asdot')), asplain=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain.from_gdata(n.get_opt_container('asplain')))
         return Cisco_IOS_XR_um_router_bgp_cfg__as_format()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /as-format')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__as_format()')
+        leaves = []
+        _asdot = self.asdot
+        if _asdot is not None:
+            res.append('')
+            res.append('# P-container: /as-format/asdot')
+            res.append(f'asdot = {self_name}.create_asdot()')
+            res.extend(_asdot.prsrc('asdot', False).splitlines())
+        _asplain = self.asplain
+        if _asplain is not None:
+            res.append('')
+            res.append('# P-container: /as-format/asplain')
+            res.append(f'asplain = {self_name}.create_asplain()')
+            res.extend(_asplain.prsrc('asplain', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /as-format'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4860,6 +6924,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(yang.adata.
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/shutdown')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/shutdown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(node: xml.Node) -> yang.gdata.Container:
@@ -4896,6 +6973,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(yang.adata.MNod
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(host_name=n.get_opt_str('host-name'), port=n.get_opt_int('port'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/host')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host()')
+        leaves = []
+        _host_name = self.host_name
+        if _host_name is not None:
+            leaves.append(f'{self_name}.host_name = {repr(_host_name)}')
+        _port = self.port
+        if _port is not None:
+            leaves.append(f'{self_name}.port = {repr(_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/host'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(node: xml.Node) -> yang.gdata.Container:
@@ -4946,6 +7042,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__del
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(initial_delay=n.get_opt_int('initial-delay'), spread=n.get_opt_int('spread'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/initial-refresh/delay')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay()')
+        leaves = []
+        _initial_delay = self.initial_delay
+        if _initial_delay is not None:
+            leaves.append(f'{self_name}.initial_delay = {repr(_initial_delay)}')
+        _spread = self.spread
+        if _spread is not None:
+            leaves.append(f'{self_name}.spread = {repr(_spread)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/initial-refresh/delay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4970,6 +7085,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__ski
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/initial-refresh/skip')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/initial-refresh/skip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip(node: xml.Node) -> yang.gdata.Container:
@@ -5010,6 +7138,31 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(yang
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(delay=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay.from_gdata(n.get_opt_container('delay')), skip=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip.from_gdata(n.get_opt_container('skip')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/initial-refresh')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh()')
+        leaves = []
+        _delay = self.delay
+        if _delay is not None:
+            res.append('')
+            res.append('# P-container: /bmp/servers/server/initial-refresh/delay')
+            res.append(f'delay = {self_name}.create_delay()')
+            res.extend(_delay.prsrc('delay', False).splitlines())
+        _skip = self.skip
+        if _skip is not None:
+            res.append('')
+            res.append('# P-container: /bmp/servers/server/initial-refresh/skip')
+            res.append(f'skip = {self_name}.create_skip()')
+            res.extend(_skip.prsrc('skip', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/initial-refresh'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(node: xml.Node) -> yang.gdata.Container:
@@ -5068,6 +7221,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(yang.adata.MNode
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(keep_alive=n.get_opt_int('keep-alive'), mss=n.get_opt_int('mss'))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server/tcp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp()')
+        leaves = []
+        _keep_alive = self.keep_alive
+        if _keep_alive is not None:
+            leaves.append(f'{self_name}.keep_alive = {repr(_keep_alive)}')
+        _mss = self.mss
+        if _mss is not None:
+            leaves.append(f'{self_name}.mss = {repr(_mss)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server/tcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(node: xml.Node) -> yang.gdata.Container:
@@ -5170,6 +7342,64 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(bmp_server_id=n.get_int('bmp-server-id'), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown.from_gdata(n.get_opt_container('shutdown')), host=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host.from_gdata(n.get_opt_container('host')), initial_delay=n.get_opt_int('initial-delay'), flapping_delay=n.get_opt_int('flapping-delay'), max_buffer_size=n.get_opt_int('max-buffer-size'), initial_refresh=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh.from_gdata(n.get_opt_container('initial-refresh')), stats_reporting_period=n.get_opt_int('stats-reporting-period'), description=n.get_opt_str('description'), dscp=n.get_opt_str('dscp'), precedence=n.get_opt_str('precedence'), update_source=n.get_opt_str('update-source'), vrf=n.get_opt_str('vrf'), tcp=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp.from_gdata(n.get_opt_container('tcp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/server')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server({repr(self.bmp_server_id)})')
+        leaves = []
+        _shutdown = self.shutdown
+        if _shutdown is not None:
+            res.append('')
+            res.append('# P-container: /bmp/servers/server/shutdown')
+            res.append(f'shutdown = {self_name}.create_shutdown()')
+            res.extend(_shutdown.prsrc('shutdown', False).splitlines())
+        _host = self.host
+        if _host is not None:
+            res.append('')
+            res.append('# P-container: /bmp/servers/server/host')
+            res.append(f'host = {self_name}.create_host()')
+            res.extend(_host.prsrc('host', False).splitlines())
+        _initial_delay = self.initial_delay
+        if _initial_delay is not None:
+            leaves.append(f'{self_name}.initial_delay = {repr(_initial_delay)}')
+        _flapping_delay = self.flapping_delay
+        if _flapping_delay is not None:
+            leaves.append(f'{self_name}.flapping_delay = {repr(_flapping_delay)}')
+        _max_buffer_size = self.max_buffer_size
+        if _max_buffer_size is not None:
+            leaves.append(f'{self_name}.max_buffer_size = {repr(_max_buffer_size)}')
+        _initial_refresh = self.initial_refresh
+        if _initial_refresh is not None:
+            res.extend(_initial_refresh.prsrc(f'{self_name}.initial_refresh', False).splitlines())
+        _stats_reporting_period = self.stats_reporting_period
+        if _stats_reporting_period is not None:
+            leaves.append(f'{self_name}.stats_reporting_period = {repr(_stats_reporting_period)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _dscp = self.dscp
+        if _dscp is not None:
+            leaves.append(f'{self_name}.dscp = {repr(_dscp)}')
+        _precedence = self.precedence
+        if _precedence is not None:
+            leaves.append(f'{self_name}.precedence = {repr(_precedence)}')
+        _update_source = self.update_source
+        if _update_source is not None:
+            leaves.append(f'{self_name}.update_source = {repr(_update_source)}')
+        _vrf = self.vrf
+        if _vrf is not None:
+            leaves.append(f'{self_name}.vrf = {repr(_vrf)}')
+        _tcp = self.tcp
+        if _tcp is not None:
+            res.extend(_tcp.prsrc(f'{self_name}.tcp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/server'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry]
@@ -5286,6 +7516,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry(mode_name=n.get_str('mode-name'), advertisement_interval=n.get_opt_int('advertisement-interval'), scan_time=n.get_opt_int('scan-time'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/all/route-monitoring/bmp-modes/bmp-mode')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode({repr(self.mode_name)})')
+        leaves = []
+        _advertisement_interval = self.advertisement_interval
+        if _advertisement_interval is not None:
+            leaves.append(f'{self_name}.advertisement_interval = {repr(_advertisement_interval)}')
+        _scan_time = self.scan_time
+        if _scan_time is not None:
+            leaves.append(f'{self_name}.scan_time = {repr(_scan_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/all/route-monitoring/bmp-modes/bmp-mode'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry]
     mut def __init__(self, elements=[]):
@@ -5359,6 +7608,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(bmp_mode=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode.from_gdata(n.get_opt_list('bmp-mode')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/all/route-monitoring/bmp-modes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes()')
+        leaves = []
+        _bmp_mode = self.bmp_mode
+        for _element in _bmp_mode.elements:
+            res.append('')
+            res.append(f"# List /bmp/servers/all/route-monitoring/bmp-modes/bmp-mode element: {_element.to_gdata().key_str(['mode-name'])}")
+            list_elem = f'bmp_mode_element = {self_name}.bmp_mode.create({repr(_element.mode_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'bmp_mode_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/all/route-monitoring/bmp-modes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5385,6 +7654,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(yang.a
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(bmp_modes=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes.from_gdata(n.get_opt_container('bmp-modes')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/all/route-monitoring')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring()')
+        leaves = []
+        _bmp_modes = self.bmp_modes
+        if _bmp_modes is not None:
+            res.extend(_bmp_modes.prsrc(f'{self_name}.bmp_modes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/all/route-monitoring'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(node: xml.Node) -> yang.gdata.Container:
@@ -5417,6 +7702,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(max_buffer_size=n.get_opt_int('max-buffer-size'), route_monitoring=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring.from_gdata(n.get_opt_container('route-monitoring')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers/all')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all()')
+        leaves = []
+        _max_buffer_size = self.max_buffer_size
+        if _max_buffer_size is not None:
+            leaves.append(f'{self_name}.max_buffer_size = {repr(_max_buffer_size)}')
+        _route_monitoring = self.route_monitoring
+        if _route_monitoring is not None:
+            res.extend(_route_monitoring.prsrc(f'{self_name}.route_monitoring', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers/all'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(node: xml.Node) -> yang.gdata.Container:
@@ -5452,6 +7756,29 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server.from_gdata(n.get_opt_list('server')), all=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all.from_gdata(n.get_opt_container('all')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp/servers')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers()')
+        leaves = []
+        _server = self.server
+        for _element in _server.elements:
+            res.append('')
+            res.append(f"# List /bmp/servers/server element: {_element.to_gdata().key_str(['bmp-server-id'])}")
+            list_elem = f'server_element = {self_name}.server.create({repr(_element.bmp_server_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'server_element', False, list_element=True).splitlines())
+        _all = self.all
+        if _all is not None:
+            res.extend(_all.prsrc(f'{self_name}.all', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp/servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5480,6 +7807,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp(servers=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers.from_gdata(n.get_opt_container('servers')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /bmp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__bmp()')
+        leaves = []
+        _servers = self.servers
+        if _servers is not None:
+            res.extend(_servers.prsrc(f'{self_name}.servers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /bmp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp(node: xml.Node) -> yang.gdata.Container:
@@ -5517,6 +7860,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(interface_name=n.get_opt_str('interface-name'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/bind-source/interface')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface()')
+        leaves = []
+        _interface_name = self.interface_name
+        if _interface_name is not None:
+            leaves.append(f'{self_name}.interface_name = {repr(_interface_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/bind-source/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5543,6 +7902,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(interface=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface.from_gdata(n.get_opt_container('interface')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/bind-source')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source()')
+        leaves = []
+        _interface = self.interface
+        if _interface is not None:
+            res.extend(_interface.prsrc(f'{self_name}.interface', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/bind-source'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(node: xml.Node) -> yang.gdata.Container:
@@ -5572,6 +7947,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/refresh-time/off')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/refresh-time/off'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off(node: xml.Node) -> yang.gdata.Container:
@@ -5608,6 +7996,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(refresh_time_value=n.get_opt_int('refresh-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off.from_gdata(n.get_opt_container('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/refresh-time')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time()')
+        leaves = []
+        _refresh_time_value = self.refresh_time_value
+        if _refresh_time_value is not None:
+            leaves.append(f'{self_name}.refresh_time_value = {repr(_refresh_time_value)}')
+        _off = self.off
+        if _off is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/rpki/servers/server/refresh-time/off')
+            res.append(f'off = {self_name}.create_off()')
+            res.extend(_off.prsrc('off', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/refresh-time'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5635,6 +8045,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/response-time/off')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/response-time/off'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off(node: xml.Node) -> yang.gdata.Container:
@@ -5670,6 +8093,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(response_time_value=n.get_opt_int('response-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off.from_gdata(n.get_opt_container('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/response-time')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time()')
+        leaves = []
+        _response_time_value = self.response_time_value
+        if _response_time_value is not None:
+            leaves.append(f'{self_name}.response_time_value = {repr(_response_time_value)}')
+        _off = self.off
+        if _off is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/rpki/servers/server/response-time/off')
+            res.append(f'off = {self_name}.create_off()')
+            res.extend(_off.prsrc('off', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/response-time'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(node: xml.Node) -> yang.gdata.Container:
@@ -5712,6 +8157,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/transport/tcp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp()')
+        leaves = []
+        _port = self.port
+        if _port is not None:
+            leaves.append(f'{self_name}.port = {repr(_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/transport/tcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5741,6 +8202,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/transport/ssh')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh()')
+        leaves = []
+        _port = self.port
+        if _port is not None:
+            leaves.append(f'{self_name}.port = {repr(_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/transport/ssh'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(node: xml.Node) -> yang.gdata.Container:
@@ -5774,6 +8251,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(tcp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp.from_gdata(n.get_opt_container('tcp')), ssh=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh.from_gdata(n.get_opt_container('ssh')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/transport')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport()')
+        leaves = []
+        _tcp = self.tcp
+        if _tcp is not None:
+            res.extend(_tcp.prsrc(f'{self_name}.tcp', False).splitlines())
+        _ssh = self.ssh
+        if _ssh is not None:
+            res.extend(_ssh.prsrc(f'{self_name}.ssh', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/transport'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5798,6 +8294,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__sh
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server/shutdown')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server/shutdown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown(node: xml.Node) -> yang.gdata.Container:
@@ -5871,6 +8380,49 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry(server_id=n.get_str('server-id'), bind_source=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source.from_gdata(n.get_opt_container('bind-source')), preference=n.get_opt_int('preference'), refresh_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time.from_gdata(n.get_opt_container('refresh-time')), response_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time.from_gdata(n.get_opt_container('response-time')), purge_time=n.get_opt_int('purge-time'), username=n.get_opt_str('username'), password=n.get_opt_str('password'), transport=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport.from_gdata(n.get_opt_container('transport')), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown.from_gdata(n.get_opt_container('shutdown')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers/server')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server({repr(self.server_id)})')
+        leaves = []
+        _bind_source = self.bind_source
+        if _bind_source is not None:
+            res.extend(_bind_source.prsrc(f'{self_name}.bind_source', False).splitlines())
+        _preference = self.preference
+        if _preference is not None:
+            leaves.append(f'{self_name}.preference = {repr(_preference)}')
+        _refresh_time = self.refresh_time
+        if _refresh_time is not None:
+            res.extend(_refresh_time.prsrc(f'{self_name}.refresh_time', False).splitlines())
+        _response_time = self.response_time
+        if _response_time is not None:
+            res.extend(_response_time.prsrc(f'{self_name}.response_time', False).splitlines())
+        _purge_time = self.purge_time
+        if _purge_time is not None:
+            leaves.append(f'{self_name}.purge_time = {repr(_purge_time)}')
+        _username = self.username
+        if _username is not None:
+            leaves.append(f'{self_name}.username = {repr(_username)}')
+        _password = self.password
+        if _password is not None:
+            leaves.append(f'{self_name}.password = {repr(_password)}')
+        _transport = self.transport
+        if _transport is not None:
+            res.extend(_transport.prsrc(f'{self_name}.transport', False).splitlines())
+        _shutdown = self.shutdown
+        if _shutdown is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/rpki/servers/server/shutdown')
+            res.append(f'shutdown = {self_name}.create_shutdown()')
+            res.extend(_shutdown.prsrc('shutdown', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers/server'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry]
@@ -5959,6 +8511,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(yang.adata.
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server.from_gdata(n.get_opt_list('server')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/servers')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers()')
+        leaves = []
+        _server = self.server
+        for _element in _server.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/rpki/servers/server element: {_element.to_gdata().key_str(['server-id'])}")
+            list_elem = f'server_element = {self_name}.server.create({repr(_element.server_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'server_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6010,6 +8582,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry(address=n.get_str('address'), minimum_prefix_length=n.get_int('minimum-prefix-length'), maximum_prefix_length=n.get_int('maximum-prefix-length'), origin_as_number=n.get_int('origin-as-number'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/routes/route')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route({repr(self.address)}, {repr(self.minimum_prefix_length)}, {repr(self.maximum_prefix_length)}, {repr(self.origin_as_number)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/routes/route'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry]
@@ -6095,6 +8680,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(yang.adata.M
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(route=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route.from_gdata(n.get_opt_list('route')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki/routes')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes()')
+        leaves = []
+        _route = self.route
+        for _element in _route.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/rpki/routes/route element: {_element.to_gdata().key_str(['address', 'minimum-prefix-length', 'maximum-prefix-length', 'origin-as-number'])}")
+            list_elem = f'route_element = {self_name}.route.create({repr(_element.address)}, {repr(_element.minimum_prefix_length)}, {repr(_element.maximum_prefix_length)}, {repr(_element.origin_as_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'route_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki/routes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6135,6 +8740,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(servers=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers.from_gdata(n.get_opt_container('servers')), routes=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes.from_gdata(n.get_opt_container('routes')), datafile=n.get_opt_str('datafile'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/rpki')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki()')
+        leaves = []
+        _servers = self.servers
+        if _servers is not None:
+            res.extend(_servers.prsrc(f'{self_name}.servers', False).splitlines())
+        _routes = self.routes
+        if _routes is not None:
+            res.extend(_routes.prsrc(f'{self_name}.routes', False).splitlines())
+        _datafile = self.datafile
+        if _datafile is not None:
+            leaves.append(f'{self_name}.datafile = {repr(_datafile)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/rpki'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6166,6 +8793,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry(af_name=n.get_str('af-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family({repr(self.af_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry]
@@ -6236,6 +8876,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(yang.ada
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/address-families/address-family element: {_element.to_gdata().key_str(['af-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6277,6 +8937,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(session_group=n.get_opt_str('session-group'), neighbor_group=n.get_opt_str('neighbor-group'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbors/neighbor/use')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use()')
+        leaves = []
+        _session_group = self.session_group
+        if _session_group is not None:
+            leaves.append(f'{self_name}.session_group = {repr(_session_group)}')
+        _neighbor_group = self.neighbor_group
+        if _neighbor_group is not None:
+            leaves.append(f'{self_name}.neighbor_group = {repr(_neighbor_group)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbors/neighbor/use'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6316,6 +8995,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry(neighbor_address=n.get_str('neighbor-address'), use=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use.from_gdata(n.get_opt_container('use')), description=n.get_opt_str('description'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbors/neighbor')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor({repr(self.neighbor_address)})')
+        leaves = []
+        _use = self.use
+        if _use is not None:
+            res.extend(_use.prsrc(f'{self_name}.use', False).splitlines())
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbors/neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry]
@@ -6390,6 +9088,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(yang.adata.MNod
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbors')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors()')
+        leaves = []
+        _neighbor = self.neighbor
+        for _element in _neighbor.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/neighbors/neighbor element: {_element.to_gdata().key_str(['neighbor-address'])}")
+            list_elem = f'neighbor_element = {self_name}.neighbor.create({repr(_element.neighbor_address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbors'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6420,6 +9138,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry(af_name=n.get_str('af-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family({repr(self.af_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry]
@@ -6490,6 +9221,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups/neighbor-group/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family element: {_element.to_gdata().key_str(['af-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups/neighbor-group/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6521,6 +9272,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups/neighbor-group/password/inheritance-disable')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups/neighbor-group/password/inheritance-disable'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
@@ -6556,6 +9320,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups/neighbor-group/password')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password()')
+        leaves = []
+        _encrypted = self.encrypted
+        if _encrypted is not None:
+            leaves.append(f'{self_name}.encrypted = {repr(_encrypted)}')
+        _inheritance_disable = self.inheritance_disable
+        if _inheritance_disable is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/neighbor-groups/neighbor-group/password/inheritance-disable')
+            res.append(f'inheritance_disable = {self_name}.create_inheritance_disable()')
+            res.extend(_inheritance_disable.prsrc('inheritance_disable', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups/neighbor-group/password'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(node: xml.Node) -> yang.gdata.Container:
@@ -6616,6 +9402,37 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry(neighbor_group_name=n.get_str('neighbor-group-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families.from_gdata(n.get_opt_container('address-families')), remote_as=n.get_opt_str('remote-as'), description=n.get_opt_str('description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password.from_gdata(n.get_opt_container('password')), update_source=n.get_opt_str('update-source'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups/neighbor-group')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group({repr(self.neighbor_group_name)})')
+        leaves = []
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _remote_as = self.remote_as
+        if _remote_as is not None:
+            leaves.append(f'{self_name}.remote_as = {repr(_remote_as)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _password = self.password
+        if _password is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/neighbor-groups/neighbor-group/password')
+            res.append(f'password = {self_name}.create_password()')
+            res.extend(_password.prsrc('password', False).splitlines())
+        _update_source = self.update_source
+        if _update_source is not None:
+            leaves.append(f'{self_name}.update_source = {repr(_update_source)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups/neighbor-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry]
@@ -6696,6 +9513,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(yang.adat
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(neighbor_group=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group.from_gdata(n.get_opt_list('neighbor-group')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/neighbor-groups')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups()')
+        leaves = []
+        _neighbor_group = self.neighbor_group
+        for _element in _neighbor_group.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/neighbor-groups/neighbor-group element: {_element.to_gdata().key_str(['neighbor-group-name'])}")
+            list_elem = f'neighbor_group_element = {self_name}.neighbor_group.create({repr(_element.neighbor_group_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/neighbor-groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6725,6 +9562,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(router_id=n.get_opt_str('router-id'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/bgp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp()')
+        leaves = []
+        _router_id = self.router_id
+        if _router_id is not None:
+            leaves.append(f'{self_name}.router_id = {repr(_router_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(node: xml.Node) -> yang.gdata.Container:
@@ -6756,6 +9609,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry(af_name=n.get_str('af-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family({repr(self.af_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry]
@@ -6826,6 +9692,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/vrfs/vrf/address-families/address-family element: {_element.to_gdata().key_str(['af-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6876,6 +9762,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(route_policy_name=n.get_opt_str('route-policy-name'), retention_time=n.get_opt_int('retention-time'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy/retention')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention()')
+        leaves = []
+        _route_policy_name = self.route_policy_name
+        if _route_policy_name is not None:
+            leaves.append(f'{self_name}.route_policy_name = {repr(_route_policy_name)}')
+        _retention_time = self.retention_time
+        if _retention_time is not None:
+            leaves.append(f'{self_name}.retention_time = {repr(_retention_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy/retention'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6915,6 +9820,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(in_=n.get_opt_str('in'), out=n.get_opt_str('out'), retention=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention.from_gdata(n.get_opt_container('retention')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy()')
+        leaves = []
+        _in_ = self.in_
+        if _in_ is not None:
+            leaves.append(f'{self_name}.in_ = {repr(_in_)}')
+        _out = self.out
+        if _out is not None:
+            leaves.append(f'{self_name}.out = {repr(_out)}')
+        _retention = self.retention
+        if _retention is not None:
+            res.extend(_retention.prsrc(f'{self_name}.retention', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6941,6 +9868,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override/inheritance-disable')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override/inheritance-disable'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
@@ -6971,6 +9911,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override()')
+        leaves = []
+        _inheritance_disable = self.inheritance_disable
+        if _inheritance_disable is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override/inheritance-disable')
+            res.append(f'inheritance_disable = {self_name}.create_inheritance_disable()')
+            res.extend(_inheritance_disable.prsrc('inheritance_disable', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(node: xml.Node) -> yang.gdata.Container:
@@ -7011,6 +9970,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry(af_name=n.get_str('af-name'), route_policy=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy.from_gdata(n.get_opt_container('route-policy')), as_override=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override.from_gdata(n.get_opt_container('as-override')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family({repr(self.af_name)})')
+        leaves = []
+        _route_policy = self.route_policy
+        if _route_policy is not None:
+            res.extend(_route_policy.prsrc(f'{self_name}.route_policy', False).splitlines())
+        _as_override = self.as_override
+        if _as_override is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override')
+            res.append(f'as_override = {self_name}.create_as_override()')
+            res.extend(_as_override.prsrc('as_override', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry]
@@ -7085,6 +10066,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family element: {_element.to_gdata().key_str(['af-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7116,6 +10117,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password/inheritance-disable')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password/inheritance-disable'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
@@ -7151,6 +10165,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password()')
+        leaves = []
+        _encrypted = self.encrypted
+        if _encrypted is not None:
+            leaves.append(f'{self_name}.encrypted = {repr(_encrypted)}')
+        _inheritance_disable = self.inheritance_disable
+        if _inheritance_disable is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password/inheritance-disable')
+            res.append(f'inheritance_disable = {self_name}.create_inheritance_disable()')
+            res.extend(_inheritance_disable.prsrc('inheritance_disable', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(node: xml.Node) -> yang.gdata.Container:
@@ -7203,6 +10239,34 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry(neighbor_address=n.get_str('neighbor-address'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families.from_gdata(n.get_opt_container('address-families')), remote_as=n.get_opt_str('remote-as'), description=n.get_opt_str('description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password.from_gdata(n.get_opt_container('password')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors/neighbor')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor({repr(self.neighbor_address)})')
+        leaves = []
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _remote_as = self.remote_as
+        if _remote_as is not None:
+            leaves.append(f'{self_name}.remote_as = {repr(_remote_as)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _password = self.password
+        if _password is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password')
+            res.append(f'password = {self_name}.create_password()')
+            res.extend(_password.prsrc('password', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry]
@@ -7281,6 +10345,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(yang
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/neighbors')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors()')
+        leaves = []
+        _neighbor = self.neighbor
+        for _element in _neighbor.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/vrfs/vrf/neighbors/neighbor element: {_element.to_gdata().key_str(['neighbor-address'])}")
+            list_elem = f'neighbor_element = {self_name}.neighbor.create({repr(_element.neighbor_address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/neighbors'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7303,6 +10387,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(yang.
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/rd/auto')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/rd/auto'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(node: xml.Node) -> yang.gdata.Container:
@@ -7339,6 +10436,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_a
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/rd/two-byte-as')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/rd/two-byte-as'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(node: xml.Node) -> yang.gdata.Container:
@@ -7380,6 +10496,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/rd/four-byte-as')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/rd/four-byte-as'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7419,6 +10554,25 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/rd/ip-address')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address()')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _index = self.index
+        if _index is not None:
+            leaves.append(f'{self_name}.index = {repr(_index)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/rd/ip-address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(node: xml.Node) -> yang.gdata.Container:
@@ -7484,6 +10638,43 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(yang.adata.
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(auto=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto.from_gdata(n.get_opt_container('auto')), two_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_container('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_container('four-byte-as')), ip_address=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_container('ip-address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf/rd')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd()')
+        leaves = []
+        _auto = self.auto
+        if _auto is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/rd/auto')
+            res.append(f'auto = {self_name}.create_auto()')
+            res.extend(_auto.prsrc('auto', False).splitlines())
+        _two_byte_as = self.two_byte_as
+        if _two_byte_as is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/rd/two-byte-as')
+            res.append(f'two_byte_as = {self_name}.create_two_byte_as()')
+            res.extend(_two_byte_as.prsrc('two_byte_as', False).splitlines())
+        _four_byte_as = self.four_byte_as
+        if _four_byte_as is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/rd/four-byte-as')
+            res.append(f'four_byte_as = {self_name}.create_four_byte_as()')
+            res.extend(_four_byte_as.prsrc('four_byte_as', False).splitlines())
+        _ip_address = self.ip_address
+        if _ip_address is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/rd/ip-address')
+            res.append(f'ip_address = {self_name}.create_ip_address()')
+            res.extend(_ip_address.prsrc('ip_address', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf/rd'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7534,6 +10725,31 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(yang.adat
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families.from_gdata(n.get_opt_container('address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors.from_gdata(n.get_opt_container('neighbors')), rd=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd.from_gdata(n.get_opt_container('rd')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs/vrf')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf({repr(self.vrf_name)})')
+        leaves = []
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _neighbors = self.neighbors
+        if _neighbors is not None:
+            res.extend(_neighbors.prsrc(f'{self_name}.neighbors', False).splitlines())
+        _rd = self.rd
+        if _rd is not None:
+            res.append('')
+            res.append('# P-container: /router/bgp/as/vrfs/vrf/rd')
+            res.append(f'rd = {self_name}.create_rd()')
+            res.extend(_rd.prsrc('rd', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs/vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry]
@@ -7610,6 +10826,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(vrf=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as/vrfs')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs()')
+        leaves = []
+        _vrf = self.vrf
+        for _element in _vrf.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as/vrfs/vrf element: {_element.to_gdata().key_str(['vrf-name'])}")
+            list_elem = f'vrf_element = {self_name}.vrf.create({repr(_element.vrf_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as/vrfs'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7664,6 +10900,37 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(as_number=n.get_str('as-number'), rpki=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki.from_gdata(n.get_opt_container('rpki')), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families.from_gdata(n.get_opt_container('address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors.from_gdata(n.get_opt_container('neighbors')), neighbor_groups=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups.from_gdata(n.get_opt_container('neighbor-groups')), bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp.from_gdata(n.get_opt_container('bgp')), vrfs=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs.from_gdata(n.get_opt_container('vrfs')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp/as')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as({repr(self.as_number)})')
+        leaves = []
+        _rpki = self.rpki
+        if _rpki is not None:
+            res.extend(_rpki.prsrc(f'{self_name}.rpki', False).splitlines())
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _neighbors = self.neighbors
+        if _neighbors is not None:
+            res.extend(_neighbors.prsrc(f'{self_name}.neighbors', False).splitlines())
+        _neighbor_groups = self.neighbor_groups
+        if _neighbor_groups is not None:
+            res.extend(_neighbor_groups.prsrc(f'{self_name}.neighbor_groups', False).splitlines())
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.extend(_bgp.prsrc(f'{self_name}.bgp', False).splitlines())
+        _vrfs = self.vrfs
+        if _vrfs is not None:
+            res.extend(_vrfs.prsrc(f'{self_name}.vrfs', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp/as'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry]
@@ -7746,6 +11013,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(as_=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as.from_gdata(n.get_opt_list('as')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router/bgp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp()')
+        leaves = []
+        _as_ = self.as_
+        for _element in _as_.elements:
+            res.append('')
+            res.append(f"# List /router/bgp/as element: {_element.to_gdata().key_str(['as-number'])}")
+            list_elem = f'as__element = {self_name}.as_.create({repr(_element.as_number)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'as__element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7772,6 +11059,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router(bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp.from_gdata(n.get_opt_container('bgp')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /router')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_router_bgp_cfg__router()')
+        leaves = []
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.extend(_bgp.prsrc(f'{self_name}.bgp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router(node: xml.Node) -> yang.gdata.Container:
@@ -7800,6 +11103,19 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry:
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry(af_name=n.get_str('af-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls/ldp/address-families/address-family')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family({repr(self.af_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls/ldp/address-families/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry]
@@ -7870,6 +11186,26 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(yang.adata.MNode
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(address_family=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls/ldp/address-families')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /mpls/ldp/address-families/address-family element: {_element.to_gdata().key_str(['af-name'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls/ldp/address-families'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7897,6 +11233,19 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(yang.
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry:
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(interface_name=n.get_str('interface-name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls/ldp/interfaces/interface')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface({repr(self.interface_name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls/ldp/interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry]
@@ -7967,6 +11316,26 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(interface=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls/ldp/interfaces')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /mpls/ldp/interfaces/interface element: {_element.to_gdata().key_str(['interface-name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.interface_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls/ldp/interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7998,6 +11367,25 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(address_families=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families.from_gdata(n.get_opt_container('address-families')), interfaces=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces.from_gdata(n.get_opt_container('interfaces')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls/ldp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp()')
+        leaves = []
+        _address_families = self.address_families
+        if _address_families is not None:
+            res.extend(_address_families.prsrc(f'{self_name}.address_families', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls/ldp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(node: xml.Node) -> yang.gdata.Container:
@@ -8033,6 +11421,25 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(yang.adata.MNode):
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(ldp=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp.from_gdata(n.get_opt_container('ldp')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /mpls')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_mpls_ldp_cfg__mpls()')
+        leaves = []
+        _ldp = self.ldp
+        if _ldp is not None:
+            res.append('')
+            res.append('# P-container: /mpls/ldp')
+            res.append(f'ldp = {self_name}.create_ldp()')
+            res.extend(_ldp.prsrc('ldp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /mpls'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8059,6 +11466,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/sub-interface-type/l2transport')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/sub-interface-type/l2transport'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8080,6 +11500,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/sub-interface-type/point-to-point')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/sub-interface-type/point-to-point'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8100,6 +11533,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/sub-interface-type/multipoint')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/sub-interface-type/multipoint'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint(node: xml.Node) -> yang.gdata.Container:
@@ -8150,6 +11596,37 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(y
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(l2transport=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport.from_gdata(n.get_opt_container('l2transport')), point_to_point=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point.from_gdata(n.get_opt_container('point-to-point')), multipoint=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint.from_gdata(n.get_opt_container('multipoint')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/sub-interface-type')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type()')
+        leaves = []
+        _l2transport = self.l2transport
+        if _l2transport is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/sub-interface-type/l2transport')
+            res.append(f'l2transport = {self_name}.create_l2transport()')
+            res.extend(_l2transport.prsrc('l2transport', False).splitlines())
+        _point_to_point = self.point_to_point
+        if _point_to_point is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/sub-interface-type/point-to-point')
+            res.append(f'point_to_point = {self_name}.create_point_to_point()')
+            res.extend(_point_to_point.prsrc('point_to_point', False).splitlines())
+        _multipoint = self.multipoint
+        if _multipoint is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/sub-interface-type/multipoint')
+            res.append(f'multipoint = {self_name}.create_multipoint()')
+            res.extend(_multipoint.prsrc('multipoint', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/sub-interface-type'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(node: xml.Node) -> yang.gdata.Container:
@@ -8209,6 +11686,31 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__add
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(address=n.get_opt_str('address'), netmask=n.get_opt_str('netmask'), route_tag=n.get_opt_int('route-tag'), algorithm=n.get_opt_int('algorithm'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4/addresses/address')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address()')
+        leaves = []
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        _netmask = self.netmask
+        if _netmask is not None:
+            leaves.append(f'{self_name}.netmask = {repr(_netmask)}')
+        _route_tag = self.route_tag
+        if _route_tag is not None:
+            leaves.append(f'{self_name}.route_tag = {repr(_route_tag)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4/addresses/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8266,6 +11768,28 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry:
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry(address=n.get_str('address'), netmask=n.get_opt_str('netmask'), route_tag=n.get_opt_int('route-tag'), algorithm=n.get_opt_int('algorithm'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4/addresses/secondaries/secondary')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary({repr(self.address)})')
+        leaves = []
+        _netmask = self.netmask
+        if _netmask is not None:
+            leaves.append(f'{self_name}.netmask = {repr(_netmask)}')
+        _route_tag = self.route_tag
+        if _route_tag is not None:
+            leaves.append(f'{self_name}.route_tag = {repr(_route_tag)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4/addresses/secondaries/secondary'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry]
@@ -8342,6 +11866,26 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(secondary=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary.from_gdata(n.get_opt_list('secondary')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4/addresses/secondaries')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries()')
+        leaves = []
+        _secondary = self.secondary
+        for _element in _secondary.elements:
+            res.append('')
+            res.append(f"# List /interfaces/interface/ipv4/addresses/secondaries/secondary element: {_element.to_gdata().key_str(['address'])}")
+            list_elem = f'secondary_element = {self_name}.secondary.create({repr(_element.address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'secondary_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4/addresses/secondaries'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8367,6 +11911,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhc
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4/addresses/dhcp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4/addresses/dhcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp(node: xml.Node) -> yang.gdata.Container:
@@ -8418,6 +11975,37 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(yang
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(address=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address.from_gdata(n.get_opt_container('address')), secondaries=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries.from_gdata(n.get_opt_container('secondaries')), unnumbered=n.get_opt_str('unnumbered'), dhcp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp.from_gdata(n.get_opt_container('dhcp')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4/addresses')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses()')
+        leaves = []
+        _address = self.address
+        if _address is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/ipv4/addresses/address')
+            res.append(f'address = {self_name}.create_address()')
+            res.extend(_address.prsrc('address', False).splitlines())
+        _secondaries = self.secondaries
+        if _secondaries is not None:
+            res.extend(_secondaries.prsrc(f'{self_name}.secondaries', False).splitlines())
+        _unnumbered = self.unnumbered
+        if _unnumbered is not None:
+            leaves.append(f'{self_name}.unnumbered = {repr(_unnumbered)}')
+        _dhcp = self.dhcp
+        if _dhcp is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/ipv4/addresses/dhcp')
+            res.append(f'dhcp = {self_name}.create_dhcp()')
+            res.extend(_dhcp.prsrc('dhcp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4/addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8451,6 +12039,22 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(yang.adata.MNod
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(addresses=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv4')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4()')
+        leaves = []
+        _addresses = self.addresses
+        if _addresses is not None:
+            res.extend(_addresses.prsrc(f'{self_name}.addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8474,6 +12078,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(yang.adata.MNod
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/ipv6')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8494,6 +12111,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation/ppp')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation/ppp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp(node: xml.Node) -> yang.gdata.Container:
@@ -8516,6 +12146,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation/hdlc')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation/hdlc'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8537,6 +12180,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation/mfr')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation/mfr'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8557,6 +12213,19 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay/IETF')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay/IETF'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF(node: xml.Node) -> yang.gdata.Container:
@@ -8587,6 +12256,25 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(IETF=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF.from_gdata(n.get_opt_container('IETF')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay()')
+        leaves = []
+        _IETF = self.IETF
+        if _IETF is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay/IETF')
+            res.append(f'IETF = {self_name}.create_IETF()')
+            res.extend(_IETF.prsrc('IETF', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(node: xml.Node) -> yang.gdata.Container:
@@ -8650,6 +12338,43 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(ppp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp.from_gdata(n.get_opt_container('ppp')), hdlc=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc.from_gdata(n.get_opt_container('hdlc')), mfr=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr.from_gdata(n.get_opt_container('mfr')), frame_relay=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay.from_gdata(n.get_opt_container('frame-relay')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-interface-cfg:encapsulation')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation()')
+        leaves = []
+        _ppp = self.ppp
+        if _ppp is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/um-interface-cfg:encapsulation/ppp')
+            res.append(f'ppp = {self_name}.create_ppp()')
+            res.extend(_ppp.prsrc('ppp', False).splitlines())
+        _hdlc = self.hdlc
+        if _hdlc is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/um-interface-cfg:encapsulation/hdlc')
+            res.append(f'hdlc = {self_name}.create_hdlc()')
+            res.extend(_hdlc.prsrc('hdlc', False).splitlines())
+        _mfr = self.mfr
+        if _mfr is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/um-interface-cfg:encapsulation/mfr')
+            res.append(f'mfr = {self_name}.create_mfr()')
+            res.extend(_mfr.prsrc('mfr', False).splitlines())
+        _frame_relay = self.frame_relay
+        if _frame_relay is not None:
+            res.append('')
+            res.append('# P-container: /interfaces/interface/um-interface-cfg:encapsulation/frame-relay')
+            res.append(f'frame_relay = {self_name}.create_frame_relay()')
+            res.extend(_frame_relay.prsrc('frame_relay', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-interface-cfg:encapsulation'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8706,6 +12431,25 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(vlan_id=n.get_opt_int('vlan-id'), second_dot1q=n.get_opt_int('second-dot1q'))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-l2-ethernet-cfg:encapsulation/dot1q')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q()')
+        leaves = []
+        _vlan_id = self.vlan_id
+        if _vlan_id is not None:
+            leaves.append(f'{self_name}.vlan_id = {repr(_vlan_id)}')
+        _second_dot1q = self.second_dot1q
+        if _second_dot1q is not None:
+            leaves.append(f'{self_name}.second_dot1q = {repr(_second_dot1q)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-l2-ethernet-cfg:encapsulation/dot1q'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8734,6 +12478,22 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
         if n != None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(dot1q=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q.from_gdata(n.get_opt_container('dot1q')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface/um-l2-ethernet-cfg:encapsulation')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation()')
+        leaves = []
+        _dot1q = self.dot1q
+        if _dot1q is not None:
+            res.extend(_dot1q.prsrc(f'{self_name}.dot1q', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface/um-l2-ethernet-cfg:encapsulation'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(node: xml.Node) -> yang.gdata.Container:
@@ -8804,6 +12564,46 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry:
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(interface_name=n.get_str('interface-name'), sub_interface_type=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type.from_gdata(n.get_opt_container('sub-interface-type')), ipv4=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6.from_gdata(n.get_opt_container('ipv6')), um_interface_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation.from_gdata(n.get_opt_container('um-interface-cfg:encapsulation')), shutdown=n.get_opt_bool('shutdown'), mtu=n.get_opt_int('mtu'), description=n.get_opt_str('description'), vrf=n.get_opt_str('vrf'), um_l2_ethernet_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation.from_gdata(n.get_opt_container('um-l2-ethernet-cfg:encapsulation')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces/interface')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces__interface({repr(self.interface_name)})')
+        leaves = []
+        _sub_interface_type = self.sub_interface_type
+        if _sub_interface_type is not None:
+            res.extend(_sub_interface_type.prsrc(f'{self_name}.sub_interface_type', False).splitlines())
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.extend(_ipv4.prsrc(f'{self_name}.ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.extend(_ipv6.prsrc(f'{self_name}.ipv6', False).splitlines())
+        _um_interface_cfg_encapsulation = self.um_interface_cfg_encapsulation
+        if _um_interface_cfg_encapsulation is not None:
+            res.extend(_um_interface_cfg_encapsulation.prsrc(f'{self_name}.um_interface_cfg_encapsulation', False).splitlines())
+        _shutdown = self.shutdown
+        if _shutdown is not None:
+            leaves.append(f'{self_name}.shutdown = {repr(_shutdown)}')
+        _mtu = self.mtu
+        if _mtu is not None:
+            leaves.append(f'{self_name}.mtu = {repr(_mtu)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _vrf = self.vrf
+        if _vrf is not None:
+            leaves.append(f'{self_name}.vrf = {repr(_vrf)}')
+        _um_l2_ethernet_cfg_encapsulation = self.um_l2_ethernet_cfg_encapsulation
+        if _um_l2_ethernet_cfg_encapsulation is not None:
+            res.extend(_um_l2_ethernet_cfg_encapsulation.prsrc(f'{self_name}.um_l2_ethernet_cfg_encapsulation', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry]
@@ -8892,6 +12692,26 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_interface_cfg__interfaces(interface=Cisco_IOS_XR_um_interface_cfg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /interfaces')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_interface_cfg__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /interfaces/interface element: {_element.to_gdata().key_str(['interface-name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.interface_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8914,6 +12734,19 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(yang.adat
         if n != None:
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /ethernet/egress-filter/strict')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /ethernet/egress-filter/strict'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(node: xml.Node) -> yang.gdata.Container:
@@ -8945,6 +12778,25 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(yang.adata.MNode)
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(strict=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict.from_gdata(n.get_opt_container('strict')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /ethernet/egress-filter')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter()')
+        leaves = []
+        _strict = self.strict
+        if _strict is not None:
+            res.append('')
+            res.append('# P-container: /ethernet/egress-filter/strict')
+            res.append(f'strict = {self_name}.create_strict()')
+            res.extend(_strict.prsrc('strict', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /ethernet/egress-filter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8971,6 +12823,22 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(egress_filter=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter.from_gdata(n.get_opt_container('egress-filter')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /ethernet')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet()')
+        leaves = []
+        _egress_filter = self.egress_filter
+        if _egress_filter is not None:
+            res.extend(_egress_filter.prsrc(f'{self_name}.egress_filter', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /ethernet'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(node: xml.Node) -> yang.gdata.Container:
@@ -9001,6 +12869,22 @@ class Cisco_IOS_XR_um_hostname_cfg__hostname(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_um_hostname_cfg__hostname(system_network_name=n.get_opt_str('system-network-name'))
         return Cisco_IOS_XR_um_hostname_cfg__hostname()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /hostname')
+            res.append(f'{self_name} = Cisco_IOS_XR_um_hostname_cfg__hostname()')
+        leaves = []
+        _system_network_name = self.system_network_name
+        if _system_network_name is not None:
+            leaves.append(f'{self_name}.system_network_name = {repr(_system_network_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /hostname'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_um_hostname_cfg__hostname(node: xml.Node) -> yang.gdata.Container:
@@ -9037,6 +12921,22 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry:
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry(route_policy_name=n.get_str('route-policy-name'), rpl_route_policy=n.get_opt_str('rpl-route-policy'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /routing-policy/route-policies/route-policy')
+            res.append(f'{self_name} = Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy({repr(self.route_policy_name)})')
+        leaves = []
+        _rpl_route_policy = self.rpl_route_policy
+        if _rpl_route_policy is not None:
+            leaves.append(f'{self_name}.rpl_route_policy = {repr(_rpl_route_policy)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /routing-policy/route-policies/route-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry]
@@ -9109,6 +13009,26 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(yang.ad
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(route_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy.from_gdata(n.get_opt_list('route-policy')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /routing-policy/route-policies')
+            res.append(f'{self_name} = Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies()')
+        leaves = []
+        _route_policy = self.route_policy
+        for _element in _route_policy.elements:
+            res.append('')
+            res.append(f"# List /routing-policy/route-policies/route-policy element: {_element.to_gdata().key_str(['route-policy-name'])}")
+            list_elem = f'route_policy_element = {self_name}.route_policy.create({repr(_element.route_policy_name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'route_policy_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /routing-policy/route-policies'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9135,6 +13055,22 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy(yang.adata.MNode):
         if n != None:
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy(route_policies=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies.from_gdata(n.get_opt_container('route-policies')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /routing-policy')
+            res.append(f'{self_name} = Cisco_IOS_XR_policy_repository_cfg__routing_policy()')
+        leaves = []
+        _route_policies = self.route_policies
+        if _route_policies is not None:
+            res.extend(_route_policies.prsrc(f'{self_name}.route_policies', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /routing-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy(node: xml.Node) -> yang.gdata.Container:
@@ -9232,6 +13168,64 @@ class root(yang.adata.MNode):
         if n != None:
             return root(address_family=Cisco_IOS_XR_um_vrf_cfg__address_family.from_gdata(n.get_opt_container('address-family')), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrfs.from_gdata(n.get_opt_container('vrfs')), selective_vrf_download=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download.from_gdata(n.get_opt_container('selective-vrf-download')), srlg=Cisco_IOS_XR_um_vrf_cfg__srlg.from_gdata(n.get_opt_container('srlg')), vrf_groups=Cisco_IOS_XR_um_vrf_cfg__vrf_groups.from_gdata(n.get_opt_container('vrf-groups')), um_router_isis_cfg_router=Cisco_IOS_XR_um_router_isis_cfg__router.from_gdata(n.get_opt_container('um-router-isis-cfg:router')), as_format=Cisco_IOS_XR_um_router_bgp_cfg__as_format.from_gdata(n.get_opt_container('as-format')), bmp=Cisco_IOS_XR_um_router_bgp_cfg__bmp.from_gdata(n.get_opt_container('bmp')), um_router_bgp_cfg_router=Cisco_IOS_XR_um_router_bgp_cfg__router.from_gdata(n.get_opt_container('um-router-bgp-cfg:router')), mpls=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls.from_gdata(n.get_opt_container('mpls')), interfaces=Cisco_IOS_XR_um_interface_cfg__interfaces.from_gdata(n.get_opt_container('interfaces')), ethernet=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet.from_gdata(n.get_opt_container('ethernet')), hostname=Cisco_IOS_XR_um_hostname_cfg__hostname.from_gdata(n.get_opt_container('hostname')), routing_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy.from_gdata(n.get_opt_container('routing-policy')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            res.extend(_address_family.prsrc(f'{self_name}.address_family', False).splitlines())
+        _vrfs = self.vrfs
+        if _vrfs is not None:
+            res.extend(_vrfs.prsrc(f'{self_name}.vrfs', False).splitlines())
+        _selective_vrf_download = self.selective_vrf_download
+        if _selective_vrf_download is not None:
+            res.extend(_selective_vrf_download.prsrc(f'{self_name}.selective_vrf_download', False).splitlines())
+        _srlg = self.srlg
+        if _srlg is not None:
+            res.append('')
+            res.append('# P-container: /srlg')
+            res.append(f'srlg = {self_name}.create_srlg()')
+            res.extend(_srlg.prsrc('srlg', False).splitlines())
+        _vrf_groups = self.vrf_groups
+        if _vrf_groups is not None:
+            res.extend(_vrf_groups.prsrc(f'{self_name}.vrf_groups', False).splitlines())
+        _um_router_isis_cfg_router = self.um_router_isis_cfg_router
+        if _um_router_isis_cfg_router is not None:
+            res.extend(_um_router_isis_cfg_router.prsrc(f'{self_name}.um_router_isis_cfg_router', False).splitlines())
+        _as_format = self.as_format
+        if _as_format is not None:
+            res.extend(_as_format.prsrc(f'{self_name}.as_format', False).splitlines())
+        _bmp = self.bmp
+        if _bmp is not None:
+            res.extend(_bmp.prsrc(f'{self_name}.bmp', False).splitlines())
+        _um_router_bgp_cfg_router = self.um_router_bgp_cfg_router
+        if _um_router_bgp_cfg_router is not None:
+            res.extend(_um_router_bgp_cfg_router.prsrc(f'{self_name}.um_router_bgp_cfg_router', False).splitlines())
+        _mpls = self.mpls
+        if _mpls is not None:
+            res.extend(_mpls.prsrc(f'{self_name}.mpls', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        _ethernet = self.ethernet
+        if _ethernet is not None:
+            res.extend(_ethernet.prsrc(f'{self_name}.ethernet', False).splitlines())
+        _hostname = self.hostname
+        if _hostname is not None:
+            res.extend(_hostname.prsrc(f'{self_name}.hostname', False).splitlines())
+        _routing_policy = self.routing_policy
+        if _routing_policy is not None:
+            res.extend(_routing_policy.prsrc(f'{self_name}.routing_policy', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/devices/JuniperCRPD_23_4R1_9.act
+++ b/src/respnet/devices/JuniperCRPD_23_4R1_9.act
@@ -36,6 +36,22 @@ class junos_conf_root__configuration__system(yang.adata.MNode):
             return junos_conf_root__configuration__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__system()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/system')
+            res.append(f'{self_name} = junos_conf_root__configuration__system()')
+        leaves = []
+        _host_name = self.host_name
+        if _host_name is not None:
+            leaves.append(f'{self_name}.host_name = {repr(_host_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/system'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__system(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -93,6 +109,19 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/inet/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__inet__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/inet/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry]
@@ -163,6 +192,26 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet(
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/inet')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__inet()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/interfaces/interface/unit/family/inet/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/inet'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -190,6 +239,19 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/inet6/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/inet6/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry]
@@ -260,6 +322,26 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/inet6')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__inet6()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/interfaces/interface/unit/family/inet6/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/inet6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -287,6 +369,19 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso__
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/iso/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__iso__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/iso/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry]
@@ -357,6 +452,26 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso(y
             return junos_conf_root__configuration__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family/iso')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family__iso()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/interfaces/interface/unit/family/iso/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family/iso'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -408,6 +523,37 @@ class junos_conf_root__configuration__interfaces__interface__unit__family(yang.a
         if n != None:
             return junos_conf_root__configuration__interfaces__interface__unit__family(inet=junos_conf_root__configuration__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_container('inet')), inet6=junos_conf_root__configuration__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_container('inet6')), iso=junos_conf_root__configuration__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_container('iso')))
         return junos_conf_root__configuration__interfaces__interface__unit__family()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit/family')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit__family()')
+        leaves = []
+        _inet = self.inet
+        if _inet is not None:
+            res.append('')
+            res.append('# P-container: /configuration/interfaces/interface/unit/family/inet')
+            res.append(f'inet = {self_name}.create_inet()')
+            res.extend(_inet.prsrc('inet', False).splitlines())
+        _inet6 = self.inet6
+        if _inet6 is not None:
+            res.append('')
+            res.append('# P-container: /configuration/interfaces/interface/unit/family/inet6')
+            res.append(f'inet6 = {self_name}.create_inet6()')
+            res.extend(_inet6.prsrc('inet6', False).splitlines())
+        _iso = self.iso
+        if _iso is not None:
+            res.append('')
+            res.append('# P-container: /configuration/interfaces/interface/unit/family/iso')
+            res.append(f'iso = {self_name}.create_iso()')
+            res.extend(_iso.prsrc('iso', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit/family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family(node: xml.Node) -> yang.gdata.Container:
@@ -478,6 +624,40 @@ class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.ada
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit_entry:
         return junos_conf_root__configuration__interfaces__interface__unit_entry(name=n.get_str('name'), alias=n.get_opt_str('alias'), description=n.get_opt_str('description'), vlan_id=n.get_opt_str('vlan-id'), encapsulation=n.get_opt_str('encapsulation'), family=junos_conf_root__configuration__interfaces__interface__unit__family.from_gdata(n.get_opt_container('family')), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/unit')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__unit({repr(self.name)})')
+        leaves = []
+        _alias = self.alias
+        if _alias is not None:
+            leaves.append(f'{self_name}.alias = {repr(_alias)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _vlan_id = self.vlan_id
+        if _vlan_id is not None:
+            leaves.append(f'{self_name}.vlan_id = {repr(_vlan_id)}')
+        _encapsulation = self.encapsulation
+        if _encapsulation is not None:
+            leaves.append(f'{self_name}.encapsulation = {repr(_encapsulation)}')
+        _family = self.family
+        if _family is not None:
+            res.extend(_family.prsrc(f'{self_name}.family', False).splitlines())
+        _mtu = self.mtu
+        if _mtu is not None:
+            leaves.append(f'{self_name}.mtu = {repr(_mtu)}')
+        _mac = self.mac
+        if _mac is not None:
+            leaves.append(f'{self_name}.mac = {repr(_mac)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/unit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__interfaces__interface__unit(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit_entry]
@@ -582,6 +762,19 @@ class junos_conf_root__configuration__interfaces__interface__hierarchical_schedu
             return junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface/hierarchical-scheduler')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface/hierarchical-scheduler'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -680,6 +873,68 @@ class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface_entry:
         return junos_conf_root__configuration__interfaces__interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'), native_vlan_id=n.get_opt_value('native-vlan-id'), unit=junos_conf_root__configuration__interfaces__interface__unit.from_gdata(n.get_opt_list('unit')), encapsulation=n.get_opt_str('encapsulation'), vlan_tagging=n.get_opt_bool('vlan-tagging'), stacked_vlan_tagging=n.get_opt_bool('stacked-vlan-tagging'), flexible_vlan_tagging=n.get_opt_bool('flexible-vlan-tagging'), vlan_vci_tagging=n.get_opt_bool('vlan-vci-tagging'), per_unit_scheduler=n.get_opt_bool('per-unit-scheduler'), no_per_unit_scheduler=n.get_opt_bool('no-per-unit-scheduler'), shared_scheduler=n.get_opt_bool('shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler.from_gdata(n.get_opt_container('hierarchical-scheduler')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces__interface({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _mtu = self.mtu
+        if _mtu is not None:
+            leaves.append(f'{self_name}.mtu = {repr(_mtu)}')
+        _mac = self.mac
+        if _mac is not None:
+            leaves.append(f'{self_name}.mac = {repr(_mac)}')
+        _native_vlan_id = self.native_vlan_id
+        if _native_vlan_id is not None:
+            leaves.append(f'{self_name}.native_vlan_id = {repr(_native_vlan_id)}')
+        _unit = self.unit
+        for _element in _unit.elements:
+            res.append('')
+            res.append(f"# List /configuration/interfaces/interface/unit element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'unit_element = {self_name}.unit.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'unit_element', False, list_element=True).splitlines())
+        _encapsulation = self.encapsulation
+        if _encapsulation is not None:
+            leaves.append(f'{self_name}.encapsulation = {repr(_encapsulation)}')
+        _vlan_tagging = self.vlan_tagging
+        if _vlan_tagging is not None:
+            leaves.append(f'{self_name}.vlan_tagging = {repr(_vlan_tagging)}')
+        _stacked_vlan_tagging = self.stacked_vlan_tagging
+        if _stacked_vlan_tagging is not None:
+            leaves.append(f'{self_name}.stacked_vlan_tagging = {repr(_stacked_vlan_tagging)}')
+        _flexible_vlan_tagging = self.flexible_vlan_tagging
+        if _flexible_vlan_tagging is not None:
+            leaves.append(f'{self_name}.flexible_vlan_tagging = {repr(_flexible_vlan_tagging)}')
+        _vlan_vci_tagging = self.vlan_vci_tagging
+        if _vlan_vci_tagging is not None:
+            leaves.append(f'{self_name}.vlan_vci_tagging = {repr(_vlan_vci_tagging)}')
+        _per_unit_scheduler = self.per_unit_scheduler
+        if _per_unit_scheduler is not None:
+            leaves.append(f'{self_name}.per_unit_scheduler = {repr(_per_unit_scheduler)}')
+        _no_per_unit_scheduler = self.no_per_unit_scheduler
+        if _no_per_unit_scheduler is not None:
+            leaves.append(f'{self_name}.no_per_unit_scheduler = {repr(_no_per_unit_scheduler)}')
+        _shared_scheduler = self.shared_scheduler
+        if _shared_scheduler is not None:
+            leaves.append(f'{self_name}.shared_scheduler = {repr(_shared_scheduler)}')
+        _hierarchical_scheduler = self.hierarchical_scheduler
+        if _hierarchical_scheduler is not None:
+            res.append('')
+            res.append('# P-container: /configuration/interfaces/interface/hierarchical-scheduler')
+            res.append(f'hierarchical_scheduler = {self_name}.create_hierarchical_scheduler()')
+            res.extend(_hierarchical_scheduler.prsrc('hierarchical_scheduler', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__interfaces__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -777,6 +1032,26 @@ class junos_conf_root__configuration__interfaces(yang.adata.MNode):
             return junos_conf_root__configuration__interfaces(interface=junos_conf_root__configuration__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/interfaces')
+            res.append(f'{self_name} = junos_conf_root__configuration__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/interfaces/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -848,6 +1123,31 @@ class junos_conf_root__configuration__routing_instances__instance__interface_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__interface_entry:
         return junos_conf_root__configuration__routing_instances__instance__interface_entry(name=n.get_str('name'), any=n.get_opt_bool('any'), unicast=n.get_opt_bool('unicast'), multicast=n.get_opt_bool('multicast'), primary=n.get_opt_bool('primary'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__interface({repr(self.name)})')
+        leaves = []
+        _any = self.any
+        if _any is not None:
+            leaves.append(f'{self_name}.any = {repr(_any)}')
+        _unicast = self.unicast
+        if _unicast is not None:
+            leaves.append(f'{self_name}.unicast = {repr(_unicast)}')
+        _multicast = self.multicast
+        if _multicast is not None:
+            leaves.append(f'{self_name}.multicast = {repr(_multicast)}')
+        _primary = self.primary
+        if _primary is not None:
+            leaves.append(f'{self_name}.primary = {repr(_primary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__routing_instances__instance__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__interface_entry]
@@ -929,6 +1229,22 @@ class junos_conf_root__configuration__routing_instances__instance__route_disting
             return junos_conf_root__configuration__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__routing_instances__instance__route_distinguisher()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/route-distinguisher')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__route_distinguisher()')
+        leaves = []
+        _rd_type = self.rd_type
+        if _rd_type is not None:
+            leaves.append(f'{self_name}.rd_type = {repr(_rd_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/route-distinguisher'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__route_distinguisher(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -989,6 +1305,31 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_target(ya
             return junos_conf_root__configuration__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_bool('auto'))
         return junos_conf_root__configuration__routing_instances__instance__vrf_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/vrf-target')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__vrf_target()')
+        leaves = []
+        _community = self.community
+        if _community is not None:
+            leaves.append(f'{self_name}.community = {repr(_community)}')
+        _import_ = self.import_
+        if _import_ is not None:
+            leaves.append(f'{self_name}.import_ = {repr(_import_)}')
+        _export = self.export
+        if _export is not None:
+            leaves.append(f'{self_name}.export = {repr(_export)}')
+        _auto = self.auto
+        if _auto is not None:
+            leaves.append(f'{self_name}.auto = {repr(_auto)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/vrf-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1035,6 +1376,25 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_table_lab
         if n != None:
             return junos_conf_root__configuration__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_bool('source-class-usage'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/vrf-table-label')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__vrf_table_label()')
+        leaves = []
+        _static = self.static
+        if _static is not None:
+            leaves.append(f'{self_name}.static = {repr(_static)}')
+        _source_class_usage = self.source_class_usage
+        if _source_class_usage is not None:
+            leaves.append(f'{self_name}.source_class_usage = {repr(_source_class_usage)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/vrf-table-label'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label(node: xml.Node) -> yang.gdata.Container:
@@ -1106,6 +1466,25 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_bool('no-nexthop-change'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols/bgp/group/neighbor/multihop')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop()')
+        leaves = []
+        _ttl = self.ttl
+        if _ttl is not None:
+            leaves.append(f'{self_name}.ttl = {repr(_ttl)}')
+        _no_nexthop_change = self.no_nexthop_change
+        if _no_nexthop_change is not None:
+            leaves.append(f'{self_name}.no_nexthop_change = {repr(_no_nexthop_change)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols/bgp/group/neighbor/multihop'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1167,6 +1546,40 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), peer_as=n.get_opt_str('peer-as'), authentication_key=n.get_opt_str('authentication-key'), as_override=n.get_opt_bool('as-override'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), multihop=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_gdata(n.get_opt_container('multihop')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols/bgp/group/neighbor')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _peer_as = self.peer_as
+        if _peer_as is not None:
+            leaves.append(f'{self_name}.peer_as = {repr(_peer_as)}')
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        _as_override = self.as_override
+        if _as_override is not None:
+            leaves.append(f'{self_name}.as_override = {repr(_as_override)}')
+        _authentication_algorithm = self.authentication_algorithm
+        if _authentication_algorithm is not None:
+            leaves.append(f'{self_name}.authentication_algorithm = {repr(_authentication_algorithm)}')
+        _multihop = self.multihop
+        if _multihop is not None:
+            res.append('')
+            res.append('# P-container: /configuration/routing-instances/instance/protocols/bgp/group/neighbor/multihop')
+            res.append(f'multihop = {self_name}.create_multihop()')
+            res.extend(_multihop.prsrc('multihop', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols/bgp/group/neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry]
@@ -1263,6 +1676,35 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry:
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry(name=n.get_str('name'), passive=n.get_opt_bool('passive'), import_=n.get_opt_strs('import'), export=n.get_opt_strs('export'), neighbor=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols/bgp/group')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group({repr(self.name)})')
+        leaves = []
+        _passive = self.passive
+        if _passive is not None:
+            leaves.append(f'{self_name}.passive = {repr(_passive)}')
+        _import_ = self.import_
+        if _import_ is not None:
+            leaves.append(f'{self_name}.import_ = {repr(_import_)}')
+        _export = self.export
+        if _export is not None:
+            leaves.append(f'{self_name}.export = {repr(_export)}')
+        _neighbor = self.neighbor
+        for _element in _neighbor.elements:
+            res.append('')
+            res.append(f"# List /configuration/routing-instances/instance/protocols/bgp/group/neighbor element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'neighbor_element = {self_name}.neighbor.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols/bgp/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -1340,6 +1782,26 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols/bgp')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols__bgp()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /configuration/routing-instances/instance/protocols/bgp/group element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1377,6 +1839,25 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__ev
         if n != None:
             return junos_conf_root__configuration__routing_instances__instance__protocols__evpn(control_word=n.get_opt_bool('control-word'), no_mac_learning=n.get_opt_bool('no-mac-learning'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols/evpn')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols__evpn()')
+        leaves = []
+        _control_word = self.control_word
+        if _control_word is not None:
+            leaves.append(f'{self_name}.control_word = {repr(_control_word)}')
+        _no_mac_learning = self.no_mac_learning
+        if _no_mac_learning is not None:
+            leaves.append(f'{self_name}.no_mac_learning = {repr(_no_mac_learning)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols/evpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn(node: xml.Node) -> yang.gdata.Container:
@@ -1416,6 +1897,28 @@ class junos_conf_root__configuration__routing_instances__instance__protocols(yan
         if n != None:
             return junos_conf_root__configuration__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_container('bgp')), evpn=junos_conf_root__configuration__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_container('evpn')))
         return junos_conf_root__configuration__routing_instances__instance__protocols()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance/protocols')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance__protocols()')
+        leaves = []
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.extend(_bgp.prsrc(f'{self_name}.bgp', False).splitlines())
+        _evpn = self.evpn
+        if _evpn is not None:
+            res.append('')
+            res.append('# P-container: /configuration/routing-instances/instance/protocols/evpn')
+            res.append(f'evpn = {self_name}.create_evpn()')
+            res.extend(_evpn.prsrc('evpn', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance/protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols(node: xml.Node) -> yang.gdata.Container:
@@ -1499,6 +2002,59 @@ class junos_conf_root__configuration__routing_instances__instance_entry(yang.ada
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance_entry:
         return junos_conf_root__configuration__routing_instances__instance_entry(name=n.get_str('name'), apply_groups=n.get_opt_strs('apply-groups'), apply_groups_except=n.get_opt_strs('apply-groups-except'), instance_type=n.get_opt_str('instance-type'), interface=junos_conf_root__configuration__routing_instances__instance__interface.from_gdata(n.get_opt_list('interface')), route_distinguisher=junos_conf_root__configuration__routing_instances__instance__route_distinguisher.from_gdata(n.get_opt_container('route-distinguisher')), export_default_action=n.get_opt_str('export-default-action'), import_default_action=n.get_opt_str('import-default-action'), vrf_target=junos_conf_root__configuration__routing_instances__instance__vrf_target.from_gdata(n.get_opt_container('vrf-target')), no_vrf_advertise=n.get_opt_bool('no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__routing_instances__instance__vrf_table_label.from_gdata(n.get_opt_container('vrf-table-label')), protocols=junos_conf_root__configuration__routing_instances__instance__protocols.from_gdata(n.get_opt_container('protocols')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances/instance')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances__instance({repr(self.name)})')
+        leaves = []
+        _apply_groups = self.apply_groups
+        if _apply_groups is not None:
+            leaves.append(f'{self_name}.apply_groups = {repr(_apply_groups)}')
+        _apply_groups_except = self.apply_groups_except
+        if _apply_groups_except is not None:
+            leaves.append(f'{self_name}.apply_groups_except = {repr(_apply_groups_except)}')
+        _instance_type = self.instance_type
+        if _instance_type is not None:
+            leaves.append(f'{self_name}.instance_type = {repr(_instance_type)}')
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/routing-instances/instance/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        _route_distinguisher = self.route_distinguisher
+        if _route_distinguisher is not None:
+            res.extend(_route_distinguisher.prsrc(f'{self_name}.route_distinguisher', False).splitlines())
+        _export_default_action = self.export_default_action
+        if _export_default_action is not None:
+            leaves.append(f'{self_name}.export_default_action = {repr(_export_default_action)}')
+        _import_default_action = self.import_default_action
+        if _import_default_action is not None:
+            leaves.append(f'{self_name}.import_default_action = {repr(_import_default_action)}')
+        _vrf_target = self.vrf_target
+        if _vrf_target is not None:
+            res.extend(_vrf_target.prsrc(f'{self_name}.vrf_target', False).splitlines())
+        _no_vrf_advertise = self.no_vrf_advertise
+        if _no_vrf_advertise is not None:
+            leaves.append(f'{self_name}.no_vrf_advertise = {repr(_no_vrf_advertise)}')
+        _vrf_table_label = self.vrf_table_label
+        if _vrf_table_label is not None:
+            res.append('')
+            res.append('# P-container: /configuration/routing-instances/instance/vrf-table-label')
+            res.append(f'vrf_table_label = {self_name}.create_vrf_table_label()')
+            res.extend(_vrf_table_label.prsrc('vrf_table_label', False).splitlines())
+        _protocols = self.protocols
+        if _protocols is not None:
+            res.extend(_protocols.prsrc(f'{self_name}.protocols', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances/instance'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__routing_instances__instance(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance_entry]
@@ -1591,6 +2147,26 @@ class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
             return junos_conf_root__configuration__routing_instances(instance=junos_conf_root__configuration__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__routing_instances()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-instances')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_instances()')
+        leaves = []
+        _instance = self.instance
+        for _element in _instance.elements:
+            res.append('')
+            res.append(f"# List /configuration/routing-instances/instance element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'instance_element = {self_name}.instance.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'instance_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-instances'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_instances(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1627,6 +2203,22 @@ class junos_conf_root__configuration__groups__when__time__to(yang.adata.MNode):
             return junos_conf_root__configuration__groups__when__time__to(end_time=n.get_opt_str('end-time'))
         return junos_conf_root__configuration__groups__when__time__to()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/when/time/to')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__when__time__to()')
+        leaves = []
+        _end_time = self.end_time
+        if _end_time is not None:
+            leaves.append(f'{self_name}.end_time = {repr(_end_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/when/time/to'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__when__time__to(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1658,6 +2250,25 @@ class junos_conf_root__configuration__groups__when__time(yang.adata.MNode):
         if n != None:
             return junos_conf_root__configuration__groups__when__time(start_time=n.get_opt_str('start-time'), to=junos_conf_root__configuration__groups__when__time__to.from_gdata(n.get_opt_container('to')))
         return junos_conf_root__configuration__groups__when__time()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/when/time')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__when__time()')
+        leaves = []
+        _start_time = self.start_time
+        if _start_time is not None:
+            leaves.append(f'{self_name}.start_time = {repr(_start_time)}')
+        _to = self.to
+        if _to is not None:
+            res.extend(_to.prsrc(f'{self_name}.to', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/when/time'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__when__time(node: xml.Node) -> yang.gdata.Container:
@@ -1728,6 +2339,37 @@ class junos_conf_root__configuration__groups__when(yang.adata.MNode):
             return junos_conf_root__configuration__groups__when(time=junos_conf_root__configuration__groups__when__time.from_gdata(n.get_opt_container('time')), chassis=n.get_opt_str('chassis'), model=n.get_opt_str('model'), routing_engine=n.get_opt_str('routing-engine'), member=n.get_opt_str('member'), node=n.get_opt_str('node'))
         return junos_conf_root__configuration__groups__when()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/when')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__when()')
+        leaves = []
+        _time = self.time
+        if _time is not None:
+            res.extend(_time.prsrc(f'{self_name}.time', False).splitlines())
+        _chassis = self.chassis
+        if _chassis is not None:
+            leaves.append(f'{self_name}.chassis = {repr(_chassis)}')
+        _model = self.model
+        if _model is not None:
+            leaves.append(f'{self_name}.model = {repr(_model)}')
+        _routing_engine = self.routing_engine
+        if _routing_engine is not None:
+            leaves.append(f'{self_name}.routing_engine = {repr(_routing_engine)}')
+        _member = self.member
+        if _member is not None:
+            leaves.append(f'{self_name}.member = {repr(_member)}')
+        _node = self.node
+        if _node is not None:
+            leaves.append(f'{self_name}.node = {repr(_node)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/when'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__when(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1773,6 +2415,22 @@ class junos_conf_root__configuration__groups__system(yang.adata.MNode):
         if n != None:
             return junos_conf_root__configuration__groups__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__groups__system()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/system')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__system()')
+        leaves = []
+        _host_name = self.host_name
+        if _host_name is not None:
+            leaves.append(f'{self_name}.host_name = {repr(_host_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/system'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__system(node: xml.Node) -> yang.gdata.Container:
@@ -1831,6 +2489,19 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/inet/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/inet/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry]
@@ -1901,6 +2572,26 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/inet')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/interfaces/interface/unit/family/inet/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/inet'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1928,6 +2619,19 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/inet6/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/inet6/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry]
@@ -1998,6 +2702,26 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/inet6')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/interfaces/interface/unit/family/inet6/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/inet6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2025,6 +2749,19 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry(name=n.get_str('name'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/iso/address')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address({repr(self.name)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/iso/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry]
@@ -2095,6 +2832,26 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family/iso')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso()')
+        leaves = []
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/interfaces/interface/unit/family/iso/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family/iso'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2146,6 +2903,37 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
         if n != None:
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family(inet=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_container('inet')), inet6=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_container('inet6')), iso=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_container('iso')))
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit/family')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit__family()')
+        leaves = []
+        _inet = self.inet
+        if _inet is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/interfaces/interface/unit/family/inet')
+            res.append(f'inet = {self_name}.create_inet()')
+            res.extend(_inet.prsrc('inet', False).splitlines())
+        _inet6 = self.inet6
+        if _inet6 is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/interfaces/interface/unit/family/inet6')
+            res.append(f'inet6 = {self_name}.create_inet6()')
+            res.extend(_inet6.prsrc('inet6', False).splitlines())
+        _iso = self.iso
+        if _iso is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/interfaces/interface/unit/family/iso')
+            res.append(f'iso = {self_name}.create_iso()')
+            res.extend(_iso.prsrc('iso', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit/family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family(node: xml.Node) -> yang.gdata.Container:
@@ -2216,6 +3004,40 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit_entry(
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit_entry(name=n.get_str('name'), alias=n.get_opt_str('alias'), description=n.get_opt_str('description'), vlan_id=n.get_opt_str('vlan-id'), encapsulation=n.get_opt_str('encapsulation'), family=junos_conf_root__configuration__groups__interfaces__interface__unit__family.from_gdata(n.get_opt_container('family')), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/unit')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__unit({repr(self.name)})')
+        leaves = []
+        _alias = self.alias
+        if _alias is not None:
+            leaves.append(f'{self_name}.alias = {repr(_alias)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _vlan_id = self.vlan_id
+        if _vlan_id is not None:
+            leaves.append(f'{self_name}.vlan_id = {repr(_vlan_id)}')
+        _encapsulation = self.encapsulation
+        if _encapsulation is not None:
+            leaves.append(f'{self_name}.encapsulation = {repr(_encapsulation)}')
+        _family = self.family
+        if _family is not None:
+            res.extend(_family.prsrc(f'{self_name}.family', False).splitlines())
+        _mtu = self.mtu
+        if _mtu is not None:
+            leaves.append(f'{self_name}.mtu = {repr(_mtu)}')
+        _mac = self.mac
+        if _mac is not None:
+            leaves.append(f'{self_name}.mac = {repr(_mac)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/unit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit_entry]
@@ -2320,6 +3142,19 @@ class junos_conf_root__configuration__groups__interfaces__interface__hierarchica
             return junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler()
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface/hierarchical-scheduler')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface/hierarchical-scheduler'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2418,6 +3253,68 @@ class junos_conf_root__configuration__groups__interfaces__interface_entry(yang.a
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface_entry:
         return junos_conf_root__configuration__groups__interfaces__interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'), native_vlan_id=n.get_opt_value('native-vlan-id'), unit=junos_conf_root__configuration__groups__interfaces__interface__unit.from_gdata(n.get_opt_list('unit')), encapsulation=n.get_opt_str('encapsulation'), vlan_tagging=n.get_opt_bool('vlan-tagging'), stacked_vlan_tagging=n.get_opt_bool('stacked-vlan-tagging'), flexible_vlan_tagging=n.get_opt_bool('flexible-vlan-tagging'), vlan_vci_tagging=n.get_opt_bool('vlan-vci-tagging'), per_unit_scheduler=n.get_opt_bool('per-unit-scheduler'), no_per_unit_scheduler=n.get_opt_bool('no-per-unit-scheduler'), shared_scheduler=n.get_opt_bool('shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler.from_gdata(n.get_opt_container('hierarchical-scheduler')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces__interface({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _mtu = self.mtu
+        if _mtu is not None:
+            leaves.append(f'{self_name}.mtu = {repr(_mtu)}')
+        _mac = self.mac
+        if _mac is not None:
+            leaves.append(f'{self_name}.mac = {repr(_mac)}')
+        _native_vlan_id = self.native_vlan_id
+        if _native_vlan_id is not None:
+            leaves.append(f'{self_name}.native_vlan_id = {repr(_native_vlan_id)}')
+        _unit = self.unit
+        for _element in _unit.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/interfaces/interface/unit element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'unit_element = {self_name}.unit.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'unit_element', False, list_element=True).splitlines())
+        _encapsulation = self.encapsulation
+        if _encapsulation is not None:
+            leaves.append(f'{self_name}.encapsulation = {repr(_encapsulation)}')
+        _vlan_tagging = self.vlan_tagging
+        if _vlan_tagging is not None:
+            leaves.append(f'{self_name}.vlan_tagging = {repr(_vlan_tagging)}')
+        _stacked_vlan_tagging = self.stacked_vlan_tagging
+        if _stacked_vlan_tagging is not None:
+            leaves.append(f'{self_name}.stacked_vlan_tagging = {repr(_stacked_vlan_tagging)}')
+        _flexible_vlan_tagging = self.flexible_vlan_tagging
+        if _flexible_vlan_tagging is not None:
+            leaves.append(f'{self_name}.flexible_vlan_tagging = {repr(_flexible_vlan_tagging)}')
+        _vlan_vci_tagging = self.vlan_vci_tagging
+        if _vlan_vci_tagging is not None:
+            leaves.append(f'{self_name}.vlan_vci_tagging = {repr(_vlan_vci_tagging)}')
+        _per_unit_scheduler = self.per_unit_scheduler
+        if _per_unit_scheduler is not None:
+            leaves.append(f'{self_name}.per_unit_scheduler = {repr(_per_unit_scheduler)}')
+        _no_per_unit_scheduler = self.no_per_unit_scheduler
+        if _no_per_unit_scheduler is not None:
+            leaves.append(f'{self_name}.no_per_unit_scheduler = {repr(_no_per_unit_scheduler)}')
+        _shared_scheduler = self.shared_scheduler
+        if _shared_scheduler is not None:
+            leaves.append(f'{self_name}.shared_scheduler = {repr(_shared_scheduler)}')
+        _hierarchical_scheduler = self.hierarchical_scheduler
+        if _hierarchical_scheduler is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/interfaces/interface/hierarchical-scheduler')
+            res.append(f'hierarchical_scheduler = {self_name}.create_hierarchical_scheduler()')
+            res.extend(_hierarchical_scheduler.prsrc('hierarchical_scheduler', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__groups__interfaces__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -2515,6 +3412,26 @@ class junos_conf_root__configuration__groups__interfaces(yang.adata.MNode):
             return junos_conf_root__configuration__groups__interfaces(interface=junos_conf_root__configuration__groups__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__groups__interfaces()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/interfaces')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__interfaces()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/interfaces/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/interfaces'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__interfaces(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2586,6 +3503,31 @@ class junos_conf_root__configuration__groups__routing_instances__instance__inter
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__interface_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__interface_entry(name=n.get_str('name'), any=n.get_opt_bool('any'), unicast=n.get_opt_bool('unicast'), multicast=n.get_opt_bool('multicast'), primary=n.get_opt_bool('primary'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__interface({repr(self.name)})')
+        leaves = []
+        _any = self.any
+        if _any is not None:
+            leaves.append(f'{self_name}.any = {repr(_any)}')
+        _unicast = self.unicast
+        if _unicast is not None:
+            leaves.append(f'{self_name}.unicast = {repr(_unicast)}')
+        _multicast = self.multicast
+        if _multicast is not None:
+            leaves.append(f'{self_name}.multicast = {repr(_multicast)}')
+        _primary = self.primary
+        if _primary is not None:
+            leaves.append(f'{self_name}.primary = {repr(_primary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__interface_entry]
@@ -2667,6 +3609,22 @@ class junos_conf_root__configuration__groups__routing_instances__instance__route
             return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/route-distinguisher')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher()')
+        leaves = []
+        _rd_type = self.rd_type
+        if _rd_type is not None:
+            leaves.append(f'{self_name}.rd_type = {repr(_rd_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/route-distinguisher'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2727,6 +3685,31 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_bool('auto'))
         return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/vrf-target')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__vrf_target()')
+        leaves = []
+        _community = self.community
+        if _community is not None:
+            leaves.append(f'{self_name}.community = {repr(_community)}')
+        _import_ = self.import_
+        if _import_ is not None:
+            leaves.append(f'{self_name}.import_ = {repr(_import_)}')
+        _export = self.export
+        if _export is not None:
+            leaves.append(f'{self_name}.export = {repr(_export)}')
+        _auto = self.auto
+        if _auto is not None:
+            leaves.append(f'{self_name}.auto = {repr(_auto)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/vrf-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2773,6 +3756,25 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
         if n != None:
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_bool('source-class-usage'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/vrf-table-label')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label()')
+        leaves = []
+        _static = self.static
+        if _static is not None:
+            leaves.append(f'{self_name}.static = {repr(_static)}')
+        _source_class_usage = self.source_class_usage
+        if _source_class_usage is not None:
+            leaves.append(f'{self_name}.source_class_usage = {repr(_source_class_usage)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/vrf-table-label'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(node: xml.Node) -> yang.gdata.Container:
@@ -2844,6 +3846,25 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_bool('no-nexthop-change'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor/multihop')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop()')
+        leaves = []
+        _ttl = self.ttl
+        if _ttl is not None:
+            leaves.append(f'{self_name}.ttl = {repr(_ttl)}')
+        _no_nexthop_change = self.no_nexthop_change
+        if _no_nexthop_change is not None:
+            leaves.append(f'{self_name}.no_nexthop_change = {repr(_no_nexthop_change)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor/multihop'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2905,6 +3926,40 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), peer_as=n.get_opt_str('peer-as'), authentication_key=n.get_opt_str('authentication-key'), as_override=n.get_opt_bool('as-override'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), multihop=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_gdata(n.get_opt_container('multihop')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _peer_as = self.peer_as
+        if _peer_as is not None:
+            leaves.append(f'{self_name}.peer_as = {repr(_peer_as)}')
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        _as_override = self.as_override
+        if _as_override is not None:
+            leaves.append(f'{self_name}.as_override = {repr(_as_override)}')
+        _authentication_algorithm = self.authentication_algorithm
+        if _authentication_algorithm is not None:
+            leaves.append(f'{self_name}.authentication_algorithm = {repr(_authentication_algorithm)}')
+        _multihop = self.multihop
+        if _multihop is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor/multihop')
+            res.append(f'multihop = {self_name}.create_multihop()')
+            res.extend(_multihop.prsrc('multihop', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry]
@@ -3001,6 +4056,35 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry(name=n.get_str('name'), passive=n.get_opt_bool('passive'), import_=n.get_opt_strs('import'), export=n.get_opt_strs('export'), neighbor=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols/bgp/group')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group({repr(self.name)})')
+        leaves = []
+        _passive = self.passive
+        if _passive is not None:
+            leaves.append(f'{self_name}.passive = {repr(_passive)}')
+        _import_ = self.import_
+        if _import_ is not None:
+            leaves.append(f'{self_name}.import_ = {repr(_import_)}')
+        _export = self.export
+        if _export is not None:
+            leaves.append(f'{self_name}.export = {repr(_export)}')
+        _neighbor = self.neighbor
+        for _element in _neighbor.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/routing-instances/instance/protocols/bgp/group/neighbor element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'neighbor_element = {self_name}.neighbor.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols/bgp/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -3078,6 +4162,26 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols/bgp')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/routing-instances/instance/protocols/bgp/group element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3115,6 +4219,25 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
         if n != None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(control_word=n.get_opt_bool('control-word'), no_mac_learning=n.get_opt_bool('no-mac-learning'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols/evpn')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn()')
+        leaves = []
+        _control_word = self.control_word
+        if _control_word is not None:
+            leaves.append(f'{self_name}.control_word = {repr(_control_word)}')
+        _no_mac_learning = self.no_mac_learning
+        if _no_mac_learning is not None:
+            leaves.append(f'{self_name}.no_mac_learning = {repr(_no_mac_learning)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols/evpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(node: xml.Node) -> yang.gdata.Container:
@@ -3154,6 +4277,28 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
         if n != None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_container('bgp')), evpn=junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_container('evpn')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance/protocols')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance__protocols()')
+        leaves = []
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.extend(_bgp.prsrc(f'{self_name}.bgp', False).splitlines())
+        _evpn = self.evpn
+        if _evpn is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/routing-instances/instance/protocols/evpn')
+            res.append(f'evpn = {self_name}.create_evpn()')
+            res.extend(_evpn.prsrc('evpn', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance/protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols(node: xml.Node) -> yang.gdata.Container:
@@ -3237,6 +4382,59 @@ class junos_conf_root__configuration__groups__routing_instances__instance_entry(
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance_entry(name=n.get_str('name'), apply_groups=n.get_opt_strs('apply-groups'), apply_groups_except=n.get_opt_strs('apply-groups-except'), instance_type=n.get_opt_str('instance-type'), interface=junos_conf_root__configuration__groups__routing_instances__instance__interface.from_gdata(n.get_opt_list('interface')), route_distinguisher=junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher.from_gdata(n.get_opt_container('route-distinguisher')), export_default_action=n.get_opt_str('export-default-action'), import_default_action=n.get_opt_str('import-default-action'), vrf_target=junos_conf_root__configuration__groups__routing_instances__instance__vrf_target.from_gdata(n.get_opt_container('vrf-target')), no_vrf_advertise=n.get_opt_bool('no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label.from_gdata(n.get_opt_container('vrf-table-label')), protocols=junos_conf_root__configuration__groups__routing_instances__instance__protocols.from_gdata(n.get_opt_container('protocols')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances/instance')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances__instance({repr(self.name)})')
+        leaves = []
+        _apply_groups = self.apply_groups
+        if _apply_groups is not None:
+            leaves.append(f'{self_name}.apply_groups = {repr(_apply_groups)}')
+        _apply_groups_except = self.apply_groups_except
+        if _apply_groups_except is not None:
+            leaves.append(f'{self_name}.apply_groups_except = {repr(_apply_groups_except)}')
+        _instance_type = self.instance_type
+        if _instance_type is not None:
+            leaves.append(f'{self_name}.instance_type = {repr(_instance_type)}')
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/routing-instances/instance/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        _route_distinguisher = self.route_distinguisher
+        if _route_distinguisher is not None:
+            res.extend(_route_distinguisher.prsrc(f'{self_name}.route_distinguisher', False).splitlines())
+        _export_default_action = self.export_default_action
+        if _export_default_action is not None:
+            leaves.append(f'{self_name}.export_default_action = {repr(_export_default_action)}')
+        _import_default_action = self.import_default_action
+        if _import_default_action is not None:
+            leaves.append(f'{self_name}.import_default_action = {repr(_import_default_action)}')
+        _vrf_target = self.vrf_target
+        if _vrf_target is not None:
+            res.extend(_vrf_target.prsrc(f'{self_name}.vrf_target', False).splitlines())
+        _no_vrf_advertise = self.no_vrf_advertise
+        if _no_vrf_advertise is not None:
+            leaves.append(f'{self_name}.no_vrf_advertise = {repr(_no_vrf_advertise)}')
+        _vrf_table_label = self.vrf_table_label
+        if _vrf_table_label is not None:
+            res.append('')
+            res.append('# P-container: /configuration/groups/routing-instances/instance/vrf-table-label')
+            res.append(f'vrf_table_label = {self_name}.create_vrf_table_label()')
+            res.extend(_vrf_table_label.prsrc('vrf_table_label', False).splitlines())
+        _protocols = self.protocols
+        if _protocols is not None:
+            res.extend(_protocols.prsrc(f'{self_name}.protocols', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances/instance'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups__routing_instances__instance(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance_entry]
@@ -3329,6 +4527,26 @@ class junos_conf_root__configuration__groups__routing_instances(yang.adata.MNode
             return junos_conf_root__configuration__groups__routing_instances(instance=junos_conf_root__configuration__groups__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__groups__routing_instances()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups/routing-instances')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups__routing_instances()')
+        leaves = []
+        _instance = self.instance
+        for _element in _instance.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups/routing-instances/instance element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'instance_element = {self_name}.instance.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'instance_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups/routing-instances'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__groups__routing_instances(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3383,6 +4601,37 @@ class junos_conf_root__configuration__groups_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups_entry:
         return junos_conf_root__configuration__groups_entry(name=n.get_str('name'), when=junos_conf_root__configuration__groups__when.from_gdata(n.get_opt_container('when')), rcsid=n.get_opt_str('rcsid'), version=n.get_opt_str('version'), system=junos_conf_root__configuration__groups__system.from_gdata(n.get_opt_container('system')), interfaces=junos_conf_root__configuration__groups__interfaces.from_gdata(n.get_opt_container('interfaces')), routing_instances=junos_conf_root__configuration__groups__routing_instances.from_gdata(n.get_opt_container('routing-instances')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/groups')
+            res.append(f'{self_name} = junos_conf_root__configuration__groups({repr(self.name)})')
+        leaves = []
+        _when = self.when
+        if _when is not None:
+            res.extend(_when.prsrc(f'{self_name}.when', False).splitlines())
+        _rcsid = self.rcsid
+        if _rcsid is not None:
+            leaves.append(f'{self_name}.rcsid = {repr(_rcsid)}')
+        _version = self.version
+        if _version is not None:
+            leaves.append(f'{self_name}.version = {repr(_version)}')
+        _system = self.system
+        if _system is not None:
+            res.extend(_system.prsrc(f'{self_name}.system', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        _routing_instances = self.routing_instances
+        if _routing_instances is not None:
+            res.extend(_routing_instances.prsrc(f'{self_name}.routing_instances', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__groups(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups_entry]
@@ -3468,6 +4717,22 @@ class junos_conf_root__configuration__routing_options__autonomous_system(yang.ad
             return junos_conf_root__configuration__routing_options__autonomous_system(as_number=n.get_opt_str('as-number'))
         return junos_conf_root__configuration__routing_options__autonomous_system()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-options/autonomous-system')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_options__autonomous_system()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-options/autonomous-system'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__routing_options__autonomous_system(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3494,6 +4759,22 @@ class junos_conf_root__configuration__routing_options(yang.adata.MNode):
         if n != None:
             return junos_conf_root__configuration__routing_options(autonomous_system=junos_conf_root__configuration__routing_options__autonomous_system.from_gdata(n.get_opt_container('autonomous-system')))
         return junos_conf_root__configuration__routing_options()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/routing-options')
+            res.append(f'{self_name} = junos_conf_root__configuration__routing_options()')
+        leaves = []
+        _autonomous_system = self.autonomous_system
+        if _autonomous_system is not None:
+            res.extend(_autonomous_system.prsrc(f'{self_name}.autonomous_system', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/routing-options'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__routing_options(node: xml.Node) -> yang.gdata.Container:
@@ -3541,6 +4822,25 @@ class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_i
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=n.get_opt_value('med-multiplier'), igp_multiplier=n.get_opt_value('igp-multiplier'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/path-selection/med-plus-igp')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp()')
+        leaves = []
+        _med_multiplier = self.med_multiplier
+        if _med_multiplier is not None:
+            leaves.append(f'{self_name}.med_multiplier = {repr(_med_multiplier)}')
+        _igp_multiplier = self.igp_multiplier
+        if _igp_multiplier is not None:
+            leaves.append(f'{self_name}.igp_multiplier = {repr(_igp_multiplier)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/path-selection/med-plus-igp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(node: xml.Node) -> yang.gdata.Container:
@@ -3606,6 +4906,40 @@ class junos_conf_root__configuration__protocols__bgp__path_selection(yang.adata.
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__path_selection(l2vpn_use_bgp_rules=n.get_opt_bool('l2vpn-use-bgp-rules'), cisco_non_deterministic=n.get_opt_bool('cisco-non-deterministic'), always_compare_med=n.get_opt_bool('always-compare-med'), med_plus_igp=junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp.from_gdata(n.get_opt_container('med-plus-igp')), external_router_id=n.get_opt_bool('external-router-id'), as_path_ignore=n.get_opt_bool('as-path-ignore'))
         return junos_conf_root__configuration__protocols__bgp__path_selection()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/path-selection')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__path_selection()')
+        leaves = []
+        _l2vpn_use_bgp_rules = self.l2vpn_use_bgp_rules
+        if _l2vpn_use_bgp_rules is not None:
+            leaves.append(f'{self_name}.l2vpn_use_bgp_rules = {repr(_l2vpn_use_bgp_rules)}')
+        _cisco_non_deterministic = self.cisco_non_deterministic
+        if _cisco_non_deterministic is not None:
+            leaves.append(f'{self_name}.cisco_non_deterministic = {repr(_cisco_non_deterministic)}')
+        _always_compare_med = self.always_compare_med
+        if _always_compare_med is not None:
+            leaves.append(f'{self_name}.always_compare_med = {repr(_always_compare_med)}')
+        _med_plus_igp = self.med_plus_igp
+        if _med_plus_igp is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/path-selection/med-plus-igp')
+            res.append(f'med_plus_igp = {self_name}.create_med_plus_igp()')
+            res.extend(_med_plus_igp.prsrc('med_plus_igp', False).splitlines())
+        _external_router_id = self.external_router_id
+        if _external_router_id is not None:
+            leaves.append(f'{self_name}.external_router_id = {repr(_external_router_id)}')
+        _as_path_ignore = self.as_path_ignore
+        if _as_path_ignore is not None:
+            leaves.append(f'{self_name}.as_path_ignore = {repr(_as_path_ignore)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/path-selection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection(node: xml.Node) -> yang.gdata.Container:
@@ -3676,6 +5010,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown/idle-timeout')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout()')
+        leaves = []
+        _forever = self.forever
+        if _forever is not None:
+            leaves.append(f'{self_name}.forever = {repr(_forever)}')
+        _timeout = self.timeout
+        if _timeout is not None:
+            leaves.append(f'{self_name}.timeout = {repr(_timeout)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown/idle-timeout'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3715,6 +5068,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        _idle_timeout = self.idle_timeout
+        if _idle_timeout is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown/idle-timeout')
+            res.append(f'idle_timeout = {self_name}.create_idle_timeout()')
+            res.extend(_idle_timeout.prsrc('idle_timeout', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3747,6 +5122,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/drop-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/drop-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3776,6 +5167,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/hide-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/hide-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
@@ -3834,6 +5241,40 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()')
+        leaves = []
+        _maximum = self.maximum
+        if _maximum is not None:
+            leaves.append(f'{self_name}.maximum = {repr(_maximum)}')
+        _teardown = self.teardown
+        if _teardown is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/teardown')
+            res.append(f'teardown = {self_name}.create_teardown()')
+            res.extend(_teardown.prsrc('teardown', False).splitlines())
+        _drop_excess = self.drop_excess
+        if _drop_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/drop-excess')
+            res.append(f'drop_excess = {self_name}.create_drop_excess()')
+            res.extend(_drop_excess.prsrc('drop_excess', False).splitlines())
+        _hide_excess = self.hide_excess
+        if _hide_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit/hide-excess')
+            res.append(f'hide_excess = {self_name}.create_hide_excess()')
+            res.extend(_hide_excess.prsrc('hide_excess', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/prefix-limit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3884,6 +5325,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout()')
+        leaves = []
+        _forever = self.forever
+        if _forever is not None:
+            leaves.append(f'{self_name}.forever = {repr(_forever)}')
+        _timeout = self.timeout
+        if _timeout is not None:
+            leaves.append(f'{self_name}.timeout = {repr(_timeout)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3923,6 +5383,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        _idle_timeout = self.idle_timeout
+        if _idle_timeout is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout')
+            res.append(f'idle_timeout = {self_name}.create_idle_timeout()')
+            res.extend(_idle_timeout.prsrc('idle_timeout', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3955,6 +5437,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/drop-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/drop-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3984,6 +5482,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/hide-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/hide-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
@@ -4042,6 +5556,40 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()')
+        leaves = []
+        _maximum = self.maximum
+        if _maximum is not None:
+            leaves.append(f'{self_name}.maximum = {repr(_maximum)}')
+        _teardown = self.teardown
+        if _teardown is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/teardown')
+            res.append(f'teardown = {self_name}.create_teardown()')
+            res.extend(_teardown.prsrc('teardown', False).splitlines())
+        _drop_excess = self.drop_excess
+        if _drop_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/drop-excess')
+            res.append(f'drop_excess = {self_name}.create_drop_excess()')
+            res.extend(_drop_excess.prsrc('drop_excess', False).splitlines())
+        _hide_excess = self.hide_excess
+        if _hide_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit/hide-excess')
+            res.append(f'hide_excess = {self_name}.create_hide_excess()')
+            res.extend(_hide_excess.prsrc('hide_excess', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/accepted-prefix-limit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4077,6 +5625,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/rib-group')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group()')
+        leaves = []
+        _ribgroup_name = self.ribgroup_name
+        if _ribgroup_name is not None:
+            leaves.append(f'{self_name}.ribgroup_name = {repr(_ribgroup_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/rib-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(node: xml.Node) -> yang.gdata.Container:
@@ -4118,6 +5682,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_bool('all-paths'), equal_cost_paths=n.get_opt_bool('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path/send/path-selection-mode')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode()')
+        leaves = []
+        _all_paths = self.all_paths
+        if _all_paths is not None:
+            leaves.append(f'{self_name}.all_paths = {repr(_all_paths)}')
+        _equal_cost_paths = self.equal_cost_paths
+        if _equal_cost_paths is not None:
+            leaves.append(f'{self_name}.equal_cost_paths = {repr(_equal_cost_paths)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path/send/path-selection-mode'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(node: xml.Node) -> yang.gdata.Container:
@@ -4178,6 +5761,34 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_bool('multipath'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path/send')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send()')
+        leaves = []
+        _path_selection_mode = self.path_selection_mode
+        if _path_selection_mode is not None:
+            res.extend(_path_selection_mode.prsrc(f'{self_name}.path_selection_mode', False).splitlines())
+        _prefix_policy = self.prefix_policy
+        if _prefix_policy is not None:
+            leaves.append(f'{self_name}.prefix_policy = {repr(_prefix_policy)}')
+        _path_count = self.path_count
+        if _path_count is not None:
+            leaves.append(f'{self_name}.path_count = {repr(_path_count)}')
+        _include_backup_path = self.include_backup_path
+        if _include_backup_path is not None:
+            leaves.append(f'{self_name}.include_backup_path = {repr(_include_backup_path)}')
+        _multipath = self.multipath
+        if _multipath is not None:
+            leaves.append(f'{self_name}.multipath = {repr(_multipath)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path/send'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4223,6 +5834,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(receive=n.get_opt_bool('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send.from_gdata(n.get_opt_container('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path()')
+        leaves = []
+        _receive = self.receive
+        if _receive is not None:
+            leaves.append(f'{self_name}.receive = {repr(_receive)}')
+        _send = self.send
+        if _send is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path/send')
+            res.append(f'send = {self_name}.create_send()')
+            res.extend(_send.prsrc('send', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/add-path'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4254,6 +5887,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(disable=n.get_opt_bool('disable'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aigp')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aigp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(node: xml.Node) -> yang.gdata.Container:
@@ -4290,6 +5939,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/loops')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()')
+        leaves = []
+        _loops = self.loops
+        if _loops is not None:
+            leaves.append(f'{self_name}.loops = {repr(_loops)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/loops'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(node: xml.Node) -> yang.gdata.Container:
@@ -4332,6 +5997,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements/minimum-delay')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()')
+        leaves = []
+        _routing_uptime = self.routing_uptime
+        if _routing_uptime is not None:
+            leaves.append(f'{self_name}.routing_uptime = {repr(_routing_uptime)}')
+        _inbound_convergence = self.inbound_convergence
+        if _inbound_convergence is not None:
+            leaves.append(f'{self_name}.inbound_convergence = {repr(_inbound_convergence)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements/minimum-delay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4372,6 +6056,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements/maximum-delay')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()')
+        leaves = []
+        _route_age = self.route_age
+        if _route_age is not None:
+            leaves.append(f'{self_name}.route_age = {repr(_route_age)}')
+        _routing_uptime = self.routing_uptime
+        if _routing_uptime is not None:
+            leaves.append(f'{self_name}.routing_uptime = {repr(_routing_uptime)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements/maximum-delay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4410,6 +6113,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_bool('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_container('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_container('maximum-delay')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements()')
+        leaves = []
+        _always_wait_for_krt_drain = self.always_wait_for_krt_drain
+        if _always_wait_for_krt_drain is not None:
+            leaves.append(f'{self_name}.always_wait_for_krt_drain = {repr(_always_wait_for_krt_drain)}')
+        _minimum_delay = self.minimum_delay
+        if _minimum_delay is not None:
+            res.extend(_minimum_delay.prsrc(f'{self_name}.minimum_delay', False).splitlines())
+        _maximum_delay = self.maximum_delay
+        if _maximum_delay is not None:
+            res.extend(_maximum_delay.prsrc(f'{self_name}.maximum_delay', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(node: xml.Node) -> yang.gdata.Container:
@@ -4453,6 +6178,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_bool('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_bool('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/nexthop-resolution')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution()')
+        leaves = []
+        _no_resolution = self.no_resolution
+        if _no_resolution is not None:
+            leaves.append(f'{self_name}.no_resolution = {repr(_no_resolution)}')
+        _preserve_nexthop_hierarchy = self.preserve_nexthop_hierarchy
+        if _preserve_nexthop_hierarchy is not None:
+            leaves.append(f'{self_name}.preserve_nexthop_hierarchy = {repr(_preserve_nexthop_hierarchy)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/nexthop-resolution'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4484,6 +6228,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/defer-initial-multipath-build')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build()')
+        leaves = []
+        _maximum_delay = self.maximum_delay
+        if _maximum_delay is not None:
+            leaves.append(f'{self_name}.maximum_delay = {repr(_maximum_delay)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/defer-initial-multipath-build'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(node: xml.Node) -> yang.gdata.Container:
@@ -4522,6 +6282,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_bool('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/restarter')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _stale_time = self.stale_time
+        if _stale_time is not None:
+            leaves.append(f'{self_name}.stale_time = {repr(_stale_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/restarter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(node: xml.Node) -> yang.gdata.Container:
@@ -4569,6 +6348,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_bool('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/extended-route-retention')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _retention_time = self.retention_time
+        if _retention_time is not None:
+            leaves.append(f'{self_name}.retention_time = {repr(_retention_time)}')
+        _retention_policy = self.retention_policy
+        if _retention_policy is not None:
+            leaves.append(f'{self_name}.retention_policy = {repr(_retention_policy)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/extended-route-retention'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4604,6 +6405,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_container('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_container('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived()')
+        leaves = []
+        _restarter = self.restarter
+        if _restarter is not None:
+            res.extend(_restarter.prsrc(f'{self_name}.restarter', False).splitlines())
+        _extended_route_retention = self.extended_route_retention
+        if _extended_route_retention is not None:
+            res.extend(_extended_route_retention.prsrc(f'{self_name}.extended_route_retention', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(node: xml.Node) -> yang.gdata.Container:
@@ -4641,6 +6461,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_container('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart()')
+        leaves = []
+        _long_lived = self.long_lived
+        if _long_lived is not None:
+            res.extend(_long_lived.prsrc(f'{self_name}.long_lived', False).splitlines())
+        _forwarding_state_bit = self.forwarding_state_bit
+        if _forwarding_state_bit is not None:
+            leaves.append(f'{self_name}.forwarding_state_bit = {repr(_forwarding_state_bit)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(node: xml.Node) -> yang.gdata.Container:
@@ -4697,6 +6536,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/output-queue-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/output-queue-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4736,6 +6594,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/route-refresh-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/route-refresh-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(node: xml.Node) -> yang.gdata.Container:
@@ -4777,6 +6654,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/withdraw-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/withdraw-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4815,6 +6711,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aggregate-label')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label()')
+        leaves = []
+        _community = self.community
+        if _community is not None:
+            leaves.append(f'{self_name}.community = {repr(_community)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aggregate-label'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4844,6 +6756,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/egress-protection/context-identifier')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier()')
+        leaves = []
+        _context_id = self.context_id
+        if _context_id is not None:
+            leaves.append(f'{self_name}.context_id = {repr(_context_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/egress-protection/context-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(node: xml.Node) -> yang.gdata.Container:
@@ -4877,6 +6805,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_container('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast/egress-protection')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection()')
+        leaves = []
+        _context_identifier = self.context_identifier
+        if _context_identifier is not None:
+            res.extend(_context_identifier.prsrc(f'{self_name}.context_identifier', False).splitlines())
+        _keep_import = self.keep_import
+        if _keep_import is not None:
+            leaves.append(f'{self_name}.keep_import = {repr(_keep_import)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/egress-protection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(node: xml.Node) -> yang.gdata.Container:
@@ -5063,6 +7010,112 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit.from_gdata(n.get_opt_container('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_container('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group.from_gdata(n.get_opt_container('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path.from_gdata(n.get_opt_container('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp.from_gdata(n.get_opt_container('aigp')), damping=n.get_opt_bool('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops.from_gdata(n.get_opt_container('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_container('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_container('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_container('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart.from_gdata(n.get_opt_container('graceful-restart')), extended_nexthop=n.get_opt_bool('extended-nexthop'), extended_nexthop_color=n.get_opt_bool('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_bool('extended-nexthop-tunnel'), no_install=n.get_opt_bool('no-install'), route_age_bgp_view=n.get_opt_bool('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_container('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_container('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_container('withdraw-priority')), advertise_srv6_service=n.get_opt_bool('advertise-srv6-service'), accept_srv6_service=n.get_opt_bool('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label.from_gdata(n.get_opt_container('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection.from_gdata(n.get_opt_container('egress-protection')), accept_local_nexthop=n.get_opt_bool('accept-local-nexthop'), accept_own=n.get_opt_bool('accept-own'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn/unicast')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast()')
+        leaves = []
+        _prefix_limit = self.prefix_limit
+        if _prefix_limit is not None:
+            res.extend(_prefix_limit.prsrc(f'{self_name}.prefix_limit', False).splitlines())
+        _accepted_prefix_limit = self.accepted_prefix_limit
+        if _accepted_prefix_limit is not None:
+            res.extend(_accepted_prefix_limit.prsrc(f'{self_name}.accepted_prefix_limit', False).splitlines())
+        _rib_group = self.rib_group
+        if _rib_group is not None:
+            res.extend(_rib_group.prsrc(f'{self_name}.rib_group', False).splitlines())
+        _add_path = self.add_path
+        if _add_path is not None:
+            res.extend(_add_path.prsrc(f'{self_name}.add_path', False).splitlines())
+        _aigp = self.aigp
+        if _aigp is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aigp')
+            res.append(f'aigp = {self_name}.create_aigp()')
+            res.extend(_aigp.prsrc('aigp', False).splitlines())
+        _damping = self.damping
+        if _damping is not None:
+            leaves.append(f'{self_name}.damping = {repr(_damping)}')
+        _local_ipv4_address = self.local_ipv4_address
+        if _local_ipv4_address is not None:
+            leaves.append(f'{self_name}.local_ipv4_address = {repr(_local_ipv4_address)}')
+        _loops = self.loops
+        if _loops is not None:
+            res.extend(_loops.prsrc(f'{self_name}.loops', False).splitlines())
+        _delay_route_advertisements = self.delay_route_advertisements
+        if _delay_route_advertisements is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/delay-route-advertisements')
+            res.append(f'delay_route_advertisements = {self_name}.create_delay_route_advertisements()')
+            res.extend(_delay_route_advertisements.prsrc('delay_route_advertisements', False).splitlines())
+        _nexthop_resolution = self.nexthop_resolution
+        if _nexthop_resolution is not None:
+            res.extend(_nexthop_resolution.prsrc(f'{self_name}.nexthop_resolution', False).splitlines())
+        _defer_initial_multipath_build = self.defer_initial_multipath_build
+        if _defer_initial_multipath_build is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/defer-initial-multipath-build')
+            res.append(f'defer_initial_multipath_build = {self_name}.create_defer_initial_multipath_build()')
+            res.extend(_defer_initial_multipath_build.prsrc('defer_initial_multipath_build', False).splitlines())
+        _graceful_restart = self.graceful_restart
+        if _graceful_restart is not None:
+            res.extend(_graceful_restart.prsrc(f'{self_name}.graceful_restart', False).splitlines())
+        _extended_nexthop = self.extended_nexthop
+        if _extended_nexthop is not None:
+            leaves.append(f'{self_name}.extended_nexthop = {repr(_extended_nexthop)}')
+        _extended_nexthop_color = self.extended_nexthop_color
+        if _extended_nexthop_color is not None:
+            leaves.append(f'{self_name}.extended_nexthop_color = {repr(_extended_nexthop_color)}')
+        _extended_nexthop_tunnel = self.extended_nexthop_tunnel
+        if _extended_nexthop_tunnel is not None:
+            leaves.append(f'{self_name}.extended_nexthop_tunnel = {repr(_extended_nexthop_tunnel)}')
+        _no_install = self.no_install
+        if _no_install is not None:
+            leaves.append(f'{self_name}.no_install = {repr(_no_install)}')
+        _route_age_bgp_view = self.route_age_bgp_view
+        if _route_age_bgp_view is not None:
+            leaves.append(f'{self_name}.route_age_bgp_view = {repr(_route_age_bgp_view)}')
+        _output_queue_priority = self.output_queue_priority
+        if _output_queue_priority is not None:
+            res.extend(_output_queue_priority.prsrc(f'{self_name}.output_queue_priority', False).splitlines())
+        _route_refresh_priority = self.route_refresh_priority
+        if _route_refresh_priority is not None:
+            res.extend(_route_refresh_priority.prsrc(f'{self_name}.route_refresh_priority', False).splitlines())
+        _withdraw_priority = self.withdraw_priority
+        if _withdraw_priority is not None:
+            res.extend(_withdraw_priority.prsrc(f'{self_name}.withdraw_priority', False).splitlines())
+        _advertise_srv6_service = self.advertise_srv6_service
+        if _advertise_srv6_service is not None:
+            leaves.append(f'{self_name}.advertise_srv6_service = {repr(_advertise_srv6_service)}')
+        _accept_srv6_service = self.accept_srv6_service
+        if _accept_srv6_service is not None:
+            leaves.append(f'{self_name}.accept_srv6_service = {repr(_accept_srv6_service)}')
+        _aggregate_label = self.aggregate_label
+        if _aggregate_label is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/aggregate-label')
+            res.append(f'aggregate_label = {self_name}.create_aggregate_label()')
+            res.extend(_aggregate_label.prsrc('aggregate_label', False).splitlines())
+        _egress_protection = self.egress_protection
+        if _egress_protection is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/egress-protection')
+            res.append(f'egress_protection = {self_name}.create_egress_protection()')
+            res.extend(_egress_protection.prsrc('egress_protection', False).splitlines())
+        _accept_local_nexthop = self.accept_local_nexthop
+        if _accept_local_nexthop is not None:
+            leaves.append(f'{self_name}.accept_local_nexthop = {repr(_accept_local_nexthop)}')
+        _accept_own = self.accept_own
+        if _accept_own is not None:
+            leaves.append(f'{self_name}.accept_own = {repr(_accept_own)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5145,6 +7198,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast.from_gdata(n.get_opt_container('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet-vpn')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet-vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5189,6 +7261,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown/idle-timeout')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout()')
+        leaves = []
+        _forever = self.forever
+        if _forever is not None:
+            leaves.append(f'{self_name}.forever = {repr(_forever)}')
+        _timeout = self.timeout
+        if _timeout is not None:
+            leaves.append(f'{self_name}.timeout = {repr(_timeout)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown/idle-timeout'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5228,6 +7319,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        _idle_timeout = self.idle_timeout
+        if _idle_timeout is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown/idle-timeout')
+            res.append(f'idle_timeout = {self_name}.create_idle_timeout()')
+            res.extend(_idle_timeout.prsrc('idle_timeout', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5260,6 +7373,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/drop-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/drop-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5289,6 +7418,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/hide-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/hide-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
@@ -5347,6 +7492,40 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()')
+        leaves = []
+        _maximum = self.maximum
+        if _maximum is not None:
+            leaves.append(f'{self_name}.maximum = {repr(_maximum)}')
+        _teardown = self.teardown
+        if _teardown is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/teardown')
+            res.append(f'teardown = {self_name}.create_teardown()')
+            res.extend(_teardown.prsrc('teardown', False).splitlines())
+        _drop_excess = self.drop_excess
+        if _drop_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/drop-excess')
+            res.append(f'drop_excess = {self_name}.create_drop_excess()')
+            res.extend(_drop_excess.prsrc('drop_excess', False).splitlines())
+        _hide_excess = self.hide_excess
+        if _hide_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit/hide-excess')
+            res.append(f'hide_excess = {self_name}.create_hide_excess()')
+            res.extend(_hide_excess.prsrc('hide_excess', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/prefix-limit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5397,6 +7576,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout()')
+        leaves = []
+        _forever = self.forever
+        if _forever is not None:
+            leaves.append(f'{self_name}.forever = {repr(_forever)}')
+        _timeout = self.timeout
+        if _timeout is not None:
+            leaves.append(f'{self_name}.timeout = {repr(_timeout)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5436,6 +7634,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        _idle_timeout = self.idle_timeout
+        if _idle_timeout is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown/idle-timeout')
+            res.append(f'idle_timeout = {self_name}.create_idle_timeout()')
+            res.extend(_idle_timeout.prsrc('idle_timeout', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5468,6 +7688,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/drop-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/drop-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5497,6 +7733,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/hide-excess')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess()')
+        leaves = []
+        _limit_threshold = self.limit_threshold
+        if _limit_threshold is not None:
+            leaves.append(f'{self_name}.limit_threshold = {repr(_limit_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/hide-excess'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
@@ -5555,6 +7807,40 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()')
+        leaves = []
+        _maximum = self.maximum
+        if _maximum is not None:
+            leaves.append(f'{self_name}.maximum = {repr(_maximum)}')
+        _teardown = self.teardown
+        if _teardown is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/teardown')
+            res.append(f'teardown = {self_name}.create_teardown()')
+            res.extend(_teardown.prsrc('teardown', False).splitlines())
+        _drop_excess = self.drop_excess
+        if _drop_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/drop-excess')
+            res.append(f'drop_excess = {self_name}.create_drop_excess()')
+            res.extend(_drop_excess.prsrc('drop_excess', False).splitlines())
+        _hide_excess = self.hide_excess
+        if _hide_excess is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit/hide-excess')
+            res.append(f'hide_excess = {self_name}.create_hide_excess()')
+            res.extend(_hide_excess.prsrc('hide_excess', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/accepted-prefix-limit'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5590,6 +7876,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/rib-group')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group()')
+        leaves = []
+        _ribgroup_name = self.ribgroup_name
+        if _ribgroup_name is not None:
+            leaves.append(f'{self_name}.ribgroup_name = {repr(_ribgroup_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/rib-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(node: xml.Node) -> yang.gdata.Container:
@@ -5631,6 +7933,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_bool('all-paths'), equal_cost_paths=n.get_opt_bool('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path/send/path-selection-mode')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode()')
+        leaves = []
+        _all_paths = self.all_paths
+        if _all_paths is not None:
+            leaves.append(f'{self_name}.all_paths = {repr(_all_paths)}')
+        _equal_cost_paths = self.equal_cost_paths
+        if _equal_cost_paths is not None:
+            leaves.append(f'{self_name}.equal_cost_paths = {repr(_equal_cost_paths)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path/send/path-selection-mode'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(node: xml.Node) -> yang.gdata.Container:
@@ -5691,6 +8012,34 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_bool('multipath'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path/send')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send()')
+        leaves = []
+        _path_selection_mode = self.path_selection_mode
+        if _path_selection_mode is not None:
+            res.extend(_path_selection_mode.prsrc(f'{self_name}.path_selection_mode', False).splitlines())
+        _prefix_policy = self.prefix_policy
+        if _prefix_policy is not None:
+            leaves.append(f'{self_name}.prefix_policy = {repr(_prefix_policy)}')
+        _path_count = self.path_count
+        if _path_count is not None:
+            leaves.append(f'{self_name}.path_count = {repr(_path_count)}')
+        _include_backup_path = self.include_backup_path
+        if _include_backup_path is not None:
+            leaves.append(f'{self_name}.include_backup_path = {repr(_include_backup_path)}')
+        _multipath = self.multipath
+        if _multipath is not None:
+            leaves.append(f'{self_name}.multipath = {repr(_multipath)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path/send'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5736,6 +8085,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(receive=n.get_opt_bool('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send.from_gdata(n.get_opt_container('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path()')
+        leaves = []
+        _receive = self.receive
+        if _receive is not None:
+            leaves.append(f'{self_name}.receive = {repr(_receive)}')
+        _send = self.send
+        if _send is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path/send')
+            res.append(f'send = {self_name}.create_send()')
+            res.extend(_send.prsrc('send', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/add-path'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5767,6 +8138,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(disable=n.get_opt_bool('disable'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aigp')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aigp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(node: xml.Node) -> yang.gdata.Container:
@@ -5803,6 +8190,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/loops')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()')
+        leaves = []
+        _loops = self.loops
+        if _loops is not None:
+            leaves.append(f'{self_name}.loops = {repr(_loops)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/loops'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(node: xml.Node) -> yang.gdata.Container:
@@ -5845,6 +8248,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements/minimum-delay')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()')
+        leaves = []
+        _routing_uptime = self.routing_uptime
+        if _routing_uptime is not None:
+            leaves.append(f'{self_name}.routing_uptime = {repr(_routing_uptime)}')
+        _inbound_convergence = self.inbound_convergence
+        if _inbound_convergence is not None:
+            leaves.append(f'{self_name}.inbound_convergence = {repr(_inbound_convergence)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements/minimum-delay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5885,6 +8307,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements/maximum-delay')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()')
+        leaves = []
+        _route_age = self.route_age
+        if _route_age is not None:
+            leaves.append(f'{self_name}.route_age = {repr(_route_age)}')
+        _routing_uptime = self.routing_uptime
+        if _routing_uptime is not None:
+            leaves.append(f'{self_name}.routing_uptime = {repr(_routing_uptime)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements/maximum-delay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5923,6 +8364,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_bool('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_container('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_container('maximum-delay')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements()')
+        leaves = []
+        _always_wait_for_krt_drain = self.always_wait_for_krt_drain
+        if _always_wait_for_krt_drain is not None:
+            leaves.append(f'{self_name}.always_wait_for_krt_drain = {repr(_always_wait_for_krt_drain)}')
+        _minimum_delay = self.minimum_delay
+        if _minimum_delay is not None:
+            res.extend(_minimum_delay.prsrc(f'{self_name}.minimum_delay', False).splitlines())
+        _maximum_delay = self.maximum_delay
+        if _maximum_delay is not None:
+            res.extend(_maximum_delay.prsrc(f'{self_name}.maximum_delay', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(node: xml.Node) -> yang.gdata.Container:
@@ -5966,6 +8429,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_bool('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_bool('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/nexthop-resolution')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution()')
+        leaves = []
+        _no_resolution = self.no_resolution
+        if _no_resolution is not None:
+            leaves.append(f'{self_name}.no_resolution = {repr(_no_resolution)}')
+        _preserve_nexthop_hierarchy = self.preserve_nexthop_hierarchy
+        if _preserve_nexthop_hierarchy is not None:
+            leaves.append(f'{self_name}.preserve_nexthop_hierarchy = {repr(_preserve_nexthop_hierarchy)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/nexthop-resolution'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5997,6 +8479,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/defer-initial-multipath-build')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build()')
+        leaves = []
+        _maximum_delay = self.maximum_delay
+        if _maximum_delay is not None:
+            leaves.append(f'{self_name}.maximum_delay = {repr(_maximum_delay)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/defer-initial-multipath-build'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(node: xml.Node) -> yang.gdata.Container:
@@ -6035,6 +8533,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_bool('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/restarter')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _stale_time = self.stale_time
+        if _stale_time is not None:
+            leaves.append(f'{self_name}.stale_time = {repr(_stale_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/restarter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(node: xml.Node) -> yang.gdata.Container:
@@ -6082,6 +8599,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_bool('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/extended-route-retention')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _retention_time = self.retention_time
+        if _retention_time is not None:
+            leaves.append(f'{self_name}.retention_time = {repr(_retention_time)}')
+        _retention_policy = self.retention_policy
+        if _retention_policy is not None:
+            leaves.append(f'{self_name}.retention_policy = {repr(_retention_policy)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/extended-route-retention'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6117,6 +8656,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_container('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_container('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived()')
+        leaves = []
+        _restarter = self.restarter
+        if _restarter is not None:
+            res.extend(_restarter.prsrc(f'{self_name}.restarter', False).splitlines())
+        _extended_route_retention = self.extended_route_retention
+        if _extended_route_retention is not None:
+            res.extend(_extended_route_retention.prsrc(f'{self_name}.extended_route_retention', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(node: xml.Node) -> yang.gdata.Container:
@@ -6154,6 +8712,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_container('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart()')
+        leaves = []
+        _long_lived = self.long_lived
+        if _long_lived is not None:
+            res.extend(_long_lived.prsrc(f'{self_name}.long_lived', False).splitlines())
+        _forwarding_state_bit = self.forwarding_state_bit
+        if _forwarding_state_bit is not None:
+            leaves.append(f'{self_name}.forwarding_state_bit = {repr(_forwarding_state_bit)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(node: xml.Node) -> yang.gdata.Container:
@@ -6210,6 +8787,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/output-queue-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/output-queue-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6249,6 +8845,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/route-refresh-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/route-refresh-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(node: xml.Node) -> yang.gdata.Container:
@@ -6290,6 +8905,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/withdraw-priority')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()')
+        leaves = []
+        _priority = self.priority
+        if _priority is not None:
+            leaves.append(f'{self_name}.priority = {repr(_priority)}')
+        _expedited = self.expedited
+        if _expedited is not None:
+            leaves.append(f'{self_name}.expedited = {repr(_expedited)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/withdraw-priority'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6328,6 +8962,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aggregate-label')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label()')
+        leaves = []
+        _community = self.community
+        if _community is not None:
+            leaves.append(f'{self_name}.community = {repr(_community)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aggregate-label'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6357,6 +9007,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/egress-protection/context-identifier')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier()')
+        leaves = []
+        _context_id = self.context_id
+        if _context_id is not None:
+            leaves.append(f'{self_name}.context_id = {repr(_context_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/egress-protection/context-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(node: xml.Node) -> yang.gdata.Container:
@@ -6390,6 +9056,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_container('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/egress-protection')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection()')
+        leaves = []
+        _context_identifier = self.context_identifier
+        if _context_identifier is not None:
+            res.extend(_context_identifier.prsrc(f'{self_name}.context_identifier', False).splitlines())
+        _keep_import = self.keep_import
+        if _keep_import is not None:
+            leaves.append(f'{self_name}.keep_import = {repr(_keep_import)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/egress-protection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(node: xml.Node) -> yang.gdata.Container:
@@ -6576,6 +9261,112 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit.from_gdata(n.get_opt_container('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_container('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group.from_gdata(n.get_opt_container('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path.from_gdata(n.get_opt_container('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp.from_gdata(n.get_opt_container('aigp')), damping=n.get_opt_bool('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops.from_gdata(n.get_opt_container('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_container('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_container('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_container('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart.from_gdata(n.get_opt_container('graceful-restart')), extended_nexthop=n.get_opt_bool('extended-nexthop'), extended_nexthop_color=n.get_opt_bool('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_bool('extended-nexthop-tunnel'), no_install=n.get_opt_bool('no-install'), route_age_bgp_view=n.get_opt_bool('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_container('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_container('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_container('withdraw-priority')), advertise_srv6_service=n.get_opt_bool('advertise-srv6-service'), accept_srv6_service=n.get_opt_bool('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label.from_gdata(n.get_opt_container('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection.from_gdata(n.get_opt_container('egress-protection')), accept_local_nexthop=n.get_opt_bool('accept-local-nexthop'), accept_own=n.get_opt_bool('accept-own'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn/unicast')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast()')
+        leaves = []
+        _prefix_limit = self.prefix_limit
+        if _prefix_limit is not None:
+            res.extend(_prefix_limit.prsrc(f'{self_name}.prefix_limit', False).splitlines())
+        _accepted_prefix_limit = self.accepted_prefix_limit
+        if _accepted_prefix_limit is not None:
+            res.extend(_accepted_prefix_limit.prsrc(f'{self_name}.accepted_prefix_limit', False).splitlines())
+        _rib_group = self.rib_group
+        if _rib_group is not None:
+            res.extend(_rib_group.prsrc(f'{self_name}.rib_group', False).splitlines())
+        _add_path = self.add_path
+        if _add_path is not None:
+            res.extend(_add_path.prsrc(f'{self_name}.add_path', False).splitlines())
+        _aigp = self.aigp
+        if _aigp is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aigp')
+            res.append(f'aigp = {self_name}.create_aigp()')
+            res.extend(_aigp.prsrc('aigp', False).splitlines())
+        _damping = self.damping
+        if _damping is not None:
+            leaves.append(f'{self_name}.damping = {repr(_damping)}')
+        _local_ipv4_address = self.local_ipv4_address
+        if _local_ipv4_address is not None:
+            leaves.append(f'{self_name}.local_ipv4_address = {repr(_local_ipv4_address)}')
+        _loops = self.loops
+        if _loops is not None:
+            res.extend(_loops.prsrc(f'{self_name}.loops', False).splitlines())
+        _delay_route_advertisements = self.delay_route_advertisements
+        if _delay_route_advertisements is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/delay-route-advertisements')
+            res.append(f'delay_route_advertisements = {self_name}.create_delay_route_advertisements()')
+            res.extend(_delay_route_advertisements.prsrc('delay_route_advertisements', False).splitlines())
+        _nexthop_resolution = self.nexthop_resolution
+        if _nexthop_resolution is not None:
+            res.extend(_nexthop_resolution.prsrc(f'{self_name}.nexthop_resolution', False).splitlines())
+        _defer_initial_multipath_build = self.defer_initial_multipath_build
+        if _defer_initial_multipath_build is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/defer-initial-multipath-build')
+            res.append(f'defer_initial_multipath_build = {self_name}.create_defer_initial_multipath_build()')
+            res.extend(_defer_initial_multipath_build.prsrc('defer_initial_multipath_build', False).splitlines())
+        _graceful_restart = self.graceful_restart
+        if _graceful_restart is not None:
+            res.extend(_graceful_restart.prsrc(f'{self_name}.graceful_restart', False).splitlines())
+        _extended_nexthop = self.extended_nexthop
+        if _extended_nexthop is not None:
+            leaves.append(f'{self_name}.extended_nexthop = {repr(_extended_nexthop)}')
+        _extended_nexthop_color = self.extended_nexthop_color
+        if _extended_nexthop_color is not None:
+            leaves.append(f'{self_name}.extended_nexthop_color = {repr(_extended_nexthop_color)}')
+        _extended_nexthop_tunnel = self.extended_nexthop_tunnel
+        if _extended_nexthop_tunnel is not None:
+            leaves.append(f'{self_name}.extended_nexthop_tunnel = {repr(_extended_nexthop_tunnel)}')
+        _no_install = self.no_install
+        if _no_install is not None:
+            leaves.append(f'{self_name}.no_install = {repr(_no_install)}')
+        _route_age_bgp_view = self.route_age_bgp_view
+        if _route_age_bgp_view is not None:
+            leaves.append(f'{self_name}.route_age_bgp_view = {repr(_route_age_bgp_view)}')
+        _output_queue_priority = self.output_queue_priority
+        if _output_queue_priority is not None:
+            res.extend(_output_queue_priority.prsrc(f'{self_name}.output_queue_priority', False).splitlines())
+        _route_refresh_priority = self.route_refresh_priority
+        if _route_refresh_priority is not None:
+            res.extend(_route_refresh_priority.prsrc(f'{self_name}.route_refresh_priority', False).splitlines())
+        _withdraw_priority = self.withdraw_priority
+        if _withdraw_priority is not None:
+            res.extend(_withdraw_priority.prsrc(f'{self_name}.withdraw_priority', False).splitlines())
+        _advertise_srv6_service = self.advertise_srv6_service
+        if _advertise_srv6_service is not None:
+            leaves.append(f'{self_name}.advertise_srv6_service = {repr(_advertise_srv6_service)}')
+        _accept_srv6_service = self.accept_srv6_service
+        if _accept_srv6_service is not None:
+            leaves.append(f'{self_name}.accept_srv6_service = {repr(_accept_srv6_service)}')
+        _aggregate_label = self.aggregate_label
+        if _aggregate_label is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/aggregate-label')
+            res.append(f'aggregate_label = {self_name}.create_aggregate_label()')
+            res.extend(_aggregate_label.prsrc('aggregate_label', False).splitlines())
+        _egress_protection = self.egress_protection
+        if _egress_protection is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/egress-protection')
+            res.append(f'egress_protection = {self_name}.create_egress_protection()')
+            res.extend(_egress_protection.prsrc('egress_protection', False).splitlines())
+        _accept_local_nexthop = self.accept_local_nexthop
+        if _accept_local_nexthop is not None:
+            leaves.append(f'{self_name}.accept_local_nexthop = {repr(_accept_local_nexthop)}')
+        _accept_own = self.accept_own
+        if _accept_own is not None:
+            leaves.append(f'{self_name}.accept_own = {repr(_accept_own)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6658,6 +9449,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(y
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast.from_gdata(n.get_opt_container('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/inet6-vpn')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn()')
+        leaves = []
+        _unicast = self.unicast
+        if _unicast is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast')
+            res.append(f'unicast = {self_name}.create_unicast()')
+            res.extend(_unicast.prsrc('unicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/inet6-vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6680,6 +9490,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signa
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/evpn/signaling')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/evpn/signaling'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling(node: xml.Node) -> yang.gdata.Container:
@@ -6711,6 +9534,25 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.a
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn(signaling=junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling.from_gdata(n.get_opt_container('signaling')))
         return junos_conf_root__configuration__protocols__bgp__group__family__evpn()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/evpn')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__evpn()')
+        leaves = []
+        _signaling = self.signaling
+        if _signaling is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/evpn/signaling')
+            res.append(f'signaling = {self_name}.create_signaling()')
+            res.extend(_signaling.prsrc('signaling', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/evpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6733,6 +9575,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__route_targe
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family__route_target()
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family/route-target')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family__route_target()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family/route-target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__route_target(node: xml.Node) -> yang.gdata.Container:
@@ -6778,6 +9633,34 @@ class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.M
         if n != None:
             return junos_conf_root__configuration__protocols__bgp__group__family(inet_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn.from_gdata(n.get_opt_container('inet-vpn')), inet6_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn.from_gdata(n.get_opt_container('inet6-vpn')), evpn=junos_conf_root__configuration__protocols__bgp__group__family__evpn.from_gdata(n.get_opt_container('evpn')), route_target=junos_conf_root__configuration__protocols__bgp__group__family__route_target.from_gdata(n.get_opt_container('route-target')))
         return junos_conf_root__configuration__protocols__bgp__group__family()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/family')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__family()')
+        leaves = []
+        _inet_vpn = self.inet_vpn
+        if _inet_vpn is not None:
+            res.extend(_inet_vpn.prsrc(f'{self_name}.inet_vpn', False).splitlines())
+        _inet6_vpn = self.inet6_vpn
+        if _inet6_vpn is not None:
+            res.extend(_inet6_vpn.prsrc(f'{self_name}.inet6_vpn', False).splitlines())
+        _evpn = self.evpn
+        if _evpn is not None:
+            res.extend(_evpn.prsrc(f'{self_name}.evpn', False).splitlines())
+        _route_target = self.route_target
+        if _route_target is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/bgp/group/family/route-target')
+            res.append(f'route_target = {self_name}.create_route_target()')
+            res.extend(_route_target.prsrc('route_target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family(node: xml.Node) -> yang.gdata.Container:
@@ -6846,6 +9729,25 @@ class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), passive=n.get_opt_bool('passive'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group/neighbor')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group__neighbor({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _passive = self.passive
+        if _passive is not None:
+            leaves.append(f'{self_name}.passive = {repr(_passive)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group/neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]
@@ -6976,6 +9878,59 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group_entry:
         return junos_conf_root__configuration__protocols__bgp__group_entry(name=n.get_str('name'), type=n.get_opt_str('type'), description=n.get_opt_str('description'), local_address=n.get_opt_str('local-address'), hold_time=n.get_opt_value('hold-time'), family=junos_conf_root__configuration__protocols__bgp__group__family.from_gdata(n.get_opt_container('family')), authentication_key=n.get_opt_str('authentication-key'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), tcpao_auth_mismatch=n.get_opt_str('tcpao-auth-mismatch'), authentication_key_chain=n.get_opt_str('authentication-key-chain'), export=n.get_opt_strs('export'), tcp_mss=n.get_opt_value('tcp-mss'), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp/group')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp__group({repr(self.name)})')
+        leaves = []
+        _type = self.type
+        if _type is not None:
+            leaves.append(f'{self_name}.type = {repr(_type)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _local_address = self.local_address
+        if _local_address is not None:
+            leaves.append(f'{self_name}.local_address = {repr(_local_address)}')
+        _hold_time = self.hold_time
+        if _hold_time is not None:
+            leaves.append(f'{self_name}.hold_time = {repr(_hold_time)}')
+        _family = self.family
+        if _family is not None:
+            res.extend(_family.prsrc(f'{self_name}.family', False).splitlines())
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        _authentication_algorithm = self.authentication_algorithm
+        if _authentication_algorithm is not None:
+            leaves.append(f'{self_name}.authentication_algorithm = {repr(_authentication_algorithm)}')
+        _tcpao_auth_mismatch = self.tcpao_auth_mismatch
+        if _tcpao_auth_mismatch is not None:
+            leaves.append(f'{self_name}.tcpao_auth_mismatch = {repr(_tcpao_auth_mismatch)}')
+        _authentication_key_chain = self.authentication_key_chain
+        if _authentication_key_chain is not None:
+            leaves.append(f'{self_name}.authentication_key_chain = {repr(_authentication_key_chain)}')
+        _export = self.export
+        if _export is not None:
+            leaves.append(f'{self_name}.export = {repr(_export)}')
+        _tcp_mss = self.tcp_mss
+        if _tcp_mss is not None:
+            leaves.append(f'{self_name}.tcp_mss = {repr(_tcp_mss)}')
+        _neighbor = self.neighbor
+        for _element in _neighbor.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/bgp/group/neighbor element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'neighbor_element = {self_name}.neighbor.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'neighbor_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -7082,6 +10037,32 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__bgp(path_selection=junos_conf_root__configuration__protocols__bgp__path_selection.from_gdata(n.get_opt_container('path-selection')), group=junos_conf_root__configuration__protocols__bgp__group.from_gdata(n.get_opt_list('group')), log_updown=n.get_opt_bool('log-updown'))
         return junos_conf_root__configuration__protocols__bgp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/bgp')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__bgp()')
+        leaves = []
+        _path_selection = self.path_selection
+        if _path_selection is not None:
+            res.extend(_path_selection.prsrc(f'{self_name}.path_selection', False).splitlines())
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/bgp/group element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        _log_updown = self.log_updown
+        if _log_updown is not None:
+            leaves.append(f'{self_name}.log_updown = {repr(_log_updown)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7126,6 +10107,25 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
         if n != None:
             return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=n.get_opt_bool('disable'), hold_time=n.get_opt_value('hold-time'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/ldp-synchronization')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _hold_time = self.hold_time
+        if _hold_time is not None:
+            leaves.append(f'{self_name}.hold_time = {repr(_hold_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/ldp-synchronization'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(node: xml.Node) -> yang.gdata.Container:
@@ -7172,6 +10172,25 @@ class junos_conf_root__configuration__protocols__isis__interface__level_entry(ya
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__level_entry:
         return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=n.get_value('name'), disable=n.get_opt_bool('disable'), metric=n.get_opt_value('metric'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/level')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__level({repr(self.name)})')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/level'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__isis__interface__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]
@@ -7270,6 +10289,25 @@ class junos_conf_root__configuration__protocols__isis__interface__passive(yang.a
             return junos_conf_root__configuration__protocols__isis__interface__passive(remote_node_iso=n.get_opt_str('remote-node-iso'), remote_node_id=n.get_opt_str('remote-node-id'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/passive')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__passive()')
+        leaves = []
+        _remote_node_iso = self.remote_node_iso
+        if _remote_node_iso is not None:
+            leaves.append(f'{self_name}.remote_node_iso = {repr(_remote_node_iso)}')
+        _remote_node_id = self.remote_node_id
+        if _remote_node_id is not None:
+            leaves.append(f'{self_name}.remote_node_id = {repr(_remote_node_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/passive'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__passive(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7337,6 +10375,25 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=n.get_opt_value('minimum-interval'), threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection/transmit-interval')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()')
+        leaves = []
+        _minimum_interval = self.minimum_interval
+        if _minimum_interval is not None:
+            leaves.append(f'{self_name}.minimum_interval = {repr(_minimum_interval)}')
+        _threshold = self.threshold
+        if _threshold is not None:
+            leaves.append(f'{self_name}.threshold = {repr(_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection/transmit-interval'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7368,6 +10425,22 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         if n != None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection/detection-time')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()')
+        leaves = []
+        _threshold = self.threshold
+        if _threshold is not None:
+            leaves.append(f'{self_name}.threshold = {repr(_threshold)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection/detection-time'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(node: xml.Node) -> yang.gdata.Container:
@@ -7415,6 +10488,28 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(key_chain=n.get_opt_str('key-chain'), algorithm=n.get_opt_str('algorithm'), loose_check=n.get_opt_bool('loose-check'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection/authentication')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication()')
+        leaves = []
+        _key_chain = self.key_chain
+        if _key_chain is not None:
+            leaves.append(f'{self_name}.key_chain = {repr(_key_chain)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        _loose_check = self.loose_check
+        if _loose_check is not None:
+            leaves.append(f'{self_name}.loose_check = {repr(_loose_check)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection/authentication'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7449,6 +10544,22 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection/echo')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()')
+        leaves = []
+        _minimum_interval = self.minimum_interval
+        if _minimum_interval is not None:
+            leaves.append(f'{self_name}.minimum_interval = {repr(_minimum_interval)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection/echo'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7478,6 +10589,22 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         if n != None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection/echo-lite')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()')
+        leaves = []
+        _minimum_interval = self.minimum_interval
+        if _minimum_interval is not None:
+            leaves.append(f'{self_name}.minimum_interval = {repr(_minimum_interval)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection/echo-lite'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(node: xml.Node) -> yang.gdata.Container:
@@ -7574,6 +10701,61 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=n.get_opt_str('version'), minimum_interval=n.get_opt_value('minimum-interval'), minimum_transmit_interval=n.get_opt_value('minimum-transmit-interval'), minimum_receive_interval=n.get_opt_value('minimum-receive-interval'), multiplier=n.get_opt_value('multiplier'), inline_disable=n.get_opt_bool('inline-disable'), pdu_size=n.get_opt_value('pdu-size'), no_adaptation=n.get_opt_bool('no-adaptation'), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_gdata(n.get_opt_container('transmit-interval')), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_gdata(n.get_opt_container('detection-time')), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_gdata(n.get_opt_container('authentication')), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_gdata(n.get_opt_container('echo')), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_gdata(n.get_opt_container('echo-lite')), holddown_interval=n.get_opt_value('holddown-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family/bfd-liveness-detection')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()')
+        leaves = []
+        _version = self.version
+        if _version is not None:
+            leaves.append(f'{self_name}.version = {repr(_version)}')
+        _minimum_interval = self.minimum_interval
+        if _minimum_interval is not None:
+            leaves.append(f'{self_name}.minimum_interval = {repr(_minimum_interval)}')
+        _minimum_transmit_interval = self.minimum_transmit_interval
+        if _minimum_transmit_interval is not None:
+            leaves.append(f'{self_name}.minimum_transmit_interval = {repr(_minimum_transmit_interval)}')
+        _minimum_receive_interval = self.minimum_receive_interval
+        if _minimum_receive_interval is not None:
+            leaves.append(f'{self_name}.minimum_receive_interval = {repr(_minimum_receive_interval)}')
+        _multiplier = self.multiplier
+        if _multiplier is not None:
+            leaves.append(f'{self_name}.multiplier = {repr(_multiplier)}')
+        _inline_disable = self.inline_disable
+        if _inline_disable is not None:
+            leaves.append(f'{self_name}.inline_disable = {repr(_inline_disable)}')
+        _pdu_size = self.pdu_size
+        if _pdu_size is not None:
+            leaves.append(f'{self_name}.pdu_size = {repr(_pdu_size)}')
+        _no_adaptation = self.no_adaptation
+        if _no_adaptation is not None:
+            leaves.append(f'{self_name}.no_adaptation = {repr(_no_adaptation)}')
+        _transmit_interval = self.transmit_interval
+        if _transmit_interval is not None:
+            res.extend(_transmit_interval.prsrc(f'{self_name}.transmit_interval', False).splitlines())
+        _detection_time = self.detection_time
+        if _detection_time is not None:
+            res.extend(_detection_time.prsrc(f'{self_name}.detection_time', False).splitlines())
+        _authentication = self.authentication
+        if _authentication is not None:
+            res.extend(_authentication.prsrc(f'{self_name}.authentication', False).splitlines())
+        _echo = self.echo
+        if _echo is not None:
+            res.extend(_echo.prsrc(f'{self_name}.echo', False).splitlines())
+        _echo_lite = self.echo_lite
+        if _echo_lite is not None:
+            res.extend(_echo_lite.prsrc(f'{self_name}.echo_lite', False).splitlines())
+        _holddown_interval = self.holddown_interval
+        if _holddown_interval is not None:
+            leaves.append(f'{self_name}.holddown_interval = {repr(_holddown_interval)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family/bfd-liveness-detection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7629,6 +10811,22 @@ class junos_conf_root__configuration__protocols__isis__interface__family_entry(y
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family_entry:
         return junos_conf_root__configuration__protocols__isis__interface__family_entry(name=n.get_str('name'), bfd_liveness_detection=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection.from_gdata(n.get_opt_container('bfd-liveness-detection')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface/family')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface__family({repr(self.name)})')
+        leaves = []
+        _bfd_liveness_detection = self.bfd_liveness_detection
+        if _bfd_liveness_detection is not None:
+            res.extend(_bfd_liveness_detection.prsrc(f'{self_name}.bfd_liveness_detection', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface/family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__isis__interface__family(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]
@@ -7739,6 +10937,51 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface_entry:
         return junos_conf_root__configuration__protocols__isis__interface_entry(name=n.get_str('name'), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_gdata(n.get_opt_container('ldp-synchronization')), level=junos_conf_root__configuration__protocols__isis__interface__level.from_gdata(n.get_opt_list('level')), lsp_interval=n.get_opt_value('lsp-interval'), point_to_point=n.get_opt_bool('point-to-point'), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_gdata(n.get_opt_container('passive')), family=junos_conf_root__configuration__protocols__isis__interface__family.from_gdata(n.get_opt_list('family')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__interface({repr(self.name)})')
+        leaves = []
+        _ldp_synchronization = self.ldp_synchronization
+        if _ldp_synchronization is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/interface/ldp-synchronization')
+            res.append(f'ldp_synchronization = {self_name}.create_ldp_synchronization()')
+            res.extend(_ldp_synchronization.prsrc('ldp_synchronization', False).splitlines())
+        _level = self.level
+        for _element in _level.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/interface/level element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'level_element = {self_name}.level.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'level_element', False, list_element=True).splitlines())
+        _lsp_interval = self.lsp_interval
+        if _lsp_interval is not None:
+            leaves.append(f'{self_name}.lsp_interval = {repr(_lsp_interval)}')
+        _point_to_point = self.point_to_point
+        if _point_to_point is not None:
+            leaves.append(f'{self_name}.point_to_point = {repr(_point_to_point)}')
+        _passive = self.passive
+        if _passive is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/interface/passive')
+            res.append(f'passive = {self_name}.create_passive()')
+            res.extend(_passive.prsrc('passive', False).splitlines())
+        _family = self.family
+        for _element in _family.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/interface/family element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'family_element = {self_name}.family.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface_entry]
     mut def __init__(self, elements=[]):
@@ -7823,6 +11066,22 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ad
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=n.get_opt_value('hold-time'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/adjacency-segment')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()')
+        leaves = []
+        _hold_time = self.hold_time
+        if _hold_time is not None:
+            leaves.append(f'{self_name}.hold_time = {repr(_hold_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/adjacency-segment'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7860,6 +11119,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ud
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(encapsulation=n.get_opt_bool('encapsulation'), decapsulation=n.get_opt_bool('decapsulation'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/udp-tunneling')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling()')
+        leaves = []
+        _encapsulation = self.encapsulation
+        if _encapsulation is not None:
+            leaves.append(f'{self_name}.encapsulation = {repr(_encapsulation)}')
+        _decapsulation = self.decapsulation
+        if _decapsulation is not None:
+            leaves.append(f'{self_name}.decapsulation = {repr(_decapsulation)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/udp-tunneling'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(node: xml.Node) -> yang.gdata.Container:
@@ -7900,6 +11178,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=n.get_opt_value('start-label'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srgb')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()')
+        leaves = []
+        _start_label = self.start_label
+        if _start_label is not None:
+            leaves.append(f'{self_name}.start_label = {repr(_start_label)}')
+        _index_range = self.index_range
+        if _index_range is not None:
+            leaves.append(f'{self_name}.index_range = {repr(_index_range)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srgb'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(node: xml.Node) -> yang.gdata.Container:
@@ -7948,6 +11245,28 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__no
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=n.get_opt_value('ipv4-index'), ipv6_index=n.get_opt_value('ipv6-index'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/node-segment')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()')
+        leaves = []
+        _ipv4_index = self.ipv4_index
+        if _ipv4_index is not None:
+            leaves.append(f'{self_name}.ipv4_index = {repr(_ipv4_index)}')
+        _ipv6_index = self.ipv6_index
+        if _ipv6_index is not None:
+            leaves.append(f'{self_name}.ipv6_index = {repr(_ipv6_index)}')
+        _index_range = self.index_range
+        if _index_range is not None:
+            leaves.append(f'{self_name}.index_range = {repr(_index_range)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/node-segment'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(node: xml.Node) -> yang.gdata.Container:
@@ -8035,6 +11354,28 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(psp=n.get_opt_bool('psp'), usp=n.get_opt_bool('usp'), usd=n.get_opt_bool('usd'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid/flavor')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor()')
+        leaves = []
+        _psp = self.psp
+        if _psp is not None:
+            leaves.append(f'{self_name}.psp = {repr(_psp)}')
+        _usp = self.usp
+        if _usp is not None:
+            leaves.append(f'{self_name}.usp = {repr(_usp)}')
+        _usd = self.usd
+        if _usd is not None:
+            leaves.append(f'{self_name}.usd = {repr(_usd)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid/flavor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8073,6 +11414,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry:
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry(name=n.get_str('name'), flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor.from_gdata(n.get_opt_container('flavor')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid({repr(self.name)})')
+        leaves = []
+        _flavor = self.flavor
+        if _flavor is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid/flavor')
+            res.append(f'flavor = {self_name}.create_flavor()')
+            res.extend(_flavor.prsrc('flavor', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry]
@@ -8164,6 +11524,28 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(psp=n.get_opt_bool('psp'), usp=n.get_opt_bool('usp'), usd=n.get_opt_bool('usd'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid/flavor')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor()')
+        leaves = []
+        _psp = self.psp
+        if _psp is not None:
+            leaves.append(f'{self_name}.psp = {repr(_psp)}')
+        _usp = self.usp
+        if _usp is not None:
+            leaves.append(f'{self_name}.usp = {repr(_usp)}')
+        _usd = self.usd
+        if _usd is not None:
+            leaves.append(f'{self_name}.usd = {repr(_usd)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid/flavor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8199,6 +11581,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor.from_gdata(n.get_opt_container('flavor')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid()')
+        leaves = []
+        _flavor = self.flavor
+        if _flavor is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid/flavor')
+            res.append(f'flavor = {self_name}.create_flavor()')
+            res.extend(_flavor.prsrc('flavor', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(node: xml.Node) -> yang.gdata.Container:
@@ -8252,6 +11653,38 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry:
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry(name=n.get_str('name'), anycast=n.get_opt_bool('anycast'), end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid.from_gdata(n.get_opt_list('end-sid')), dynamic_end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid.from_gdata(n.get_opt_container('dynamic-end-sid')), micro_node_sid=n.get_opt_bool('micro-node-sid'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6/locator')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator({repr(self.name)})')
+        leaves = []
+        _anycast = self.anycast
+        if _anycast is not None:
+            leaves.append(f'{self_name}.anycast = {repr(_anycast)}')
+        _end_sid = self.end_sid
+        for _element in _end_sid.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/source-packet-routing/srv6/locator/end-sid element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'end_sid_element = {self_name}.end_sid.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'end_sid_element', False, list_element=True).splitlines())
+        _dynamic_end_sid = self.dynamic_end_sid
+        if _dynamic_end_sid is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing/srv6/locator/dynamic-end-sid')
+            res.append(f'dynamic_end_sid = {self_name}.create_dynamic_end_sid()')
+            res.extend(_dynamic_end_sid.prsrc('dynamic_end_sid', False).splitlines())
+        _micro_node_sid = self.micro_node_sid
+        if _micro_node_sid is not None:
+            leaves.append(f'{self_name}.micro_node_sid = {repr(_micro_node_sid)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6/locator'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry]
@@ -8330,6 +11763,26 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(locator=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator.from_gdata(n.get_opt_list('locator')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/srv6')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6()')
+        leaves = []
+        _locator = self.locator
+        for _element in _locator.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/source-packet-routing/srv6/locator element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'locator_element = {self_name}.locator.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'locator_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/srv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8367,6 +11820,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(ingress=n.get_opt_bool('ingress'), egress=n.get_opt_bool('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/per-interface-per-member-link')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link()')
+        leaves = []
+        _ingress = self.ingress
+        if _ingress is not None:
+            leaves.append(f'{self_name}.ingress = {repr(_ingress)}')
+        _egress = self.egress
+        if _egress is not None:
+            leaves.append(f'{self_name}.egress = {repr(_egress)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/per-interface-per-member-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(node: xml.Node) -> yang.gdata.Container:
@@ -8408,6 +11880,25 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(ingress=n.get_opt_bool('ingress'), egress=n.get_opt_bool('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/per-sid')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid()')
+        leaves = []
+        _ingress = self.ingress
+        if _ingress is not None:
+            leaves.append(f'{self_name}.ingress = {repr(_ingress)}')
+        _egress = self.egress
+        if _egress is not None:
+            leaves.append(f'{self_name}.egress = {repr(_egress)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/per-sid'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8439,6 +11930,22 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=n.get_opt_value('interval'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/subscribe')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe()')
+        leaves = []
+        _interval = self.interval
+        if _interval is not None:
+            leaves.append(f'{self_name}.interval = {repr(_interval)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/subscribe'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(node: xml.Node) -> yang.gdata.Container:
@@ -8482,6 +11989,31 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(per_interface_per_member_link=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link.from_gdata(n.get_opt_container('per-interface-per-member-link')), per_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid.from_gdata(n.get_opt_container('per-sid')), subscribe=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe.from_gdata(n.get_opt_container('subscribe')))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/sensor-based-stats')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats()')
+        leaves = []
+        _per_interface_per_member_link = self.per_interface_per_member_link
+        if _per_interface_per_member_link is not None:
+            res.extend(_per_interface_per_member_link.prsrc(f'{self_name}.per_interface_per_member_link', False).splitlines())
+        _per_sid = self.per_sid
+        if _per_sid is not None:
+            res.extend(_per_sid.prsrc(f'{self_name}.per_sid', False).splitlines())
+        _subscribe = self.subscribe
+        if _subscribe is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing/sensor-based-stats/subscribe')
+            res.append(f'subscribe = {self_name}.create_subscribe()')
+            res.extend(_subscribe.prsrc('subscribe', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/sensor-based-stats'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8515,6 +12047,22 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(per_interface=n.get_opt_bool('per-interface'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/traffic-statistics/statistics-granularity')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity()')
+        leaves = []
+        _per_interface = self.per_interface
+        if _per_interface is not None:
+            leaves.append(f'{self_name}.per_interface = {repr(_per_interface)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/traffic-statistics/statistics-granularity'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(node: xml.Node) -> yang.gdata.Container:
@@ -8558,6 +12106,28 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(statistics_granularity=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity.from_gdata(n.get_opt_container('statistics-granularity')), congestion_protection=n.get_opt_bool('congestion-protection'), auto_bandwidth=n.get_opt_str('auto-bandwidth'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing/traffic-statistics')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics()')
+        leaves = []
+        _statistics_granularity = self.statistics_granularity
+        if _statistics_granularity is not None:
+            res.extend(_statistics_granularity.prsrc(f'{self_name}.statistics_granularity', False).splitlines())
+        _congestion_protection = self.congestion_protection
+        if _congestion_protection is not None:
+            leaves.append(f'{self_name}.congestion_protection = {repr(_congestion_protection)}')
+        _auto_bandwidth = self.auto_bandwidth
+        if _auto_bandwidth is not None:
+            leaves.append(f'{self_name}.auto_bandwidth = {repr(_auto_bandwidth)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing/traffic-statistics'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(node: xml.Node) -> yang.gdata.Container:
@@ -8667,6 +12237,70 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
         if n != None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_gdata(n.get_opt_container('adjacency-segment')), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_gdata(n.get_opt_container('udp-tunneling')), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_gdata(n.get_opt_container('srgb')), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_gdata(n.get_opt_container('node-segment')), flex_algorithm=n.get_opt_values('flex-algorithm'), use_flex_algorithm_metric_always=n.get_opt_bool('use-flex-algorithm-metric-always'), strict_asla_based_flex_algorithm=n.get_opt_bool('strict-asla-based-flex-algorithm'), new_capability_subtlv=n.get_opt_bool('new-capability-subtlv'), explicit_null=n.get_opt_bool('explicit-null'), mapping_server=n.get_opt_str('mapping-server'), no_strict_spf=n.get_opt_bool('no-strict-spf'), no_binding_sid_leaking=n.get_opt_bool('no-binding-sid-leaking'), ldp_stitching=n.get_opt_bool('ldp-stitching'), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_gdata(n.get_opt_container('srv6')), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_gdata(n.get_opt_container('sensor-based-stats')), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_gdata(n.get_opt_container('traffic-statistics')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/source-packet-routing')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__source_packet_routing()')
+        leaves = []
+        _adjacency_segment = self.adjacency_segment
+        if _adjacency_segment is not None:
+            res.extend(_adjacency_segment.prsrc(f'{self_name}.adjacency_segment', False).splitlines())
+        _udp_tunneling = self.udp_tunneling
+        if _udp_tunneling is not None:
+            res.extend(_udp_tunneling.prsrc(f'{self_name}.udp_tunneling', False).splitlines())
+        _srgb = self.srgb
+        if _srgb is not None:
+            res.extend(_srgb.prsrc(f'{self_name}.srgb', False).splitlines())
+        _node_segment = self.node_segment
+        if _node_segment is not None:
+            res.extend(_node_segment.prsrc(f'{self_name}.node_segment', False).splitlines())
+        _flex_algorithm = self.flex_algorithm
+        if _flex_algorithm is not None:
+            leaves.append(f'{self_name}.flex_algorithm = {repr(_flex_algorithm)}')
+        _use_flex_algorithm_metric_always = self.use_flex_algorithm_metric_always
+        if _use_flex_algorithm_metric_always is not None:
+            leaves.append(f'{self_name}.use_flex_algorithm_metric_always = {repr(_use_flex_algorithm_metric_always)}')
+        _strict_asla_based_flex_algorithm = self.strict_asla_based_flex_algorithm
+        if _strict_asla_based_flex_algorithm is not None:
+            leaves.append(f'{self_name}.strict_asla_based_flex_algorithm = {repr(_strict_asla_based_flex_algorithm)}')
+        _new_capability_subtlv = self.new_capability_subtlv
+        if _new_capability_subtlv is not None:
+            leaves.append(f'{self_name}.new_capability_subtlv = {repr(_new_capability_subtlv)}')
+        _explicit_null = self.explicit_null
+        if _explicit_null is not None:
+            leaves.append(f'{self_name}.explicit_null = {repr(_explicit_null)}')
+        _mapping_server = self.mapping_server
+        if _mapping_server is not None:
+            leaves.append(f'{self_name}.mapping_server = {repr(_mapping_server)}')
+        _no_strict_spf = self.no_strict_spf
+        if _no_strict_spf is not None:
+            leaves.append(f'{self_name}.no_strict_spf = {repr(_no_strict_spf)}')
+        _no_binding_sid_leaking = self.no_binding_sid_leaking
+        if _no_binding_sid_leaking is not None:
+            leaves.append(f'{self_name}.no_binding_sid_leaking = {repr(_no_binding_sid_leaking)}')
+        _ldp_stitching = self.ldp_stitching
+        if _ldp_stitching is not None:
+            leaves.append(f'{self_name}.ldp_stitching = {repr(_ldp_stitching)}')
+        _srv6 = self.srv6
+        if _srv6 is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing/srv6')
+            res.append(f'srv6 = {self_name}.create_srv6()')
+            res.extend(_srv6.prsrc('srv6', False).splitlines())
+        _sensor_based_stats = self.sensor_based_stats
+        if _sensor_based_stats is not None:
+            res.extend(_sensor_based_stats.prsrc(f'{self_name}.sensor_based_stats', False).splitlines())
+        _traffic_statistics = self.traffic_statistics
+        if _traffic_statistics is not None:
+            res.extend(_traffic_statistics.prsrc(f'{self_name}.traffic_statistics', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/source-packet-routing'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing(node: xml.Node) -> yang.gdata.Container:
@@ -8782,6 +12416,40 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__level_entry:
         return junos_conf_root__configuration__protocols__isis__level_entry(name=n.get_value('name'), disable=n.get_opt_bool('disable'), authentication_key=n.get_opt_str('authentication-key'), authentication_type=n.get_opt_str('authentication-type'), no_hello_authentication=n.get_opt_bool('no-hello-authentication'), no_csnp_authentication=n.get_opt_bool('no-csnp-authentication'), no_psnp_authentication=n.get_opt_bool('no-psnp-authentication'), wide_metrics_only=n.get_opt_bool('wide-metrics-only'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis/level')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis__level({repr(self.name)})')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        _authentication_type = self.authentication_type
+        if _authentication_type is not None:
+            leaves.append(f'{self_name}.authentication_type = {repr(_authentication_type)}')
+        _no_hello_authentication = self.no_hello_authentication
+        if _no_hello_authentication is not None:
+            leaves.append(f'{self_name}.no_hello_authentication = {repr(_no_hello_authentication)}')
+        _no_csnp_authentication = self.no_csnp_authentication
+        if _no_csnp_authentication is not None:
+            leaves.append(f'{self_name}.no_csnp_authentication = {repr(_no_csnp_authentication)}')
+        _no_psnp_authentication = self.no_psnp_authentication
+        if _no_psnp_authentication is not None:
+            leaves.append(f'{self_name}.no_psnp_authentication = {repr(_no_psnp_authentication)}')
+        _wide_metrics_only = self.wide_metrics_only
+        if _wide_metrics_only is not None:
+            leaves.append(f'{self_name}.wide_metrics_only = {repr(_wide_metrics_only)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis/level'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__level_entry]
     mut def __init__(self, elements=[]):
@@ -8895,6 +12563,42 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_gdata(n.get_opt_list('interface')), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_gdata(n.get_opt_container('source-packet-routing')), level=junos_conf_root__configuration__protocols__isis__level.from_gdata(n.get_opt_list('level')), lsp_lifetime=n.get_opt_value('lsp-lifetime'))
         return junos_conf_root__configuration__protocols__isis()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/isis')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__isis()')
+        leaves = []
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        _source_packet_routing = self.source_packet_routing
+        if _source_packet_routing is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/isis/source-packet-routing')
+            res.append(f'source_packet_routing = {self_name}.create_source_packet_routing()')
+            res.extend(_source_packet_routing.prsrc('source_packet_routing', False).splitlines())
+        _level = self.level
+        for _element in _level.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/isis/level element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'level_element = {self_name}.level.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'level_element', False, list_element=True).splitlines())
+        _lsp_lifetime = self.lsp_lifetime
+        if _lsp_lifetime is not None:
+            leaves.append(f'{self_name}.lsp_lifetime = {repr(_lsp_lifetime)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/isis'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__isis(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8979,6 +12683,40 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=n.get_opt_str('filename'), replace=n.get_opt_bool('replace'), size=n.get_opt_str('size'), files=n.get_opt_value('files'), no_stamp=n.get_opt_bool('no-stamp'), world_readable=n.get_opt_bool('world-readable'), no_world_readable=n.get_opt_bool('no-world-readable'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/traffic-statistics/file')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()')
+        leaves = []
+        _filename = self.filename
+        if _filename is not None:
+            leaves.append(f'{self_name}.filename = {repr(_filename)}')
+        _replace = self.replace
+        if _replace is not None:
+            leaves.append(f'{self_name}.replace = {repr(_replace)}')
+        _size = self.size
+        if _size is not None:
+            leaves.append(f'{self_name}.size = {repr(_size)}')
+        _files = self.files
+        if _files is not None:
+            leaves.append(f'{self_name}.files = {repr(_files)}')
+        _no_stamp = self.no_stamp
+        if _no_stamp is not None:
+            leaves.append(f'{self_name}.no_stamp = {repr(_no_stamp)}')
+        _world_readable = self.world_readable
+        if _world_readable is not None:
+            leaves.append(f'{self_name}.world_readable = {repr(_world_readable)}')
+        _no_world_readable = self.no_world_readable
+        if _no_world_readable is not None:
+            leaves.append(f'{self_name}.no_world_readable = {repr(_no_world_readable)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/traffic-statistics/file'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9042,6 +12780,31 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.ad
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_gdata(n.get_opt_container('file')), interval=n.get_opt_value('interval'), sensor_based_stats=n.get_opt_bool('sensor-based-stats'), no_penultimate_hop=n.get_opt_bool('no-penultimate-hop'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/traffic-statistics')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__traffic_statistics()')
+        leaves = []
+        _file = self.file
+        if _file is not None:
+            res.extend(_file.prsrc(f'{self_name}.file', False).splitlines())
+        _interval = self.interval
+        if _interval is not None:
+            leaves.append(f'{self_name}.interval = {repr(_interval)}')
+        _sensor_based_stats = self.sensor_based_stats
+        if _sensor_based_stats is not None:
+            leaves.append(f'{self_name}.sensor_based_stats = {repr(_sensor_based_stats)}')
+        _no_penultimate_hop = self.no_penultimate_hop
+        if _no_penultimate_hop is not None:
+            leaves.append(f'{self_name}.no_penultimate_hop = {repr(_no_penultimate_hop)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/traffic-statistics'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9097,6 +12860,28 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
             return junos_conf_root__configuration__protocols__ldp__transport_address(router_id=n.get_opt_bool('router-id'), interface=n.get_opt_bool('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__transport_address()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/transport-address')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__transport_address()')
+        leaves = []
+        _router_id = self.router_id
+        if _router_id is not None:
+            leaves.append(f'{self_name}.router_id = {repr(_router_id)}')
+        _interface = self.interface
+        if _interface is not None:
+            leaves.append(f'{self_name}.interface = {repr(_interface)}')
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/transport-address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp__transport_address(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9151,6 +12936,25 @@ class junos_conf_root__configuration__protocols__ldp__interface__link_protection
             return junos_conf_root__configuration__protocols__ldp__interface__link_protection(disable=n.get_opt_bool('disable'), dynamic_rsvp_lsp=n.get_opt_bool('dynamic-rsvp-lsp'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/interface/link-protection')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__interface__link_protection()')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _dynamic_rsvp_lsp = self.dynamic_rsvp_lsp
+        if _dynamic_rsvp_lsp is not None:
+            leaves.append(f'{self_name}.dynamic_rsvp_lsp = {repr(_dynamic_rsvp_lsp)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/interface/link-protection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9198,6 +13002,28 @@ class junos_conf_root__configuration__protocols__ldp__interface__transport_addre
         if n != None:
             return junos_conf_root__configuration__protocols__ldp__interface__transport_address(router_id=n.get_opt_bool('router-id'), interface=n.get_opt_bool('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__interface__transport_address()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/interface/transport-address')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__interface__transport_address()')
+        leaves = []
+        _router_id = self.router_id
+        if _router_id is not None:
+            leaves.append(f'{self_name}.router_id = {repr(_router_id)}')
+        _interface = self.interface
+        if _interface is not None:
+            leaves.append(f'{self_name}.interface = {repr(_interface)}')
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/interface/transport-address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address(node: xml.Node) -> yang.gdata.Container:
@@ -9273,6 +13099,43 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__interface_entry:
         return junos_conf_root__configuration__protocols__ldp__interface_entry(name=n.get_str('name'), disable=n.get_opt_bool('disable'), hello_interval=n.get_opt_value('hello-interval'), hold_time=n.get_opt_value('hold-time'), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_gdata(n.get_opt_container('link-protection')), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_gdata(n.get_opt_container('transport-address')), allow_subnet_mismatch=n.get_opt_bool('allow-subnet-mismatch'), no_allow_subnet_mismatch=n.get_opt_bool('no-allow-subnet-mismatch'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp__interface({repr(self.name)})')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _hello_interval = self.hello_interval
+        if _hello_interval is not None:
+            leaves.append(f'{self_name}.hello_interval = {repr(_hello_interval)}')
+        _hold_time = self.hold_time
+        if _hold_time is not None:
+            leaves.append(f'{self_name}.hold_time = {repr(_hold_time)}')
+        _link_protection = self.link_protection
+        if _link_protection is not None:
+            res.append('')
+            res.append('# P-container: /configuration/protocols/ldp/interface/link-protection')
+            res.append(f'link_protection = {self_name}.create_link_protection()')
+            res.extend(_link_protection.prsrc('link_protection', False).splitlines())
+        _transport_address = self.transport_address
+        if _transport_address is not None:
+            res.extend(_transport_address.prsrc(f'{self_name}.transport_address', False).splitlines())
+        _allow_subnet_mismatch = self.allow_subnet_mismatch
+        if _allow_subnet_mismatch is not None:
+            leaves.append(f'{self_name}.allow_subnet_mismatch = {repr(_allow_subnet_mismatch)}')
+        _no_allow_subnet_mismatch = self.no_allow_subnet_mismatch
+        if _no_allow_subnet_mismatch is not None:
+            leaves.append(f'{self_name}.no_allow_subnet_mismatch = {repr(_no_allow_subnet_mismatch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__ldp__interface_entry]
@@ -9372,6 +13235,35 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_gdata(n.get_opt_container('traffic-statistics')), preference=n.get_opt_value('preference'), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(n.get_opt_container('transport-address')), interface=junos_conf_root__configuration__protocols__ldp__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__ldp()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/ldp')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__ldp()')
+        leaves = []
+        _traffic_statistics = self.traffic_statistics
+        if _traffic_statistics is not None:
+            res.extend(_traffic_statistics.prsrc(f'{self_name}.traffic_statistics', False).splitlines())
+        _preference = self.preference
+        if _preference is not None:
+            leaves.append(f'{self_name}.preference = {repr(_preference)}')
+        _transport_address = self.transport_address
+        if _transport_address is not None:
+            res.extend(_transport_address.prsrc(f'{self_name}.transport_address', False).splitlines())
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/ldp/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/ldp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__ldp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9435,6 +13327,22 @@ class junos_conf_root__configuration__protocols__mpls__interface__static(yang.ad
             return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=n.get_opt_value('protection-revert-time'))
         return junos_conf_root__configuration__protocols__mpls__interface__static()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/mpls/interface/static')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__mpls__interface__static()')
+        leaves = []
+        _protection_revert_time = self.protection_revert_time
+        if _protection_revert_time is not None:
+            leaves.append(f'{self_name}.protection_revert_time = {repr(_protection_revert_time)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/mpls/interface/static'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__static(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9488,6 +13396,40 @@ class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adat
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__mpls__interface_entry:
         return junos_conf_root__configuration__protocols__mpls__interface_entry(name=n.get_str('name'), disable=n.get_opt_bool('disable'), srlg=n.get_opt_strs('srlg'), always_mark_connection_protection_tlv=n.get_opt_bool('always-mark-connection-protection-tlv'), switch_away_lsps=n.get_opt_bool('switch-away-lsps'), admin_group=n.get_opt_strs('admin-group'), admin_group_extended=n.get_opt_strs('admin-group-extended'), static=junos_conf_root__configuration__protocols__mpls__interface__static.from_gdata(n.get_opt_container('static')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/mpls/interface')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__mpls__interface({repr(self.name)})')
+        leaves = []
+        _disable = self.disable
+        if _disable is not None:
+            leaves.append(f'{self_name}.disable = {repr(_disable)}')
+        _srlg = self.srlg
+        if _srlg is not None:
+            leaves.append(f'{self_name}.srlg = {repr(_srlg)}')
+        _always_mark_connection_protection_tlv = self.always_mark_connection_protection_tlv
+        if _always_mark_connection_protection_tlv is not None:
+            leaves.append(f'{self_name}.always_mark_connection_protection_tlv = {repr(_always_mark_connection_protection_tlv)}')
+        _switch_away_lsps = self.switch_away_lsps
+        if _switch_away_lsps is not None:
+            leaves.append(f'{self_name}.switch_away_lsps = {repr(_switch_away_lsps)}')
+        _admin_group = self.admin_group
+        if _admin_group is not None:
+            leaves.append(f'{self_name}.admin_group = {repr(_admin_group)}')
+        _admin_group_extended = self.admin_group_extended
+        if _admin_group_extended is not None:
+            leaves.append(f'{self_name}.admin_group_extended = {repr(_admin_group_extended)}')
+        _static = self.static
+        if _static is not None:
+            res.extend(_static.prsrc(f'{self_name}.static', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/mpls/interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class junos_conf_root__configuration__protocols__mpls__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__mpls__interface_entry]
@@ -9582,6 +13524,32 @@ class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__mpls(no_propagate_ttl=n.get_opt_bool('no-propagate-ttl'), ipv6_tunneling=n.get_opt_bool('ipv6-tunneling'), interface=junos_conf_root__configuration__protocols__mpls__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__mpls()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols/mpls')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols__mpls()')
+        leaves = []
+        _no_propagate_ttl = self.no_propagate_ttl
+        if _no_propagate_ttl is not None:
+            leaves.append(f'{self_name}.no_propagate_ttl = {repr(_no_propagate_ttl)}')
+        _ipv6_tunneling = self.ipv6_tunneling
+        if _ipv6_tunneling is not None:
+            leaves.append(f'{self_name}.ipv6_tunneling = {repr(_ipv6_tunneling)}')
+        _interface = self.interface
+        for _element in _interface.elements:
+            res.append('')
+            res.append(f"# List /configuration/protocols/mpls/interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'interface_element = {self_name}.interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'interface_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols/mpls'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration__protocols__mpls(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9627,6 +13595,31 @@ class junos_conf_root__configuration__protocols(yang.adata.MNode):
         if n != None:
             return junos_conf_root__configuration__protocols(bgp=junos_conf_root__configuration__protocols__bgp.from_gdata(n.get_opt_container('bgp')), isis=junos_conf_root__configuration__protocols__isis.from_gdata(n.get_opt_container('isis')), ldp=junos_conf_root__configuration__protocols__ldp.from_gdata(n.get_opt_container('ldp')), mpls=junos_conf_root__configuration__protocols__mpls.from_gdata(n.get_opt_container('mpls')))
         return junos_conf_root__configuration__protocols()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration/protocols')
+            res.append(f'{self_name} = junos_conf_root__configuration__protocols()')
+        leaves = []
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.extend(_bgp.prsrc(f'{self_name}.bgp', False).splitlines())
+        _isis = self.isis
+        if _isis is not None:
+            res.extend(_isis.prsrc(f'{self_name}.isis', False).splitlines())
+        _ldp = self.ldp
+        if _ldp is not None:
+            res.extend(_ldp.prsrc(f'{self_name}.ldp', False).splitlines())
+        _mpls = self.mpls
+        if _mpls is not None:
+            res.extend(_mpls.prsrc(f'{self_name}.mpls', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration/protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_junos_conf_root__configuration__protocols(node: xml.Node) -> yang.gdata.Container:
@@ -9696,6 +13689,47 @@ class junos_conf_root__configuration(yang.adata.MNode):
             return junos_conf_root__configuration(rcsid=n.get_opt_str('rcsid'), version=n.get_opt_str('version'), system=junos_conf_root__configuration__system.from_gdata(n.get_opt_container('system')), interfaces=junos_conf_root__configuration__interfaces.from_gdata(n.get_opt_container('interfaces')), routing_instances=junos_conf_root__configuration__routing_instances.from_gdata(n.get_opt_container('routing-instances')), groups=junos_conf_root__configuration__groups.from_gdata(n.get_opt_list('groups')), routing_options=junos_conf_root__configuration__routing_options.from_gdata(n.get_opt_container('routing-options')), protocols=junos_conf_root__configuration__protocols.from_gdata(n.get_opt_container('protocols')))
         return junos_conf_root__configuration()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /configuration')
+            res.append(f'{self_name} = junos_conf_root__configuration()')
+        leaves = []
+        _rcsid = self.rcsid
+        if _rcsid is not None:
+            leaves.append(f'{self_name}.rcsid = {repr(_rcsid)}')
+        _version = self.version
+        if _version is not None:
+            leaves.append(f'{self_name}.version = {repr(_version)}')
+        _system = self.system
+        if _system is not None:
+            res.extend(_system.prsrc(f'{self_name}.system', False).splitlines())
+        _interfaces = self.interfaces
+        if _interfaces is not None:
+            res.extend(_interfaces.prsrc(f'{self_name}.interfaces', False).splitlines())
+        _routing_instances = self.routing_instances
+        if _routing_instances is not None:
+            res.extend(_routing_instances.prsrc(f'{self_name}.routing_instances', False).splitlines())
+        _groups = self.groups
+        for _element in _groups.elements:
+            res.append('')
+            res.append(f"# List /configuration/groups element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'groups_element = {self_name}.groups.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'groups_element', False, list_element=True).splitlines())
+        _routing_options = self.routing_options
+        if _routing_options is not None:
+            res.extend(_routing_options.prsrc(f'{self_name}.routing_options', False).splitlines())
+        _protocols = self.protocols
+        if _protocols is not None:
+            res.extend(_protocols.prsrc(f'{self_name}.protocols', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /configuration'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_junos_conf_root__configuration(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9736,6 +13770,22 @@ class root(yang.adata.MNode):
         if n != None:
             return root(configuration=junos_conf_root__configuration.from_gdata(n.get_opt_container('configuration')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _configuration = self.configuration
+        if _configuration is not None:
+            res.extend(_configuration.prsrc(f'{self_name}.configuration', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_0.act
+++ b/src/respnet/layers/y_0.act
@@ -7376,7 +7376,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         self._name = 'routing-protocol'
         self.elements = elements
 
-    mut def create(self, type, ospf, bgp, rip, vrrp):
+    mut def create(self, type):
         for e in self.elements:
             match = True
             if e.type != type:
@@ -7385,7 +7385,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             if match:
                 return e
 
-        res = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type, ospf, bgp, rip, vrrp)
+        res = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type)
         self.elements.append(res)
         return res
 
@@ -12668,7 +12668,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         self._name = 'routing-protocol'
         self.elements = elements
 
-    mut def create(self, type, ospf, bgp, rip, vrrp):
+    mut def create(self, type):
         for e in self.elements:
             match = True
             if e.type != type:
@@ -12677,7 +12677,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             if match:
                 return e
 
-        res = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type, ospf, bgp, rip, vrrp)
+        res = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type)
         self.elements.append(res)
         return res
 

--- a/src/respnet/layers/y_0.act
+++ b/src/respnet/layers/y_0.act
@@ -75,6 +75,25 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router')
+            res.append(f'{self_name} = netinfra__netinfra__router({repr(self.name)}, {repr(self.id)}, {repr(self.asn)})')
+        leaves = []
+        _role = self.role
+        if _role is not None:
+            leaves.append(f'{self_name}.role = {repr(_role)}')
+        _mock = self.mock
+        if _mock is not None:
+            leaves.append(f'{self_name}.mock = {repr(_mock)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -263,6 +282,19 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__backbone_link_entry:
         return netinfra__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/backbone-link')
+            res.append(f'{self_name} = netinfra__netinfra__backbone_link({repr(self.left_router)}, {repr(self.left_interface)}, {repr(self.right_router)}, {repr(self.right_interface)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/backbone-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -419,6 +451,33 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra')
+            res.append(f'{self_name} = netinfra__netinfra()')
+        leaves = []
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)}, {repr(_element.id)}, {repr(_element.asn)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        _backbone_link = self.backbone_link
+        for _element in _backbone_link.elements:
+            res.append('')
+            res.append(f"# List /netinfra/backbone-link element: {_element.to_gdata().key_str(['left-router', 'left-interface', 'right-router', 'right-interface'])}")
+            list_elem = f'backbone_link_element = {self_name}.backbone_link.create({repr(_element.left_router)}, {repr(_element.left_interface)}, {repr(_element.right_router)}, {repr(_element.right_interface)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra__netinfra(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -479,6 +538,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=n.get_str('id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
@@ -611,6 +683,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=n.get_str('id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -742,6 +827,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=n.get_str('id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -872,6 +970,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=n.get_str('id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
@@ -1015,6 +1126,47 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()')
+        leaves = []
+        _cloud_identifier = self.cloud_identifier
+        for _element in _cloud_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'cloud_identifier_element = {self_name}.cloud_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'cloud_identifier_element', False, list_element=True).splitlines())
+        _encryption_profile_identifier = self.encryption_profile_identifier
+        for _element in _encryption_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'encryption_profile_identifier_element = {self_name}.encryption_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'encryption_profile_identifier_element', False, list_element=True).splitlines())
+        _qos_profile_identifier = self.qos_profile_identifier
+        for _element in _qos_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'qos_profile_identifier_element = {self_name}.qos_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'qos_profile_identifier_element', False, list_element=True).splitlines())
+        _bfd_profile_identifier = self.bfd_profile_identifier
+        for _element in _bfd_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'bfd_profile_identifier_element = {self_name}.bfd_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'bfd_profile_identifier_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1085,6 +1237,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_container('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()')
+        leaves = []
+        _valid_provider_identifiers = self.valid_provider_identifiers
+        if _valid_provider_identifiers is not None:
+            res.extend(_valid_provider_identifiers.prsrc(f'{self_name}.valid_provider_identifiers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(node: xml.Node) -> yang.gdata.Container:
@@ -1195,6 +1363,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation/nat44')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _nat44_customer_address = self.nat44_customer_address
+        if _nat44_customer_address is not None:
+            leaves.append(f'{self_name}.nat44_customer_address = {repr(_nat44_customer_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation/nat44'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1249,6 +1436,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_container('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()')
+        leaves = []
+        _nat44 = self.nat44
+        if _nat44 is not None:
+            res.extend(_nat44.prsrc(f'{self_name}.nat44', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(node: xml.Node) -> yang.gdata.Container:
@@ -1313,6 +1516,31 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=n.get_str('cloud-identifier'), permit_any=n.get_opt_bool('permit-any'), permit_site=n.get_opt_strs('permit-site'), deny_site=n.get_opt_strs('deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(n.get_opt_container('address-translation')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access({repr(self.cloud_identifier)})')
+        leaves = []
+        _permit_any = self.permit_any
+        if _permit_any is not None:
+            leaves.append(f'{self_name}.permit_any = {repr(_permit_any)}')
+        _permit_site = self.permit_site
+        if _permit_site is not None:
+            leaves.append(f'{self_name}.permit_site = {repr(_permit_site)}')
+        _deny_site = self.deny_site
+        if _deny_site is not None:
+            leaves.append(f'{self_name}.deny_site = {repr(_deny_site)}')
+        _address_translation = self.address_translation
+        if _address_translation is not None:
+            res.extend(_address_translation.prsrc(f'{self_name}.address_translation', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
@@ -1465,6 +1693,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()')
+        leaves = []
+        _cloud_access = self.cloud_access
+        for _element in _cloud_access.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access element: {_element.to_gdata().key_str(['cloud-identifier'])}")
+            list_elem = f'cloud_access_element = {self_name}.cloud_access.create({repr(_element.cloud_identifier)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'cloud_access_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1524,6 +1772,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_strs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/customer-tree-flavors')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()')
+        leaves = []
+        _tree_flavor = self.tree_flavor
+        if _tree_flavor is not None:
+            leaves.append(f'{self_name}.tree_flavor = {repr(_tree_flavor)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/customer-tree-flavors'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(node: xml.Node) -> yang.gdata.Container:
@@ -1607,6 +1871,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/provider-managed')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _rp_redundancy = self.rp_redundancy
+        if _rp_redundancy is not None:
+            leaves.append(f'{self_name}.rp_redundancy = {repr(_rp_redundancy)}')
+        _optimal_traffic_delivery = self.optimal_traffic_delivery
+        if _optimal_traffic_delivery is not None:
+            leaves.append(f'{self_name}.optimal_traffic_delivery = {repr(_optimal_traffic_delivery)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/provider-managed'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(node: xml.Node) -> yang.gdata.Container:
@@ -1711,6 +1997,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=n.get_int('id'), group_address=n.get_opt_str('group-address'), group_start=n.get_opt_str('group-start'), group_end=n.get_opt_str('group-end'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group({repr(self.id)})')
+        leaves = []
+        _group_address = self.group_address
+        if _group_address is not None:
+            leaves.append(f'{self_name}.group_address = {repr(_group_address)}')
+        _group_start = self.group_start
+        if _group_start is not None:
+            leaves.append(f'{self_name}.group_start = {repr(_group_start)}')
+        _group_end = self.group_end
+        if _group_end is not None:
+            leaves.append(f'{self_name}.group_end = {repr(_group_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
@@ -1857,6 +2165,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1919,6 +2247,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=n.get_int('id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(n.get_opt_container('provider-managed')), rp_address=n.get_str('rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(n.get_opt_container('groups')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping({repr(self.id)}, {repr(self.rp_address)})')
+        leaves = []
+        _provider_managed = self.provider_managed
+        if _provider_managed is not None:
+            res.extend(_provider_managed.prsrc(f'{self_name}.provider_managed', False).splitlines())
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
@@ -2065,6 +2412,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()')
+        leaves = []
+        _rp_group_mapping = self.rp_group_mapping
+        for _element in _rp_group_mapping.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rp_group_mapping_element = {self_name}.rp_group_mapping.create({repr(_element.id)}, {repr(_element.rp_address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rp_group_mapping_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2125,6 +2492,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery/bsr-candidates')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()')
+        leaves = []
+        _bsr_candidate_address = self.bsr_candidate_address
+        if _bsr_candidate_address is not None:
+            leaves.append(f'{self_name}.bsr_candidate_address = {repr(_bsr_candidate_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery/bsr-candidates'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2178,6 +2561,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_str('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_container('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()')
+        leaves = []
+        _rp_discovery_type = self.rp_discovery_type
+        if _rp_discovery_type is not None:
+            leaves.append(f'{self_name}.rp_discovery_type = {repr(_rp_discovery_type)}')
+        _bsr_candidates = self.bsr_candidates
+        if _bsr_candidates is not None:
+            res.extend(_bsr_candidates.prsrc(f'{self_name}.bsr_candidates', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(node: xml.Node) -> yang.gdata.Container:
@@ -2239,6 +2641,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_container('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_container('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()')
+        leaves = []
+        _rp_group_mappings = self.rp_group_mappings
+        if _rp_group_mappings is not None:
+            res.extend(_rp_group_mappings.prsrc(f'{self_name}.rp_group_mappings', False).splitlines())
+        _rp_discovery = self.rp_discovery
+        if _rp_discovery is not None:
+            res.extend(_rp_discovery.prsrc(f'{self_name}.rp_discovery', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(node: xml.Node) -> yang.gdata.Container:
@@ -2306,6 +2727,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_container('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_container('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _customer_tree_flavors = self.customer_tree_flavors
+        if _customer_tree_flavors is not None:
+            res.extend(_customer_tree_flavors.prsrc(f'{self_name}.customer_tree_flavors', False).splitlines())
+        _rp = self.rp
+        if _rp is not None:
+            res.extend(_rp.prsrc(f'{self_name}.rp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -2390,6 +2833,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=n.get_str('vpn-id'), local_sites_role=n.get_opt_str('local-sites-role'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn({repr(self.vpn_id)})')
+        leaves = []
+        _local_sites_role = self.local_sites_role
+        if _local_sites_role is not None:
+            leaves.append(f'{self_name}.local_sites_role = {repr(_local_sites_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
@@ -2524,6 +2983,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()')
+        leaves = []
+        _extranet_vpn = self.extranet_vpn
+        for _element in _extranet_vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'extranet_vpn_element = {self_name}.extranet_vpn.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'extranet_vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2601,6 +3080,37 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=n.get_str('vpn-id'), customer_name=n.get_opt_str('customer-name'), vpn_service_topology=n.get_opt_str('vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(n.get_opt_container('cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(n.get_opt_container('multicast')), carrierscarrier=n.get_opt_bool('carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(n.get_opt_container('extranet-vpns')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service({repr(self.vpn_id)})')
+        leaves = []
+        _customer_name = self.customer_name
+        if _customer_name is not None:
+            leaves.append(f'{self_name}.customer_name = {repr(_customer_name)}')
+        _vpn_service_topology = self.vpn_service_topology
+        if _vpn_service_topology is not None:
+            leaves.append(f'{self_name}.vpn_service_topology = {repr(_vpn_service_topology)}')
+        _cloud_accesses = self.cloud_accesses
+        if _cloud_accesses is not None:
+            res.extend(_cloud_accesses.prsrc(f'{self_name}.cloud_accesses', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            leaves.append(f'{self_name}.carrierscarrier = {repr(_carrierscarrier)}')
+        _extranet_vpns = self.extranet_vpns
+        if _extranet_vpns is not None:
+            res.extend(_extranet_vpns.prsrc(f'{self_name}.extranet_vpns', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
@@ -2765,6 +3275,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services()')
+        leaves = []
+        _vpn_service = self.vpn_service
+        for _element in _vpn_service.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'vpn_service_element = {self_name}.vpn_service.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_service_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2891,6 +3421,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=n.get_str('location-id'), address=n.get_opt_str('address'), postal_code=n.get_opt_str('postal-code'), state=n.get_opt_str('state'), city=n.get_opt_str('city'), country_code=n.get_opt_str('country-code'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/locations/location')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location({repr(self.location_id)})')
+        leaves = []
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        _postal_code = self.postal_code
+        if _postal_code is not None:
+            leaves.append(f'{self_name}.postal_code = {repr(_postal_code)}')
+        _state = self.state
+        if _state is not None:
+            leaves.append(f'{self_name}.state = {repr(_state)}')
+        _city = self.city
+        if _city is not None:
+            leaves.append(f'{self_name}.city = {repr(_city)}')
+        _country_code = self.country_code
+        if _country_code is not None:
+            leaves.append(f'{self_name}.country_code = {repr(_country_code)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/locations/location'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
@@ -3049,6 +3607,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/locations')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()')
+        leaves = []
+        _location = self.location
+        for _element in _location.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/locations/location element: {_element.to_gdata().key_str(['location-id'])}")
+            list_elem = f'location_element = {self_name}.location.create({repr(_element.location_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'location_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/locations'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3128,6 +3706,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices/device/management')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management({repr(self.address)})')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices/device/management'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3190,6 +3784,23 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=n.get_str('device-id'), location=n.get_str('location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(n.get_container('management')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices/device')
+            res.append(f'self_management = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management({repr(self.management.address)})')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device({repr(self.device_id)}, {repr(self.location)}, self_management)')
+        leaves = []
+        _management = self.management
+        if _management is not None:
+            res.extend(_management.prsrc(f'{self_name}.management', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices/device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
@@ -3330,6 +3941,27 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/devices/device element: {_element.to_gdata().key_str(['device-id'])}")
+            res.append(f'element_management = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management({repr(_element.management.address)})')
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.device_id)}, {repr(_element.location)}, element_management)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3383,6 +4015,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
@@ -3511,6 +4156,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-diversity/groups/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3560,6 +4225,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_container('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()')
+        leaves = []
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(node: xml.Node) -> yang.gdata.Container:
@@ -3616,6 +4297,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_str('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/management')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__management({repr(self.type)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/management'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(node: xml.Node) -> yang.gdata.Container:
@@ -3708,6 +4402,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=n.get_str('type'), lan_tag=n.get_opt_strs('lan-tag'), ipv4_lan_prefix=n.get_opt_strs('ipv4-lan-prefix'), ipv6_lan_prefix=n.get_opt_strs('ipv6-lan-prefix'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter({repr(self.type)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        _ipv4_lan_prefix = self.ipv4_lan_prefix
+        if _ipv4_lan_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_lan_prefix = {repr(_ipv4_lan_prefix)}')
+        _ipv6_lan_prefix = self.ipv6_lan_prefix
+        if _ipv6_lan_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_lan_prefix = {repr(_ipv6_lan_prefix)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
@@ -3854,6 +4570,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()')
+        leaves = []
+        _filter = self.filter
+        for _element in _filter.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'filter_element = {self_name}.filter.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'filter_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3918,6 +4654,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=n.get_str('vpn-id'), site_role=n.get_opt_str('site-role'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn({repr(self.vpn_id)})')
+        leaves = []
+        _site_role = self.site_role
+        if _site_role is not None:
+            leaves.append(f'{self_name}.site_role = {repr(_site_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
@@ -4059,6 +4811,29 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=n.get_str('id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(n.get_opt_container('filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_gdata(n.get_opt_list('vpn')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries({repr(self.id)})')
+        leaves = []
+        _filters = self.filters
+        if _filters is not None:
+            res.extend(_filters.prsrc(f'{self_name}.filters', False).splitlines())
+        _vpn = self.vpn
+        for _element in _vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'vpn_element = {self_name}.vpn.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
@@ -4202,6 +4977,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=n.get_str('vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_gdata(n.get_opt_list('entries')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy({repr(self.vpn_policy_id)})')
+        leaves = []
+        _entries = self.entries
+        for _element in _entries.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'entries_element = {self_name}.entries.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'entries_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -4335,6 +5130,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()')
+        leaves = []
+        _vpn_policy = self.vpn_policy
+        for _element in _vpn_policy.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy element: {_element.to_gdata().key_str(['vpn-policy-id'])}")
+            list_elem = f'vpn_policy_element = {self_name}.vpn_policy.create({repr(_element.vpn_policy_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_policy_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4405,6 +5220,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=n.get_str('af'), maximum_routes=n.get_opt_int('maximum-routes'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/maximum-routes/address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family({repr(self.af)})')
+        leaves = []
+        _maximum_routes = self.maximum_routes
+        if _maximum_routes is not None:
+            leaves.append(f'{self_name}.maximum_routes = {repr(_maximum_routes)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/maximum-routes/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
@@ -4539,6 +5370,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/maximum-routes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/maximum-routes/address-family element: {_element.to_gdata().key_str(['af'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/maximum-routes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4584,6 +5435,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/authentication')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/authentication'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(node: xml.Node) -> yang.gdata.Container:
@@ -4668,6 +5532,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/encryption/encryption-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()')
+        leaves = []
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        _preshared_key = self.preshared_key
+        if _preshared_key is not None:
+            leaves.append(f'{self_name}.preshared_key = {repr(_preshared_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/encryption/encryption-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4739,6 +5625,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/encryption')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _layer = self.layer
+        if _layer is not None:
+            leaves.append(f'{self_name}.layer = {repr(_layer)}')
+        _encryption_profile = self.encryption_profile
+        if _encryption_profile is not None:
+            res.extend(_encryption_profile.prsrc(f'{self_name}.encryption_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/encryption'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4805,6 +5713,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security()')
+        leaves = []
+        _authentication = self.authentication
+        if _authentication is not None:
+            res.extend(_authentication.prsrc(f'{self_name}.authentication', False).splitlines())
+        _encryption = self.encryption
+        if _encryption is not None:
+            res.extend(_encryption.prsrc(f'{self_name}.encryption', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(node: xml.Node) -> yang.gdata.Container:
@@ -4934,6 +5861,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5011,6 +5957,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
@@ -5125,6 +6090,55 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()')
+        leaves = []
+        _dscp = self.dscp
+        if _dscp is not None:
+            leaves.append(f'{self_name}.dscp = {repr(_dscp)}')
+        _dot1p = self.dot1p
+        if _dot1p is not None:
+            leaves.append(f'{self_name}.dot1p = {repr(_dot1p)}')
+        _ipv4_src_prefix = self.ipv4_src_prefix
+        if _ipv4_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_src_prefix = {repr(_ipv4_src_prefix)}')
+        _ipv6_src_prefix = self.ipv6_src_prefix
+        if _ipv6_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_src_prefix = {repr(_ipv6_src_prefix)}')
+        _ipv4_dst_prefix = self.ipv4_dst_prefix
+        if _ipv4_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_dst_prefix = {repr(_ipv4_dst_prefix)}')
+        _ipv6_dst_prefix = self.ipv6_dst_prefix
+        if _ipv6_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_dst_prefix = {repr(_ipv6_dst_prefix)}')
+        _l4_src_port = self.l4_src_port
+        if _l4_src_port is not None:
+            leaves.append(f'{self_name}.l4_src_port = {repr(_l4_src_port)}')
+        _target_sites = self.target_sites
+        if _target_sites is not None:
+            leaves.append(f'{self_name}.target_sites = {repr(_target_sites)}')
+        _l4_src_port_range = self.l4_src_port_range
+        if _l4_src_port_range is not None:
+            res.extend(_l4_src_port_range.prsrc(f'{self_name}.l4_src_port_range', False).splitlines())
+        _l4_dst_port = self.l4_dst_port
+        if _l4_dst_port is not None:
+            leaves.append(f'{self_name}.l4_dst_port = {repr(_l4_dst_port)}')
+        _l4_dst_port_range = self.l4_dst_port_range
+        if _l4_dst_port_range is not None:
+            res.extend(_l4_dst_port_range.prsrc(f'{self_name}.l4_dst_port_range', False).splitlines())
+        _protocol_field = self.protocol_field
+        if _protocol_field is not None:
+            leaves.append(f'{self_name}.protocol_field = {repr(_protocol_field)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
@@ -5267,6 +6281,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule({repr(self.id)})')
+        leaves = []
+        _match_flow = self.match_flow
+        if _match_flow is not None:
+            res.extend(_match_flow.prsrc(f'{self_name}.match_flow', False).splitlines())
+        _match_application = self.match_application
+        if _match_application is not None:
+            leaves.append(f'{self_name}.match_application = {repr(_match_application)}')
+        _target_class_id = self.target_class_id
+        if _target_class_id is not None:
+            leaves.append(f'{self_name}.target_class_id = {repr(_target_class_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
@@ -5413,6 +6449,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()')
+        leaves = []
+        _rule = self.rule
+        for _element in _rule.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rule_element = {self_name}.rule.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rule_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5504,6 +6560,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/latency')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()')
+        leaves = []
+        _use_lowest_latency = self.use_lowest_latency
+        if _use_lowest_latency is not None:
+            leaves.append(f'{self_name}.use_lowest_latency = {repr(_use_lowest_latency)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/latency'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5576,6 +6651,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/jitter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()')
+        leaves = []
+        _use_lowest_jitter = self.use_lowest_jitter
+        if _use_lowest_jitter is not None:
+            leaves.append(f'{self_name}.use_lowest_jitter = {repr(_use_lowest_jitter)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/jitter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5647,6 +6741,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/bandwidth')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth({repr(self.guaranteed_bw_percent)})')
+        leaves = []
+        _end_to_end = self.end_to_end
+        if _end_to_end is not None:
+            leaves.append(f'{self_name}.end_to_end = {repr(_end_to_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/bandwidth'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
@@ -5725,6 +6835,35 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_container('bandwidth')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class')
+            res.append(f'self_bandwidth = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth({repr(self.bandwidth.guaranteed_bw_percent)})')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class({repr(self.class_id)}, self_bandwidth)')
+        leaves = []
+        _direction = self.direction
+        if _direction is not None:
+            leaves.append(f'{self_name}.direction = {repr(_direction)}')
+        _rate_limit = self.rate_limit
+        if _rate_limit is not None:
+            leaves.append(f'{self_name}.rate_limit = {repr(_rate_limit)}')
+        _latency = self.latency
+        if _latency is not None:
+            res.extend(_latency.prsrc(f'{self_name}.latency', False).splitlines())
+        _jitter = self.jitter
+        if _jitter is not None:
+            res.extend(_jitter.prsrc(f'{self_name}.jitter', False).splitlines())
+        _bandwidth = self.bandwidth
+        if _bandwidth is not None:
+            res.extend(_bandwidth.prsrc(f'{self_name}.bandwidth', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
@@ -5883,6 +7022,27 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()')
+        leaves = []
+        _class_ = self.class_
+        for _element in _class_.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class element: {_element.to_gdata().key_str(['class-id'])}")
+            res.append(f'element_bandwidth = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth({repr(_element.bandwidth.guaranteed_bw_percent)})')
+            list_elem = f'class__element = {self_name}.class_.create({repr(_element.class_id)}, element_bandwidth)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'class__element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5937,6 +7097,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()')
+        leaves = []
+        _profile = self.profile
+        if _profile is not None:
+            leaves.append(f'{self_name}.profile = {repr(_profile)}')
+        _classes = self.classes
+        if _classes is not None:
+            res.extend(_classes.prsrc(f'{self_name}.classes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
@@ -5998,6 +7177,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()')
+        leaves = []
+        _qos_classification_policy = self.qos_classification_policy
+        if _qos_classification_policy is not None:
+            res.extend(_qos_classification_policy.prsrc(f'{self_name}.qos_classification_policy', False).splitlines())
+        _qos_profile = self.qos_profile
+        if _qos_profile is not None:
+            res.extend(_qos_profile.prsrc(f'{self_name}.qos_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(node: xml.Node) -> yang.gdata.Container:
@@ -6061,6 +7259,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/carrierscarrier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()')
+        leaves = []
+        _signalling_type = self.signalling_type
+        if _signalling_type is not None:
+            leaves.append(f'{self_name}.signalling_type = {repr(_signalling_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/carrierscarrier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
@@ -6134,6 +7348,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/multicast/multicast-address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            leaves.append(f'{self_name}.ipv4 = {repr(_ipv4)}')
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            leaves.append(f'{self_name}.ipv6 = {repr(_ipv6)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/multicast/multicast-address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6204,6 +7437,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()')
+        leaves = []
+        _multicast_site_type = self.multicast_site_type
+        if _multicast_site_type is not None:
+            leaves.append(f'{self_name}.multicast_site_type = {repr(_multicast_site_type)}')
+        _multicast_address_family = self.multicast_address_family
+        if _multicast_address_family is not None:
+            res.extend(_multicast_address_family.prsrc(f'{self_name}.multicast_address_family', False).splitlines())
+        _protocol_type = self.protocol_type
+        if _protocol_type is not None:
+            leaves.append(f'{self_name}.protocol_type = {repr(_protocol_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -6277,6 +7532,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_container('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service()')
+        leaves = []
+        _qos = self.qos
+        if _qos is not None:
+            res.extend(_qos.prsrc(f'{self_name}.qos', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            res.extend(_carrierscarrier.prsrc(f'{self_name}.carrierscarrier', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6346,6 +7623,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/traffic-protection')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/traffic-protection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(node: xml.Node) -> yang.gdata.Container:
@@ -6434,6 +7727,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link({repr(self.target_site)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -6568,6 +7877,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()')
+        leaves = []
+        _sham_link = self.sham_link
+        for _element in _sham_link.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link element: {_element.to_gdata().key_str(['target-site'])}")
+            list_elem = f'sham_link_element = {self_name}.sham_link.create({repr(_element.target_site)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'sham_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6630,6 +7959,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf({repr(self.area_address)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        _sham_links = self.sham_links
+        if _sham_links is not None:
+            res.extend(_sham_links.prsrc(f'{self_name}.sham_links', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
@@ -6714,6 +8062,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp({repr(self.autonomous_system)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6794,6 +8155,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -6962,6 +8339,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -7108,6 +8501,33 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()')
+        leaves = []
+        _ipv4_lan_prefixes = self.ipv4_lan_prefixes
+        for _element in _ipv4_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv4_lan_prefixes_element = {self_name}.ipv4_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv4_lan_prefixes_element', False, list_element=True).splitlines())
+        _ipv6_lan_prefixes = self.ipv6_lan_prefixes
+        for _element in _ipv6_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv6_lan_prefixes_element = {self_name}.ipv6_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv6_lan_prefixes_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7165,6 +8585,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static()')
+        leaves = []
+        _cascaded_lan_prefixes = self.cascaded_lan_prefixes
+        if _cascaded_lan_prefixes is not None:
+            res.extend(_cascaded_lan_prefixes.prsrc(f'{self_name}.cascaded_lan_prefixes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7219,6 +8655,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7271,6 +8720,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_strs('address-family'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
@@ -7368,6 +8830,49 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol({repr(self.type)})')
+        leaves = []
+        _ospf = self.ospf
+        if _ospf is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf')
+            res.append(f'ospf = {self_name}.create_ospf({repr(_ospf.area_address)})')
+            res.extend(_ospf.prsrc('ospf', False).splitlines())
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp')
+            res.append(f'bgp = {self_name}.create_bgp({repr(_bgp.autonomous_system)})')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        _static = self.static
+        if _static is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static')
+            res.append(f'static = {self_name}.create_static()')
+            res.extend(_static.prsrc('static', False).splitlines())
+        _rip = self.rip
+        if _rip is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip')
+            res.append(f'rip = {self_name}.create_rip()')
+            res.extend(_rip.prsrc('rip', False).splitlines())
+        _vrrp = self.vrrp
+        if _vrrp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp')
+            res.append(f'vrrp = {self_name}.create_vrrp()')
+            res.extend(_vrrp.prsrc('vrrp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
@@ -7526,6 +9031,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()')
+        leaves = []
+        _routing_protocol = self.routing_protocol
+        for _element in _routing_protocol.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'routing_protocol_element = {self_name}.routing_protocol.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'routing_protocol_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7603,6 +9128,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
@@ -7731,6 +9269,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7790,6 +9348,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
@@ -7940,6 +9511,32 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_bool('all-other-accesses'), all_other_groups=n.get_opt_bool('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        _all_other_accesses = self.all_other_accesses
+        if _all_other_accesses is not None:
+            leaves.append(f'{self_name}.all_other_accesses = {repr(_all_other_accesses)}')
+        _all_other_groups = self.all_other_groups
+        if _all_other_groups is not None:
+            leaves.append(f'{self_name}.all_other_groups = {repr(_all_other_groups)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8004,6 +9601,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=n.get_str('constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(n.get_opt_container('target')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint({repr(self.constraint_type)})')
+        leaves = []
+        _target = self.target
+        if _target is not None:
+            res.extend(_target.prsrc(f'{self_name}.target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
@@ -8138,6 +9751,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()')
+        leaves = []
+        _constraint = self.constraint
+        for _element in _constraint.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint element: {_element.to_gdata().key_str(['constraint-type'])}")
+            list_elem = f'constraint_element = {self_name}.constraint.create({repr(_element.constraint_type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'constraint_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8192,6 +9825,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_container('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_container('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()')
+        leaves = []
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        _constraints = self.constraints
+        if _constraints is not None:
+            res.extend(_constraints.prsrc(f'{self_name}.constraints', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(node: xml.Node) -> yang.gdata.Container:
@@ -8266,6 +9918,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer/requested-type')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()')
+        leaves = []
+        _requested_type = self.requested_type
+        if _requested_type is not None:
+            leaves.append(f'{self_name}.requested_type = {repr(_requested_type)}')
+        _strict = self.strict
+        if _strict is not None:
+            leaves.append(f'{self_name}.strict = {repr(_strict)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer/requested-type'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(node: xml.Node) -> yang.gdata.Container:
@@ -8343,6 +10014,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_container('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()')
+        leaves = []
+        _requested_type = self.requested_type
+        if _requested_type is not None:
+            res.extend(_requested_type.prsrc(f'{self_name}.requested_type', False).splitlines())
+        _always_on = self.always_on
+        if _always_on is not None:
+            leaves.append(f'{self_name}.always_on = {repr(_always_on)}')
+        _bearer_reference = self.bearer_reference
+        if _bearer_reference is not None:
+            leaves.append(f'{self_name}.bearer_reference = {repr(_bearer_reference)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(node: xml.Node) -> yang.gdata.Container:
@@ -8455,6 +10148,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group({repr(self.group_id)})')
+        leaves = []
+        _start_address = self.start_address
+        if _start_address is not None:
+            leaves.append(f'{self_name}.start_address = {repr(_start_address)}')
+        _end_address = self.end_address
+        if _end_address is not None:
+            leaves.append(f'{self_name}.end_address = {repr(_end_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
@@ -8595,6 +10307,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()')
+        leaves = []
+        _address_group = self.address_group
+        for _element in _address_group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'address_group_element = {self_name}.address_group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8659,6 +10391,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _number_of_dynamic_address = self.number_of_dynamic_address
+        if _number_of_dynamic_address is not None:
+            leaves.append(f'{self_name}.number_of_dynamic_address = {repr(_number_of_dynamic_address)}')
+        _customer_addresses = self.customer_addresses
+        if _customer_addresses is not None:
+            res.extend(_customer_addresses.prsrc(f'{self_name}.customer_addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
@@ -8744,6 +10501,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay/customer-dhcp-servers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()')
+        leaves = []
+        _server_ip_address = self.server_ip_address
+        if _server_ip_address is not None:
+            leaves.append(f'{self_name}.server_ip_address = {repr(_server_ip_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay/customer-dhcp-servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8802,6 +10575,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _customer_dhcp_servers = self.customer_dhcp_servers
+        if _customer_dhcp_servers is not None:
+            res.extend(_customer_dhcp_servers.prsrc(f'{self_name}.customer_dhcp_servers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
@@ -8893,6 +10688,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _customer_address = self.customer_address
+        if _customer_address is not None:
+            leaves.append(f'{self_name}.customer_address = {repr(_customer_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8968,6 +10785,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()')
+        leaves = []
+        _address_allocation_type = self.address_allocation_type
+        if _address_allocation_type is not None:
+            leaves.append(f'{self_name}.address_allocation_type = {repr(_address_allocation_type)}')
+        _provider_dhcp = self.provider_dhcp
+        if _provider_dhcp is not None:
+            res.extend(_provider_dhcp.prsrc(f'{self_name}.provider_dhcp', False).splitlines())
+        _dhcp_relay = self.dhcp_relay
+        if _dhcp_relay is not None:
+            res.extend(_dhcp_relay.prsrc(f'{self_name}.dhcp_relay', False).splitlines())
+        _addresses = self.addresses
+        if _addresses is not None:
+            res.extend(_addresses.prsrc(f'{self_name}.addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(node: xml.Node) -> yang.gdata.Container:
@@ -9088,6 +10930,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group({repr(self.group_id)})')
+        leaves = []
+        _start_address = self.start_address
+        if _start_address is not None:
+            leaves.append(f'{self_name}.start_address = {repr(_start_address)}')
+        _end_address = self.end_address
+        if _end_address is not None:
+            leaves.append(f'{self_name}.end_address = {repr(_end_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
@@ -9228,6 +11089,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()')
+        leaves = []
+        _address_group = self.address_group
+        for _element in _address_group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'address_group_element = {self_name}.address_group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9292,6 +11173,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _number_of_dynamic_address = self.number_of_dynamic_address
+        if _number_of_dynamic_address is not None:
+            leaves.append(f'{self_name}.number_of_dynamic_address = {repr(_number_of_dynamic_address)}')
+        _customer_addresses = self.customer_addresses
+        if _customer_addresses is not None:
+            res.extend(_customer_addresses.prsrc(f'{self_name}.customer_addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
@@ -9377,6 +11283,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay/customer-dhcp-servers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()')
+        leaves = []
+        _server_ip_address = self.server_ip_address
+        if _server_ip_address is not None:
+            leaves.append(f'{self_name}.server_ip_address = {repr(_server_ip_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay/customer-dhcp-servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9435,6 +11357,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _customer_dhcp_servers = self.customer_dhcp_servers
+        if _customer_dhcp_servers is not None:
+            res.extend(_customer_dhcp_servers.prsrc(f'{self_name}.customer_dhcp_servers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
@@ -9526,6 +11470,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _customer_address = self.customer_address
+        if _customer_address is not None:
+            leaves.append(f'{self_name}.customer_address = {repr(_customer_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9601,6 +11567,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()')
+        leaves = []
+        _address_allocation_type = self.address_allocation_type
+        if _address_allocation_type is not None:
+            leaves.append(f'{self_name}.address_allocation_type = {repr(_address_allocation_type)}')
+        _provider_dhcp = self.provider_dhcp
+        if _provider_dhcp is not None:
+            res.extend(_provider_dhcp.prsrc(f'{self_name}.provider_dhcp', False).splitlines())
+        _dhcp_relay = self.dhcp_relay
+        if _dhcp_relay is not None:
+            res.extend(_dhcp_relay.prsrc(f'{self_name}.dhcp_relay', False).splitlines())
+        _addresses = self.addresses
+        if _addresses is not None:
+            res.extend(_addresses.prsrc(f'{self_name}.addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(node: xml.Node) -> yang.gdata.Container:
@@ -9700,6 +11691,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam/bfd')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _fixed_value = self.fixed_value
+        if _fixed_value is not None:
+            leaves.append(f'{self_name}.fixed_value = {repr(_fixed_value)}')
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam/bfd'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9761,6 +11774,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_container('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()')
+        leaves = []
+        _bfd = self.bfd
+        if _bfd is not None:
+            res.extend(_bfd.prsrc(f'{self_name}.bfd', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9821,6 +11850,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_container('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_container('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.extend(_ipv4.prsrc(f'{self_name}.ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.extend(_ipv6.prsrc(f'{self_name}.ipv6', False).splitlines())
+        _oam = self.oam
+        if _oam is not None:
+            res.extend(_oam.prsrc(f'{self_name}.oam', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9880,6 +11931,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/authentication')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/authentication'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(node: xml.Node) -> yang.gdata.Container:
@@ -9964,6 +12028,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption/encryption-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()')
+        leaves = []
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        _preshared_key = self.preshared_key
+        if _preshared_key is not None:
+            leaves.append(f'{self_name}.preshared_key = {repr(_preshared_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption/encryption-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10035,6 +12121,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _layer = self.layer
+        if _layer is not None:
+            leaves.append(f'{self_name}.layer = {repr(_layer)}')
+        _encryption_profile = self.encryption_profile
+        if _encryption_profile is not None:
+            res.extend(_encryption_profile.prsrc(f'{self_name}.encryption_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10101,6 +12209,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()')
+        leaves = []
+        _authentication = self.authentication
+        if _authentication is not None:
+            res.extend(_authentication.prsrc(f'{self_name}.authentication', False).splitlines())
+        _encryption = self.encryption
+        if _encryption is not None:
+            res.extend(_encryption.prsrc(f'{self_name}.encryption', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(node: xml.Node) -> yang.gdata.Container:
@@ -10248,6 +12375,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10325,6 +12471,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
@@ -10439,6 +12604,55 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()')
+        leaves = []
+        _dscp = self.dscp
+        if _dscp is not None:
+            leaves.append(f'{self_name}.dscp = {repr(_dscp)}')
+        _dot1p = self.dot1p
+        if _dot1p is not None:
+            leaves.append(f'{self_name}.dot1p = {repr(_dot1p)}')
+        _ipv4_src_prefix = self.ipv4_src_prefix
+        if _ipv4_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_src_prefix = {repr(_ipv4_src_prefix)}')
+        _ipv6_src_prefix = self.ipv6_src_prefix
+        if _ipv6_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_src_prefix = {repr(_ipv6_src_prefix)}')
+        _ipv4_dst_prefix = self.ipv4_dst_prefix
+        if _ipv4_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_dst_prefix = {repr(_ipv4_dst_prefix)}')
+        _ipv6_dst_prefix = self.ipv6_dst_prefix
+        if _ipv6_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_dst_prefix = {repr(_ipv6_dst_prefix)}')
+        _l4_src_port = self.l4_src_port
+        if _l4_src_port is not None:
+            leaves.append(f'{self_name}.l4_src_port = {repr(_l4_src_port)}')
+        _target_sites = self.target_sites
+        if _target_sites is not None:
+            leaves.append(f'{self_name}.target_sites = {repr(_target_sites)}')
+        _l4_src_port_range = self.l4_src_port_range
+        if _l4_src_port_range is not None:
+            res.extend(_l4_src_port_range.prsrc(f'{self_name}.l4_src_port_range', False).splitlines())
+        _l4_dst_port = self.l4_dst_port
+        if _l4_dst_port is not None:
+            leaves.append(f'{self_name}.l4_dst_port = {repr(_l4_dst_port)}')
+        _l4_dst_port_range = self.l4_dst_port_range
+        if _l4_dst_port_range is not None:
+            res.extend(_l4_dst_port_range.prsrc(f'{self_name}.l4_dst_port_range', False).splitlines())
+        _protocol_field = self.protocol_field
+        if _protocol_field is not None:
+            leaves.append(f'{self_name}.protocol_field = {repr(_protocol_field)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
@@ -10581,6 +12795,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule({repr(self.id)})')
+        leaves = []
+        _match_flow = self.match_flow
+        if _match_flow is not None:
+            res.extend(_match_flow.prsrc(f'{self_name}.match_flow', False).splitlines())
+        _match_application = self.match_application
+        if _match_application is not None:
+            leaves.append(f'{self_name}.match_application = {repr(_match_application)}')
+        _target_class_id = self.target_class_id
+        if _target_class_id is not None:
+            leaves.append(f'{self_name}.target_class_id = {repr(_target_class_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
@@ -10727,6 +12963,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()')
+        leaves = []
+        _rule = self.rule
+        for _element in _rule.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rule_element = {self_name}.rule.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rule_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10818,6 +13074,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/latency')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()')
+        leaves = []
+        _use_lowest_latency = self.use_lowest_latency
+        if _use_lowest_latency is not None:
+            leaves.append(f'{self_name}.use_lowest_latency = {repr(_use_lowest_latency)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/latency'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10890,6 +13165,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/jitter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()')
+        leaves = []
+        _use_lowest_jitter = self.use_lowest_jitter
+        if _use_lowest_jitter is not None:
+            leaves.append(f'{self_name}.use_lowest_jitter = {repr(_use_lowest_jitter)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/jitter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10961,6 +13255,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/bandwidth')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth({repr(self.guaranteed_bw_percent)})')
+        leaves = []
+        _end_to_end = self.end_to_end
+        if _end_to_end is not None:
+            leaves.append(f'{self_name}.end_to_end = {repr(_end_to_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/bandwidth'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
@@ -11039,6 +13349,35 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_container('bandwidth')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class')
+            res.append(f'self_bandwidth = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth({repr(self.bandwidth.guaranteed_bw_percent)})')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class({repr(self.class_id)}, self_bandwidth)')
+        leaves = []
+        _direction = self.direction
+        if _direction is not None:
+            leaves.append(f'{self_name}.direction = {repr(_direction)}')
+        _rate_limit = self.rate_limit
+        if _rate_limit is not None:
+            leaves.append(f'{self_name}.rate_limit = {repr(_rate_limit)}')
+        _latency = self.latency
+        if _latency is not None:
+            res.extend(_latency.prsrc(f'{self_name}.latency', False).splitlines())
+        _jitter = self.jitter
+        if _jitter is not None:
+            res.extend(_jitter.prsrc(f'{self_name}.jitter', False).splitlines())
+        _bandwidth = self.bandwidth
+        if _bandwidth is not None:
+            res.extend(_bandwidth.prsrc(f'{self_name}.bandwidth', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
@@ -11197,6 +13536,27 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()')
+        leaves = []
+        _class_ = self.class_
+        for _element in _class_.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class element: {_element.to_gdata().key_str(['class-id'])}")
+            res.append(f'element_bandwidth = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth({repr(_element.bandwidth.guaranteed_bw_percent)})')
+            list_elem = f'class__element = {self_name}.class_.create({repr(_element.class_id)}, element_bandwidth)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'class__element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11251,6 +13611,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()')
+        leaves = []
+        _profile = self.profile
+        if _profile is not None:
+            leaves.append(f'{self_name}.profile = {repr(_profile)}')
+        _classes = self.classes
+        if _classes is not None:
+            res.extend(_classes.prsrc(f'{self_name}.classes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
@@ -11312,6 +13691,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()')
+        leaves = []
+        _qos_classification_policy = self.qos_classification_policy
+        if _qos_classification_policy is not None:
+            res.extend(_qos_classification_policy.prsrc(f'{self_name}.qos_classification_policy', False).splitlines())
+        _qos_profile = self.qos_profile
+        if _qos_profile is not None:
+            res.extend(_qos_profile.prsrc(f'{self_name}.qos_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(node: xml.Node) -> yang.gdata.Container:
@@ -11375,6 +13773,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/carrierscarrier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()')
+        leaves = []
+        _signalling_type = self.signalling_type
+        if _signalling_type is not None:
+            leaves.append(f'{self_name}.signalling_type = {repr(_signalling_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/carrierscarrier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
@@ -11448,6 +13862,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast/multicast-address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            leaves.append(f'{self_name}.ipv4 = {repr(_ipv4)}')
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            leaves.append(f'{self_name}.ipv6 = {repr(_ipv6)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast/multicast-address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11518,6 +13951,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()')
+        leaves = []
+        _multicast_site_type = self.multicast_site_type
+        if _multicast_site_type is not None:
+            leaves.append(f'{self_name}.multicast_site_type = {repr(_multicast_site_type)}')
+        _multicast_address_family = self.multicast_address_family
+        if _multicast_address_family is not None:
+            res.extend(_multicast_address_family.prsrc(f'{self_name}.multicast_address_family', False).splitlines())
+        _protocol_type = self.protocol_type
+        if _protocol_type is not None:
+            leaves.append(f'{self_name}.protocol_type = {repr(_protocol_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -11605,6 +14060,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_int('svc-output-bandwidth'), svc_mtu=n.get_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_container('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service({repr(self.svc_input_bandwidth)}, {repr(self.svc_output_bandwidth)}, {repr(self.svc_mtu)})')
+        leaves = []
+        _qos = self.qos
+        if _qos is not None:
+            res.extend(_qos.prsrc(f'{self_name}.qos', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            res.extend(_carrierscarrier.prsrc(f'{self_name}.carrierscarrier', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(node: xml.Node) -> yang.gdata.Container:
@@ -11726,6 +14203,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link({repr(self.target_site)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -11860,6 +14353,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()')
+        leaves = []
+        _sham_link = self.sham_link
+        for _element in _sham_link.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link element: {_element.to_gdata().key_str(['target-site'])}")
+            list_elem = f'sham_link_element = {self_name}.sham_link.create({repr(_element.target_site)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'sham_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11922,6 +14435,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf({repr(self.area_address)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        _sham_links = self.sham_links
+        if _sham_links is not None:
+            res.extend(_sham_links.prsrc(f'{self_name}.sham_links', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
@@ -12006,6 +14538,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp({repr(self.autonomous_system)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12086,6 +14631,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -12254,6 +14815,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12400,6 +14977,33 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()')
+        leaves = []
+        _ipv4_lan_prefixes = self.ipv4_lan_prefixes
+        for _element in _ipv4_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv4_lan_prefixes_element = {self_name}.ipv4_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv4_lan_prefixes_element', False, list_element=True).splitlines())
+        _ipv6_lan_prefixes = self.ipv6_lan_prefixes
+        for _element in _ipv6_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv6_lan_prefixes_element = {self_name}.ipv6_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv6_lan_prefixes_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12457,6 +15061,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static()')
+        leaves = []
+        _cascaded_lan_prefixes = self.cascaded_lan_prefixes
+        if _cascaded_lan_prefixes is not None:
+            res.extend(_cascaded_lan_prefixes.prsrc(f'{self_name}.cascaded_lan_prefixes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12511,6 +15131,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12563,6 +15196,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_strs('address-family'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
@@ -12660,6 +15306,49 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol({repr(self.type)})')
+        leaves = []
+        _ospf = self.ospf
+        if _ospf is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf')
+            res.append(f'ospf = {self_name}.create_ospf({repr(_ospf.area_address)})')
+            res.extend(_ospf.prsrc('ospf', False).splitlines())
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp')
+            res.append(f'bgp = {self_name}.create_bgp({repr(_bgp.autonomous_system)})')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        _static = self.static
+        if _static is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static')
+            res.append(f'static = {self_name}.create_static()')
+            res.extend(_static.prsrc('static', False).splitlines())
+        _rip = self.rip
+        if _rip is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip')
+            res.append(f'rip = {self_name}.create_rip()')
+            res.extend(_rip.prsrc('rip', False).splitlines())
+        _vrrp = self.vrrp
+        if _vrrp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp')
+            res.append(f'vrrp = {self_name}.create_vrrp()')
+            res.extend(_vrrp.prsrc('vrrp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
@@ -12818,6 +15507,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()')
+        leaves = []
+        _routing_protocol = self.routing_protocol
+        for _element in _routing_protocol.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'routing_protocol_element = {self_name}.routing_protocol.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'routing_protocol_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12873,6 +15582,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/availability')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()')
+        leaves = []
+        _access_priority = self.access_priority
+        if _access_priority is not None:
+            leaves.append(f'{self_name}.access_priority = {repr(_access_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/availability'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(node: xml.Node) -> yang.gdata.Container:
@@ -12950,6 +15675,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_str('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/vpn-attachment')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()')
+        leaves = []
+        _vpn_policy_id = self.vpn_policy_id
+        if _vpn_policy_id is not None:
+            leaves.append(f'{self_name}.vpn_policy_id = {repr(_vpn_policy_id)}')
+        _vpn_id = self.vpn_id
+        if _vpn_id is not None:
+            leaves.append(f'{self_name}.vpn_id = {repr(_vpn_id)}')
+        _site_role = self.site_role
+        if _site_role is not None:
+            leaves.append(f'{self_name}.site_role = {repr(_site_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/vpn-attachment'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(node: xml.Node) -> yang.gdata.Container:
@@ -13064,6 +15811,53 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=n.get_str('site-network-access-id'), site_network_access_type=n.get_opt_str('site-network-access-type'), location_reference=n.get_opt_str('location-reference'), device_reference=n.get_opt_str('device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(n.get_opt_container('access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(n.get_opt_container('bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(n.get_opt_container('ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(n.get_container('service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(n.get_opt_container('availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(n.get_opt_container('vpn-attachment')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access')
+            res.append(f'self_service = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service({repr(self.service.svc_input_bandwidth)}, {repr(self.service.svc_output_bandwidth)}, {repr(self.service.svc_mtu)})')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access({repr(self.site_network_access_id)}, self_service)')
+        leaves = []
+        _site_network_access_type = self.site_network_access_type
+        if _site_network_access_type is not None:
+            leaves.append(f'{self_name}.site_network_access_type = {repr(_site_network_access_type)}')
+        _location_reference = self.location_reference
+        if _location_reference is not None:
+            leaves.append(f'{self_name}.location_reference = {repr(_location_reference)}')
+        _device_reference = self.device_reference
+        if _device_reference is not None:
+            leaves.append(f'{self_name}.device_reference = {repr(_device_reference)}')
+        _access_diversity = self.access_diversity
+        if _access_diversity is not None:
+            res.extend(_access_diversity.prsrc(f'{self_name}.access_diversity', False).splitlines())
+        _bearer = self.bearer
+        if _bearer is not None:
+            res.extend(_bearer.prsrc(f'{self_name}.bearer', False).splitlines())
+        _ip_connection = self.ip_connection
+        if _ip_connection is not None:
+            res.extend(_ip_connection.prsrc(f'{self_name}.ip_connection', False).splitlines())
+        _security = self.security
+        if _security is not None:
+            res.extend(_security.prsrc(f'{self_name}.security', False).splitlines())
+        _service = self.service
+        if _service is not None:
+            res.extend(_service.prsrc(f'{self_name}.service', False).splitlines())
+        _routing_protocols = self.routing_protocols
+        if _routing_protocols is not None:
+            res.extend(_routing_protocols.prsrc(f'{self_name}.routing_protocols', False).splitlines())
+        _availability = self.availability
+        if _availability is not None:
+            res.extend(_availability.prsrc(f'{self_name}.availability', False).splitlines())
+        _vpn_attachment = self.vpn_attachment
+        if _vpn_attachment is not None:
+            res.extend(_vpn_attachment.prsrc(f'{self_name}.vpn_attachment', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
@@ -13258,6 +16052,27 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()')
+        leaves = []
+        _site_network_access = self.site_network_access
+        for _element in _site_network_access.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access element: {_element.to_gdata().key_str(['site-network-access-id'])}")
+            res.append(f'element_service = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service({repr(_element.service.svc_input_bandwidth)}, {repr(_element.service.svc_output_bandwidth)}, {repr(_element.service.svc_mtu)})')
+            list_elem = f'site_network_access_element = {self_name}.site_network_access.create({repr(_element.site_network_access_id)}, element_service)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'site_network_access_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -13375,6 +16190,62 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=n.get_str('site-id'), requested_site_start=n.get_opt_str('requested-site-start'), requested_site_stop=n.get_opt_str('requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(n.get_opt_container('locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(n.get_opt_container('devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(n.get_opt_container('site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(n.get_container('management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(n.get_opt_container('vpn-policies')), site_vpn_flavor=n.get_opt_str('site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(n.get_opt_container('maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(n.get_opt_container('service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(n.get_opt_container('traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(n.get_opt_container('site-network-accesses')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site')
+            res.append(f'self_management = ietf_l3vpn_svc__l3vpn_svc__sites__site__management({repr(self.management.type)})')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site({repr(self.site_id)}, self_management)')
+        leaves = []
+        _requested_site_start = self.requested_site_start
+        if _requested_site_start is not None:
+            leaves.append(f'{self_name}.requested_site_start = {repr(_requested_site_start)}')
+        _requested_site_stop = self.requested_site_stop
+        if _requested_site_stop is not None:
+            leaves.append(f'{self_name}.requested_site_stop = {repr(_requested_site_stop)}')
+        _locations = self.locations
+        if _locations is not None:
+            res.extend(_locations.prsrc(f'{self_name}.locations', False).splitlines())
+        _devices = self.devices
+        if _devices is not None:
+            res.extend(_devices.prsrc(f'{self_name}.devices', False).splitlines())
+        _site_diversity = self.site_diversity
+        if _site_diversity is not None:
+            res.extend(_site_diversity.prsrc(f'{self_name}.site_diversity', False).splitlines())
+        _management = self.management
+        if _management is not None:
+            res.extend(_management.prsrc(f'{self_name}.management', False).splitlines())
+        _vpn_policies = self.vpn_policies
+        if _vpn_policies is not None:
+            res.extend(_vpn_policies.prsrc(f'{self_name}.vpn_policies', False).splitlines())
+        _site_vpn_flavor = self.site_vpn_flavor
+        if _site_vpn_flavor is not None:
+            leaves.append(f'{self_name}.site_vpn_flavor = {repr(_site_vpn_flavor)}')
+        _maximum_routes = self.maximum_routes
+        if _maximum_routes is not None:
+            res.extend(_maximum_routes.prsrc(f'{self_name}.maximum_routes', False).splitlines())
+        _security = self.security
+        if _security is not None:
+            res.extend(_security.prsrc(f'{self_name}.security', False).splitlines())
+        _service = self.service
+        if _service is not None:
+            res.extend(_service.prsrc(f'{self_name}.service', False).splitlines())
+        _traffic_protection = self.traffic_protection
+        if _traffic_protection is not None:
+            res.extend(_traffic_protection.prsrc(f'{self_name}.traffic_protection', False).splitlines())
+        _routing_protocols = self.routing_protocols
+        if _routing_protocols is not None:
+            res.extend(_routing_protocols.prsrc(f'{self_name}.routing_protocols', False).splitlines())
+        _site_network_accesses = self.site_network_accesses
+        if _site_network_accesses is not None:
+            res.extend(_site_network_accesses.prsrc(f'{self_name}.site_network_accesses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
@@ -13587,6 +16458,27 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites()')
+        leaves = []
+        _site = self.site
+        for _element in _site.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site element: {_element.to_gdata().key_str(['site-id'])}")
+            res.append(f'element_management = ietf_l3vpn_svc__l3vpn_svc__sites__site__management({repr(_element.management.type)})')
+            list_elem = f'site_element = {self_name}.site.create({repr(_element.site_id)}, element_management)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'site_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -13646,6 +16538,28 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_container('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_container('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_container('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc()')
+        leaves = []
+        _vpn_profiles = self.vpn_profiles
+        if _vpn_profiles is not None:
+            res.extend(_vpn_profiles.prsrc(f'{self_name}.vpn_profiles', False).splitlines())
+        _vpn_services = self.vpn_services
+        if _vpn_services is not None:
+            res.extend(_vpn_services.prsrc(f'{self_name}.vpn_services', False).splitlines())
+        _sites = self.sites
+        if _sites is not None:
+            res.extend(_sites.prsrc(f'{self_name}.sites', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc(node: xml.Node) -> yang.gdata.Container:
@@ -13715,6 +16629,25 @@ class root(yang.adata.MNode):
         if n != None:
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_container('l3vpn-svc')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _netinfra = self.netinfra
+        if _netinfra is not None:
+            res.extend(_netinfra.prsrc(f'{self_name}.netinfra', False).splitlines())
+        _l3vpn_svc = self.l3vpn_svc
+        if _l3vpn_svc is not None:
+            res.extend(_l3vpn_svc.prsrc(f'{self_name}.l3vpn_svc', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_0_loose.act
+++ b/src/respnet/layers/y_0_loose.act
@@ -75,6 +75,31 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router')
+            res.append(f'{self_name} = netinfra__netinfra__router({repr(self.name)})')
+        leaves = []
+        _id = self.id
+        if _id is not None:
+            leaves.append(f'{self_name}.id = {repr(_id)}')
+        _role = self.role
+        if _role is not None:
+            leaves.append(f'{self_name}.role = {repr(_role)}')
+        _asn = self.asn
+        if _asn is not None:
+            leaves.append(f'{self_name}.asn = {repr(_asn)}')
+        _mock = self.mock
+        if _mock is not None:
+            leaves.append(f'{self_name}.mock = {repr(_mock)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -263,6 +288,19 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__backbone_link_entry:
         return netinfra__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/backbone-link')
+            res.append(f'{self_name} = netinfra__netinfra__backbone_link({repr(self.left_router)}, {repr(self.left_interface)}, {repr(self.right_router)}, {repr(self.right_interface)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/backbone-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -419,6 +457,33 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra')
+            res.append(f'{self_name} = netinfra__netinfra()')
+        leaves = []
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        _backbone_link = self.backbone_link
+        for _element in _backbone_link.elements:
+            res.append('')
+            res.append(f"# List /netinfra/backbone-link element: {_element.to_gdata().key_str(['left-router', 'left-interface', 'right-router', 'right-interface'])}")
+            list_elem = f'backbone_link_element = {self_name}.backbone_link.create({repr(_element.left_router)}, {repr(_element.left_interface)}, {repr(_element.right_router)}, {repr(_element.right_interface)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra__netinfra(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -479,6 +544,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=n.get_str('id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
@@ -611,6 +689,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=n.get_str('id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -742,6 +833,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=n.get_str('id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -872,6 +976,19 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=n.get_str('id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier({repr(self.id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
@@ -1015,6 +1132,47 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles/valid-provider-identifiers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()')
+        leaves = []
+        _cloud_identifier = self.cloud_identifier
+        for _element in _cloud_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/cloud-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'cloud_identifier_element = {self_name}.cloud_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'cloud_identifier_element', False, list_element=True).splitlines())
+        _encryption_profile_identifier = self.encryption_profile_identifier
+        for _element in _encryption_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/encryption-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'encryption_profile_identifier_element = {self_name}.encryption_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'encryption_profile_identifier_element', False, list_element=True).splitlines())
+        _qos_profile_identifier = self.qos_profile_identifier
+        for _element in _qos_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/qos-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'qos_profile_identifier_element = {self_name}.qos_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'qos_profile_identifier_element', False, list_element=True).splitlines())
+        _bfd_profile_identifier = self.bfd_profile_identifier
+        for _element in _bfd_profile_identifier.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-profiles/valid-provider-identifiers/bfd-profile-identifier element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'bfd_profile_identifier_element = {self_name}.bfd_profile_identifier.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'bfd_profile_identifier_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles/valid-provider-identifiers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1085,6 +1243,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_container('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-profiles')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()')
+        leaves = []
+        _valid_provider_identifiers = self.valid_provider_identifiers
+        if _valid_provider_identifiers is not None:
+            res.extend(_valid_provider_identifiers.prsrc(f'{self_name}.valid_provider_identifiers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-profiles'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(node: xml.Node) -> yang.gdata.Container:
@@ -1195,6 +1369,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation/nat44')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _nat44_customer_address = self.nat44_customer_address
+        if _nat44_customer_address is not None:
+            leaves.append(f'{self_name}.nat44_customer_address = {repr(_nat44_customer_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation/nat44'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1249,6 +1442,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_container('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()')
+        leaves = []
+        _nat44 = self.nat44
+        if _nat44 is not None:
+            res.extend(_nat44.prsrc(f'{self_name}.nat44', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access/address-translation'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(node: xml.Node) -> yang.gdata.Container:
@@ -1313,6 +1522,31 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=n.get_str('cloud-identifier'), permit_any=n.get_opt_bool('permit-any'), permit_site=n.get_opt_strs('permit-site'), deny_site=n.get_opt_strs('deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(n.get_opt_container('address-translation')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access({repr(self.cloud_identifier)})')
+        leaves = []
+        _permit_any = self.permit_any
+        if _permit_any is not None:
+            leaves.append(f'{self_name}.permit_any = {repr(_permit_any)}')
+        _permit_site = self.permit_site
+        if _permit_site is not None:
+            leaves.append(f'{self_name}.permit_site = {repr(_permit_site)}')
+        _deny_site = self.deny_site
+        if _deny_site is not None:
+            leaves.append(f'{self_name}.deny_site = {repr(_deny_site)}')
+        _address_translation = self.address_translation
+        if _address_translation is not None:
+            res.extend(_address_translation.prsrc(f'{self_name}.address_translation', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
@@ -1465,6 +1699,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()')
+        leaves = []
+        _cloud_access = self.cloud_access
+        for _element in _cloud_access.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/cloud-accesses/cloud-access element: {_element.to_gdata().key_str(['cloud-identifier'])}")
+            list_elem = f'cloud_access_element = {self_name}.cloud_access.create({repr(_element.cloud_identifier)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'cloud_access_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/cloud-accesses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1524,6 +1778,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_strs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/customer-tree-flavors')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()')
+        leaves = []
+        _tree_flavor = self.tree_flavor
+        if _tree_flavor is not None:
+            leaves.append(f'{self_name}.tree_flavor = {repr(_tree_flavor)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/customer-tree-flavors'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(node: xml.Node) -> yang.gdata.Container:
@@ -1607,6 +1877,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/provider-managed')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _rp_redundancy = self.rp_redundancy
+        if _rp_redundancy is not None:
+            leaves.append(f'{self_name}.rp_redundancy = {repr(_rp_redundancy)}')
+        _optimal_traffic_delivery = self.optimal_traffic_delivery
+        if _optimal_traffic_delivery is not None:
+            leaves.append(f'{self_name}.optimal_traffic_delivery = {repr(_optimal_traffic_delivery)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/provider-managed'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(node: xml.Node) -> yang.gdata.Container:
@@ -1711,6 +2003,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=n.get_int('id'), group_address=n.get_opt_str('group-address'), group_start=n.get_opt_str('group-start'), group_end=n.get_opt_str('group-end'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group({repr(self.id)})')
+        leaves = []
+        _group_address = self.group_address
+        if _group_address is not None:
+            leaves.append(f'{self_name}.group_address = {repr(_group_address)}')
+        _group_start = self.group_start
+        if _group_start is not None:
+            leaves.append(f'{self_name}.group_start = {repr(_group_start)}')
+        _group_end = self.group_end
+        if _group_end is not None:
+            leaves.append(f'{self_name}.group_end = {repr(_group_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
@@ -1857,6 +2171,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups/group element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1919,6 +2253,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=n.get_int('id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(n.get_opt_container('provider-managed')), rp_address=n.get_opt_str('rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(n.get_opt_container('groups')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping({repr(self.id)})')
+        leaves = []
+        _provider_managed = self.provider_managed
+        if _provider_managed is not None:
+            res.extend(_provider_managed.prsrc(f'{self_name}.provider_managed', False).splitlines())
+        _rp_address = self.rp_address
+        if _rp_address is not None:
+            leaves.append(f'{self_name}.rp_address = {repr(_rp_address)}')
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
@@ -2065,6 +2421,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()')
+        leaves = []
+        _rp_group_mapping = self.rp_group_mapping
+        for _element in _rp_group_mapping.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings/rp-group-mapping element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rp_group_mapping_element = {self_name}.rp_group_mapping.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rp_group_mapping_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-group-mappings'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2125,6 +2501,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery/bsr-candidates')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()')
+        leaves = []
+        _bsr_candidate_address = self.bsr_candidate_address
+        if _bsr_candidate_address is not None:
+            leaves.append(f'{self_name}.bsr_candidate_address = {repr(_bsr_candidate_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery/bsr-candidates'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2178,6 +2570,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_str('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_container('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()')
+        leaves = []
+        _rp_discovery_type = self.rp_discovery_type
+        if _rp_discovery_type is not None:
+            leaves.append(f'{self_name}.rp_discovery_type = {repr(_rp_discovery_type)}')
+        _bsr_candidates = self.bsr_candidates
+        if _bsr_candidates is not None:
+            res.extend(_bsr_candidates.prsrc(f'{self_name}.bsr_candidates', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp/rp-discovery'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(node: xml.Node) -> yang.gdata.Container:
@@ -2239,6 +2650,25 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_container('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_container('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast/rp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()')
+        leaves = []
+        _rp_group_mappings = self.rp_group_mappings
+        if _rp_group_mappings is not None:
+            res.extend(_rp_group_mappings.prsrc(f'{self_name}.rp_group_mappings', False).splitlines())
+        _rp_discovery = self.rp_discovery
+        if _rp_discovery is not None:
+            res.extend(_rp_discovery.prsrc(f'{self_name}.rp_discovery', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast/rp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(node: xml.Node) -> yang.gdata.Container:
@@ -2306,6 +2736,28 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_container('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_container('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _customer_tree_flavors = self.customer_tree_flavors
+        if _customer_tree_flavors is not None:
+            res.extend(_customer_tree_flavors.prsrc(f'{self_name}.customer_tree_flavors', False).splitlines())
+        _rp = self.rp
+        if _rp is not None:
+            res.extend(_rp.prsrc(f'{self_name}.rp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -2390,6 +2842,22 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=n.get_str('vpn-id'), local_sites_role=n.get_opt_str('local-sites-role'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn({repr(self.vpn_id)})')
+        leaves = []
+        _local_sites_role = self.local_sites_role
+        if _local_sites_role is not None:
+            leaves.append(f'{self_name}.local_sites_role = {repr(_local_sites_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
@@ -2524,6 +2992,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()')
+        leaves = []
+        _extranet_vpn = self.extranet_vpn
+        for _element in _extranet_vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service/extranet-vpns/extranet-vpn element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'extranet_vpn_element = {self_name}.extranet_vpn.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'extranet_vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service/extranet-vpns'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2601,6 +3089,37 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=n.get_str('vpn-id'), customer_name=n.get_opt_str('customer-name'), vpn_service_topology=n.get_opt_str('vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(n.get_opt_container('cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(n.get_opt_container('multicast')), carrierscarrier=n.get_opt_bool('carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(n.get_opt_container('extranet-vpns')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services/vpn-service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service({repr(self.vpn_id)})')
+        leaves = []
+        _customer_name = self.customer_name
+        if _customer_name is not None:
+            leaves.append(f'{self_name}.customer_name = {repr(_customer_name)}')
+        _vpn_service_topology = self.vpn_service_topology
+        if _vpn_service_topology is not None:
+            leaves.append(f'{self_name}.vpn_service_topology = {repr(_vpn_service_topology)}')
+        _cloud_accesses = self.cloud_accesses
+        if _cloud_accesses is not None:
+            res.extend(_cloud_accesses.prsrc(f'{self_name}.cloud_accesses', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            leaves.append(f'{self_name}.carrierscarrier = {repr(_carrierscarrier)}')
+        _extranet_vpns = self.extranet_vpns
+        if _extranet_vpns is not None:
+            res.extend(_extranet_vpns.prsrc(f'{self_name}.extranet_vpns', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services/vpn-service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
@@ -2765,6 +3284,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/vpn-services')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__vpn_services()')
+        leaves = []
+        _vpn_service = self.vpn_service
+        for _element in _vpn_service.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/vpn-services/vpn-service element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'vpn_service_element = {self_name}.vpn_service.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_service_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/vpn-services'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2891,6 +3430,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=n.get_str('location-id'), address=n.get_opt_str('address'), postal_code=n.get_opt_str('postal-code'), state=n.get_opt_str('state'), city=n.get_opt_str('city'), country_code=n.get_opt_str('country-code'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/locations/location')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location({repr(self.location_id)})')
+        leaves = []
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        _postal_code = self.postal_code
+        if _postal_code is not None:
+            leaves.append(f'{self_name}.postal_code = {repr(_postal_code)}')
+        _state = self.state
+        if _state is not None:
+            leaves.append(f'{self_name}.state = {repr(_state)}')
+        _city = self.city
+        if _city is not None:
+            leaves.append(f'{self_name}.city = {repr(_city)}')
+        _country_code = self.country_code
+        if _country_code is not None:
+            leaves.append(f'{self_name}.country_code = {repr(_country_code)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/locations/location'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
@@ -3049,6 +3616,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/locations')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()')
+        leaves = []
+        _location = self.location
+        for _element in _location.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/locations/location element: {_element.to_gdata().key_str(['location-id'])}")
+            list_elem = f'location_element = {self_name}.location.create({repr(_element.location_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'location_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/locations'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3128,6 +3715,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_opt_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices/device/management')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices/device/management'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3190,6 +3796,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=n.get_str('device-id'), location=n.get_opt_str('location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(n.get_opt_container('management')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices/device')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device({repr(self.device_id)})')
+        leaves = []
+        _location = self.location
+        if _location is not None:
+            leaves.append(f'{self_name}.location = {repr(_location)}')
+        _management = self.management
+        if _management is not None:
+            res.extend(_management.prsrc(f'{self_name}.management', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices/device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
@@ -3330,6 +3955,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/devices')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/devices/device element: {_element.to_gdata().key_str(['device-id'])}")
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.device_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/devices'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3383,6 +4028,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
@@ -3511,6 +4169,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-diversity/groups/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3560,6 +4238,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_container('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-diversity')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()')
+        leaves = []
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-diversity'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(node: xml.Node) -> yang.gdata.Container:
@@ -3616,6 +4310,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_opt_str('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/management')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__management()')
+        leaves = []
+        _type = self.type
+        if _type is not None:
+            leaves.append(f'{self_name}.type = {repr(_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/management'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(node: xml.Node) -> yang.gdata.Container:
@@ -3708,6 +4418,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=n.get_str('type'), lan_tag=n.get_opt_strs('lan-tag'), ipv4_lan_prefix=n.get_opt_strs('ipv4-lan-prefix'), ipv6_lan_prefix=n.get_opt_strs('ipv6-lan-prefix'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter({repr(self.type)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        _ipv4_lan_prefix = self.ipv4_lan_prefix
+        if _ipv4_lan_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_lan_prefix = {repr(_ipv4_lan_prefix)}')
+        _ipv6_lan_prefix = self.ipv6_lan_prefix
+        if _ipv6_lan_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_lan_prefix = {repr(_ipv6_lan_prefix)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
@@ -3854,6 +4586,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()')
+        leaves = []
+        _filter = self.filter
+        for _element in _filter.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters/filter element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'filter_element = {self_name}.filter.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'filter_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/filters'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3918,6 +4670,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=n.get_str('vpn-id'), site_role=n.get_opt_str('site-role'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn({repr(self.vpn_id)})')
+        leaves = []
+        _site_role = self.site_role
+        if _site_role is not None:
+            leaves.append(f'{self_name}.site_role = {repr(_site_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
@@ -4059,6 +4827,29 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=n.get_str('id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(n.get_opt_container('filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_gdata(n.get_opt_list('vpn')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries({repr(self.id)})')
+        leaves = []
+        _filters = self.filters
+        if _filters is not None:
+            res.extend(_filters.prsrc(f'{self_name}.filters', False).splitlines())
+        _vpn = self.vpn
+        for _element in _vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries/vpn element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'vpn_element = {self_name}.vpn.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
@@ -4202,6 +4993,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=n.get_str('vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_gdata(n.get_opt_list('entries')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies/vpn-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy({repr(self.vpn_policy_id)})')
+        leaves = []
+        _entries = self.entries
+        for _element in _entries.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy/entries element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'entries_element = {self_name}.entries.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'entries_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies/vpn-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -4335,6 +5146,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/vpn-policies')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()')
+        leaves = []
+        _vpn_policy = self.vpn_policy
+        for _element in _vpn_policy.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/vpn-policies/vpn-policy element: {_element.to_gdata().key_str(['vpn-policy-id'])}")
+            list_elem = f'vpn_policy_element = {self_name}.vpn_policy.create({repr(_element.vpn_policy_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vpn_policy_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/vpn-policies'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4405,6 +5236,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=n.get_str('af'), maximum_routes=n.get_opt_int('maximum-routes'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/maximum-routes/address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family({repr(self.af)})')
+        leaves = []
+        _maximum_routes = self.maximum_routes
+        if _maximum_routes is not None:
+            leaves.append(f'{self_name}.maximum_routes = {repr(_maximum_routes)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/maximum-routes/address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
@@ -4539,6 +5386,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/maximum-routes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()')
+        leaves = []
+        _address_family = self.address_family
+        for _element in _address_family.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/maximum-routes/address-family element: {_element.to_gdata().key_str(['af'])}")
+            list_elem = f'address_family_element = {self_name}.address_family.create({repr(_element.af)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_family_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/maximum-routes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4584,6 +5451,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/authentication')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/authentication'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(node: xml.Node) -> yang.gdata.Container:
@@ -4668,6 +5548,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/encryption/encryption-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()')
+        leaves = []
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        _preshared_key = self.preshared_key
+        if _preshared_key is not None:
+            leaves.append(f'{self_name}.preshared_key = {repr(_preshared_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/encryption/encryption-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4739,6 +5641,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security/encryption')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _layer = self.layer
+        if _layer is not None:
+            leaves.append(f'{self_name}.layer = {repr(_layer)}')
+        _encryption_profile = self.encryption_profile
+        if _encryption_profile is not None:
+            res.extend(_encryption_profile.prsrc(f'{self_name}.encryption_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security/encryption'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -4805,6 +5729,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/security')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__security()')
+        leaves = []
+        _authentication = self.authentication
+        if _authentication is not None:
+            res.extend(_authentication.prsrc(f'{self_name}.authentication', False).splitlines())
+        _encryption = self.encryption
+        if _encryption is not None:
+            res.extend(_encryption.prsrc(f'{self_name}.encryption', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/security'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(node: xml.Node) -> yang.gdata.Container:
@@ -4934,6 +5877,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5011,6 +5973,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
@@ -5125,6 +6106,55 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()')
+        leaves = []
+        _dscp = self.dscp
+        if _dscp is not None:
+            leaves.append(f'{self_name}.dscp = {repr(_dscp)}')
+        _dot1p = self.dot1p
+        if _dot1p is not None:
+            leaves.append(f'{self_name}.dot1p = {repr(_dot1p)}')
+        _ipv4_src_prefix = self.ipv4_src_prefix
+        if _ipv4_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_src_prefix = {repr(_ipv4_src_prefix)}')
+        _ipv6_src_prefix = self.ipv6_src_prefix
+        if _ipv6_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_src_prefix = {repr(_ipv6_src_prefix)}')
+        _ipv4_dst_prefix = self.ipv4_dst_prefix
+        if _ipv4_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_dst_prefix = {repr(_ipv4_dst_prefix)}')
+        _ipv6_dst_prefix = self.ipv6_dst_prefix
+        if _ipv6_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_dst_prefix = {repr(_ipv6_dst_prefix)}')
+        _l4_src_port = self.l4_src_port
+        if _l4_src_port is not None:
+            leaves.append(f'{self_name}.l4_src_port = {repr(_l4_src_port)}')
+        _target_sites = self.target_sites
+        if _target_sites is not None:
+            leaves.append(f'{self_name}.target_sites = {repr(_target_sites)}')
+        _l4_src_port_range = self.l4_src_port_range
+        if _l4_src_port_range is not None:
+            res.extend(_l4_src_port_range.prsrc(f'{self_name}.l4_src_port_range', False).splitlines())
+        _l4_dst_port = self.l4_dst_port
+        if _l4_dst_port is not None:
+            leaves.append(f'{self_name}.l4_dst_port = {repr(_l4_dst_port)}')
+        _l4_dst_port_range = self.l4_dst_port_range
+        if _l4_dst_port_range is not None:
+            res.extend(_l4_dst_port_range.prsrc(f'{self_name}.l4_dst_port_range', False).splitlines())
+        _protocol_field = self.protocol_field
+        if _protocol_field is not None:
+            leaves.append(f'{self_name}.protocol_field = {repr(_protocol_field)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule/match-flow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
@@ -5267,6 +6297,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule({repr(self.id)})')
+        leaves = []
+        _match_flow = self.match_flow
+        if _match_flow is not None:
+            res.extend(_match_flow.prsrc(f'{self_name}.match_flow', False).splitlines())
+        _match_application = self.match_application
+        if _match_application is not None:
+            leaves.append(f'{self_name}.match_application = {repr(_match_application)}')
+        _target_class_id = self.target_class_id
+        if _target_class_id is not None:
+            leaves.append(f'{self_name}.target_class_id = {repr(_target_class_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
@@ -5413,6 +6465,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-classification-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()')
+        leaves = []
+        _rule = self.rule
+        for _element in _rule.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/service/qos/qos-classification-policy/rule element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rule_element = {self_name}.rule.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rule_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-classification-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5504,6 +6576,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/latency')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()')
+        leaves = []
+        _use_lowest_latency = self.use_lowest_latency
+        if _use_lowest_latency is not None:
+            leaves.append(f'{self_name}.use_lowest_latency = {repr(_use_lowest_latency)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/latency'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5576,6 +6667,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/jitter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()')
+        leaves = []
+        _use_lowest_jitter = self.use_lowest_jitter
+        if _use_lowest_jitter is not None:
+            leaves.append(f'{self_name}.use_lowest_jitter = {repr(_use_lowest_jitter)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/jitter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5647,6 +6757,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/bandwidth')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth()')
+        leaves = []
+        _guaranteed_bw_percent = self.guaranteed_bw_percent
+        if _guaranteed_bw_percent is not None:
+            leaves.append(f'{self_name}.guaranteed_bw_percent = {repr(_guaranteed_bw_percent)}')
+        _end_to_end = self.end_to_end
+        if _end_to_end is not None:
+            leaves.append(f'{self_name}.end_to_end = {repr(_end_to_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class/bandwidth'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
@@ -5725,6 +6854,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_opt_container('bandwidth')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class({repr(self.class_id)})')
+        leaves = []
+        _direction = self.direction
+        if _direction is not None:
+            leaves.append(f'{self_name}.direction = {repr(_direction)}')
+        _rate_limit = self.rate_limit
+        if _rate_limit is not None:
+            leaves.append(f'{self_name}.rate_limit = {repr(_rate_limit)}')
+        _latency = self.latency
+        if _latency is not None:
+            res.extend(_latency.prsrc(f'{self_name}.latency', False).splitlines())
+        _jitter = self.jitter
+        if _jitter is not None:
+            res.extend(_jitter.prsrc(f'{self_name}.jitter', False).splitlines())
+        _bandwidth = self.bandwidth
+        if _bandwidth is not None:
+            res.extend(_bandwidth.prsrc(f'{self_name}.bandwidth', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
@@ -5883,6 +7040,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile/classes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()')
+        leaves = []
+        _class_ = self.class_
+        for _element in _class_.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/service/qos/qos-profile/classes/class element: {_element.to_gdata().key_str(['class-id'])}")
+            list_elem = f'class__element = {self_name}.class_.create({repr(_element.class_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'class__element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile/classes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -5937,6 +7114,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos/qos-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()')
+        leaves = []
+        _profile = self.profile
+        if _profile is not None:
+            leaves.append(f'{self_name}.profile = {repr(_profile)}')
+        _classes = self.classes
+        if _classes is not None:
+            res.extend(_classes.prsrc(f'{self_name}.classes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos/qos-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
@@ -5998,6 +7194,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/qos')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()')
+        leaves = []
+        _qos_classification_policy = self.qos_classification_policy
+        if _qos_classification_policy is not None:
+            res.extend(_qos_classification_policy.prsrc(f'{self_name}.qos_classification_policy', False).splitlines())
+        _qos_profile = self.qos_profile
+        if _qos_profile is not None:
+            res.extend(_qos_profile.prsrc(f'{self_name}.qos_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/qos'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(node: xml.Node) -> yang.gdata.Container:
@@ -6061,6 +7276,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/carrierscarrier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()')
+        leaves = []
+        _signalling_type = self.signalling_type
+        if _signalling_type is not None:
+            leaves.append(f'{self_name}.signalling_type = {repr(_signalling_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/carrierscarrier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
@@ -6134,6 +7365,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/multicast/multicast-address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            leaves.append(f'{self_name}.ipv4 = {repr(_ipv4)}')
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            leaves.append(f'{self_name}.ipv6 = {repr(_ipv6)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/multicast/multicast-address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6204,6 +7454,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()')
+        leaves = []
+        _multicast_site_type = self.multicast_site_type
+        if _multicast_site_type is not None:
+            leaves.append(f'{self_name}.multicast_site_type = {repr(_multicast_site_type)}')
+        _multicast_address_family = self.multicast_address_family
+        if _multicast_address_family is not None:
+            res.extend(_multicast_address_family.prsrc(f'{self_name}.multicast_address_family', False).splitlines())
+        _protocol_type = self.protocol_type
+        if _protocol_type is not None:
+            leaves.append(f'{self_name}.protocol_type = {repr(_protocol_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -6277,6 +7549,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_container('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__service()')
+        leaves = []
+        _qos = self.qos
+        if _qos is not None:
+            res.extend(_qos.prsrc(f'{self_name}.qos', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            res.extend(_carrierscarrier.prsrc(f'{self_name}.carrierscarrier', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6346,6 +7640,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/traffic-protection')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/traffic-protection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(node: xml.Node) -> yang.gdata.Container:
@@ -6434,6 +7744,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link({repr(self.target_site)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -6568,6 +7894,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()')
+        leaves = []
+        _sham_link = self.sham_link
+        for _element in _sham_link.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links/sham-link element: {_element.to_gdata().key_str(['target-site'])}")
+            list_elem = f'sham_link_element = {self_name}.sham_link.create({repr(_element.target_site)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'sham_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf/sham-links'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6630,6 +7976,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        _area_address = self.area_address
+        if _area_address is not None:
+            leaves.append(f'{self_name}.area_address = {repr(_area_address)}')
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        _sham_links = self.sham_links
+        if _sham_links is not None:
+            res.extend(_sham_links.prsrc(f'{self_name}.sham_links', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
@@ -6714,6 +8085,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp()')
+        leaves = []
+        _autonomous_system = self.autonomous_system
+        if _autonomous_system is not None:
+            leaves.append(f'{self_name}.autonomous_system = {repr(_autonomous_system)}')
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -6794,6 +8184,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -6962,6 +8368,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -7108,6 +8530,33 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()')
+        leaves = []
+        _ipv4_lan_prefixes = self.ipv4_lan_prefixes
+        for _element in _ipv4_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv4_lan_prefixes_element = {self_name}.ipv4_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv4_lan_prefixes_element', False, list_element=True).splitlines())
+        _ipv6_lan_prefixes = self.ipv6_lan_prefixes
+        for _element in _ipv6_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv6_lan_prefixes_element = {self_name}.ipv6_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv6_lan_prefixes_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static/cascaded-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7165,6 +8614,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static()')
+        leaves = []
+        _cascaded_lan_prefixes = self.cascaded_lan_prefixes
+        if _cascaded_lan_prefixes is not None:
+            res.extend(_cascaded_lan_prefixes.prsrc(f'{self_name}.cascaded_lan_prefixes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7219,6 +8684,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7271,6 +8752,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
@@ -7368,6 +8865,49 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols/routing-protocol')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol({repr(self.type)})')
+        leaves = []
+        _ospf = self.ospf
+        if _ospf is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/ospf')
+            res.append(f'ospf = {self_name}.create_ospf()')
+            res.extend(_ospf.prsrc('ospf', False).splitlines())
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/bgp')
+            res.append(f'bgp = {self_name}.create_bgp()')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        _static = self.static
+        if _static is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/static')
+            res.append(f'static = {self_name}.create_static()')
+            res.extend(_static.prsrc('static', False).splitlines())
+        _rip = self.rip
+        if _rip is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/rip')
+            res.append(f'rip = {self_name}.create_rip()')
+            res.extend(_rip.prsrc('rip', False).splitlines())
+        _vrrp = self.vrrp
+        if _vrrp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol/vrrp')
+            res.append(f'vrrp = {self_name}.create_vrrp()')
+            res.extend(_vrrp.prsrc('vrrp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols/routing-protocol'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
@@ -7526,6 +9066,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/routing-protocols')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()')
+        leaves = []
+        _routing_protocol = self.routing_protocol
+        for _element in _routing_protocol.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/routing-protocols/routing-protocol element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'routing_protocol_element = {self_name}.routing_protocol.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'routing_protocol_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/routing-protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7603,6 +9163,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
@@ -7731,6 +9304,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/groups'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -7790,6 +9383,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=n.get_str('group-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group({repr(self.group_id)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
@@ -7940,6 +9546,32 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_bool('all-other-accesses'), all_other_groups=n.get_opt_bool('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()')
+        leaves = []
+        _group = self.group
+        for _element in _group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target/group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'group_element = {self_name}.group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'group_element', False, list_element=True).splitlines())
+        _all_other_accesses = self.all_other_accesses
+        if _all_other_accesses is not None:
+            leaves.append(f'{self_name}.all_other_accesses = {repr(_all_other_accesses)}')
+        _all_other_groups = self.all_other_groups
+        if _all_other_groups is not None:
+            leaves.append(f'{self_name}.all_other_groups = {repr(_all_other_groups)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint/target'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8004,6 +9636,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=n.get_str('constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(n.get_opt_container('target')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint({repr(self.constraint_type)})')
+        leaves = []
+        _target = self.target
+        if _target is not None:
+            res.extend(_target.prsrc(f'{self_name}.target', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
@@ -8138,6 +9786,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()')
+        leaves = []
+        _constraint = self.constraint
+        for _element in _constraint.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints/constraint element: {_element.to_gdata().key_str(['constraint-type'])}")
+            list_elem = f'constraint_element = {self_name}.constraint.create({repr(_element.constraint_type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'constraint_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity/constraints'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8192,6 +9860,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_container('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_container('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()')
+        leaves = []
+        _groups = self.groups
+        if _groups is not None:
+            res.extend(_groups.prsrc(f'{self_name}.groups', False).splitlines())
+        _constraints = self.constraints
+        if _constraints is not None:
+            res.extend(_constraints.prsrc(f'{self_name}.constraints', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/access-diversity'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(node: xml.Node) -> yang.gdata.Container:
@@ -8266,6 +9953,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer/requested-type')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()')
+        leaves = []
+        _requested_type = self.requested_type
+        if _requested_type is not None:
+            leaves.append(f'{self_name}.requested_type = {repr(_requested_type)}')
+        _strict = self.strict
+        if _strict is not None:
+            leaves.append(f'{self_name}.strict = {repr(_strict)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer/requested-type'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(node: xml.Node) -> yang.gdata.Container:
@@ -8343,6 +10049,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_container('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()')
+        leaves = []
+        _requested_type = self.requested_type
+        if _requested_type is not None:
+            res.extend(_requested_type.prsrc(f'{self_name}.requested_type', False).splitlines())
+        _always_on = self.always_on
+        if _always_on is not None:
+            leaves.append(f'{self_name}.always_on = {repr(_always_on)}')
+        _bearer_reference = self.bearer_reference
+        if _bearer_reference is not None:
+            leaves.append(f'{self_name}.bearer_reference = {repr(_bearer_reference)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/bearer'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(node: xml.Node) -> yang.gdata.Container:
@@ -8455,6 +10183,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group({repr(self.group_id)})')
+        leaves = []
+        _start_address = self.start_address
+        if _start_address is not None:
+            leaves.append(f'{self_name}.start_address = {repr(_start_address)}')
+        _end_address = self.end_address
+        if _end_address is not None:
+            leaves.append(f'{self_name}.end_address = {repr(_end_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
@@ -8595,6 +10342,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()')
+        leaves = []
+        _address_group = self.address_group
+        for _element in _address_group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses/address-group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'address_group_element = {self_name}.address_group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp/customer-addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8659,6 +10426,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _number_of_dynamic_address = self.number_of_dynamic_address
+        if _number_of_dynamic_address is not None:
+            leaves.append(f'{self_name}.number_of_dynamic_address = {repr(_number_of_dynamic_address)}')
+        _customer_addresses = self.customer_addresses
+        if _customer_addresses is not None:
+            res.extend(_customer_addresses.prsrc(f'{self_name}.customer_addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/provider-dhcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
@@ -8744,6 +10536,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay/customer-dhcp-servers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()')
+        leaves = []
+        _server_ip_address = self.server_ip_address
+        if _server_ip_address is not None:
+            leaves.append(f'{self_name}.server_ip_address = {repr(_server_ip_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay/customer-dhcp-servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8802,6 +10610,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _customer_dhcp_servers = self.customer_dhcp_servers
+        if _customer_dhcp_servers is not None:
+            res.extend(_customer_dhcp_servers.prsrc(f'{self_name}.customer_dhcp_servers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/dhcp-relay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
@@ -8893,6 +10723,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _customer_address = self.customer_address
+        if _customer_address is not None:
+            leaves.append(f'{self_name}.customer_address = {repr(_customer_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4/addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -8968,6 +10820,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()')
+        leaves = []
+        _address_allocation_type = self.address_allocation_type
+        if _address_allocation_type is not None:
+            leaves.append(f'{self_name}.address_allocation_type = {repr(_address_allocation_type)}')
+        _provider_dhcp = self.provider_dhcp
+        if _provider_dhcp is not None:
+            res.extend(_provider_dhcp.prsrc(f'{self_name}.provider_dhcp', False).splitlines())
+        _dhcp_relay = self.dhcp_relay
+        if _dhcp_relay is not None:
+            res.extend(_dhcp_relay.prsrc(f'{self_name}.dhcp_relay', False).splitlines())
+        _addresses = self.addresses
+        if _addresses is not None:
+            res.extend(_addresses.prsrc(f'{self_name}.addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv4'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(node: xml.Node) -> yang.gdata.Container:
@@ -9088,6 +10965,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group({repr(self.group_id)})')
+        leaves = []
+        _start_address = self.start_address
+        if _start_address is not None:
+            leaves.append(f'{self_name}.start_address = {repr(_start_address)}')
+        _end_address = self.end_address
+        if _end_address is not None:
+            leaves.append(f'{self_name}.end_address = {repr(_end_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
@@ -9228,6 +11124,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()')
+        leaves = []
+        _address_group = self.address_group
+        for _element in _address_group.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses/address-group element: {_element.to_gdata().key_str(['group-id'])}")
+            list_elem = f'address_group_element = {self_name}.address_group.create({repr(_element.group_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_group_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp/customer-addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9292,6 +11208,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _number_of_dynamic_address = self.number_of_dynamic_address
+        if _number_of_dynamic_address is not None:
+            leaves.append(f'{self_name}.number_of_dynamic_address = {repr(_number_of_dynamic_address)}')
+        _customer_addresses = self.customer_addresses
+        if _customer_addresses is not None:
+            res.extend(_customer_addresses.prsrc(f'{self_name}.customer_addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/provider-dhcp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
@@ -9377,6 +11318,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay/customer-dhcp-servers')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()')
+        leaves = []
+        _server_ip_address = self.server_ip_address
+        if _server_ip_address is not None:
+            leaves.append(f'{self_name}.server_ip_address = {repr(_server_ip_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay/customer-dhcp-servers'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9435,6 +11392,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        _customer_dhcp_servers = self.customer_dhcp_servers
+        if _customer_dhcp_servers is not None:
+            res.extend(_customer_dhcp_servers.prsrc(f'{self_name}.customer_dhcp_servers', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/dhcp-relay'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
@@ -9526,6 +11505,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/addresses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()')
+        leaves = []
+        _provider_address = self.provider_address
+        if _provider_address is not None:
+            leaves.append(f'{self_name}.provider_address = {repr(_provider_address)}')
+        _customer_address = self.customer_address
+        if _customer_address is not None:
+            leaves.append(f'{self_name}.customer_address = {repr(_customer_address)}')
+        _prefix_length = self.prefix_length
+        if _prefix_length is not None:
+            leaves.append(f'{self_name}.prefix_length = {repr(_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6/addresses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9601,6 +11602,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()')
+        leaves = []
+        _address_allocation_type = self.address_allocation_type
+        if _address_allocation_type is not None:
+            leaves.append(f'{self_name}.address_allocation_type = {repr(_address_allocation_type)}')
+        _provider_dhcp = self.provider_dhcp
+        if _provider_dhcp is not None:
+            res.extend(_provider_dhcp.prsrc(f'{self_name}.provider_dhcp', False).splitlines())
+        _dhcp_relay = self.dhcp_relay
+        if _dhcp_relay is not None:
+            res.extend(_dhcp_relay.prsrc(f'{self_name}.dhcp_relay', False).splitlines())
+        _addresses = self.addresses
+        if _addresses is not None:
+            res.extend(_addresses.prsrc(f'{self_name}.addresses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/ipv6'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(node: xml.Node) -> yang.gdata.Container:
@@ -9700,6 +11726,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam/bfd')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _fixed_value = self.fixed_value
+        if _fixed_value is not None:
+            leaves.append(f'{self_name}.fixed_value = {repr(_fixed_value)}')
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam/bfd'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9761,6 +11809,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_container('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()')
+        leaves = []
+        _bfd = self.bfd
+        if _bfd is not None:
+            res.extend(_bfd.prsrc(f'{self_name}.bfd', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection/oam'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9821,6 +11885,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_container('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_container('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            res.extend(_ipv4.prsrc(f'{self_name}.ipv4', False).splitlines())
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            res.extend(_ipv6.prsrc(f'{self_name}.ipv6', False).splitlines())
+        _oam = self.oam
+        if _oam is not None:
+            res.extend(_oam.prsrc(f'{self_name}.oam', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/ip-connection'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -9880,6 +11966,19 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/authentication')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/authentication'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(node: xml.Node) -> yang.gdata.Container:
@@ -9964,6 +12063,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption/encryption-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()')
+        leaves = []
+        _profile_name = self.profile_name
+        if _profile_name is not None:
+            leaves.append(f'{self_name}.profile_name = {repr(_profile_name)}')
+        _algorithm = self.algorithm
+        if _algorithm is not None:
+            leaves.append(f'{self_name}.algorithm = {repr(_algorithm)}')
+        _preshared_key = self.preshared_key
+        if _preshared_key is not None:
+            leaves.append(f'{self_name}.preshared_key = {repr(_preshared_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption/encryption-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10035,6 +12156,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append(f'{self_name}.enabled = {repr(_enabled)}')
+        _layer = self.layer
+        if _layer is not None:
+            leaves.append(f'{self_name}.layer = {repr(_layer)}')
+        _encryption_profile = self.encryption_profile
+        if _encryption_profile is not None:
+            res.extend(_encryption_profile.prsrc(f'{self_name}.encryption_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security/encryption'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10101,6 +12244,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()')
+        leaves = []
+        _authentication = self.authentication
+        if _authentication is not None:
+            res.extend(_authentication.prsrc(f'{self_name}.authentication', False).splitlines())
+        _encryption = self.encryption
+        if _encryption is not None:
+            res.extend(_encryption.prsrc(f'{self_name}.encryption', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/security'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(node: xml.Node) -> yang.gdata.Container:
@@ -10248,6 +12410,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-src-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10325,6 +12506,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()')
+        leaves = []
+        _lower_port = self.lower_port
+        if _lower_port is not None:
+            leaves.append(f'{self_name}.lower_port = {repr(_lower_port)}')
+        _upper_port = self.upper_port
+        if _upper_port is not None:
+            leaves.append(f'{self_name}.upper_port = {repr(_upper_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow/l4-dst-port-range'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
@@ -10439,6 +12639,55 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()')
+        leaves = []
+        _dscp = self.dscp
+        if _dscp is not None:
+            leaves.append(f'{self_name}.dscp = {repr(_dscp)}')
+        _dot1p = self.dot1p
+        if _dot1p is not None:
+            leaves.append(f'{self_name}.dot1p = {repr(_dot1p)}')
+        _ipv4_src_prefix = self.ipv4_src_prefix
+        if _ipv4_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_src_prefix = {repr(_ipv4_src_prefix)}')
+        _ipv6_src_prefix = self.ipv6_src_prefix
+        if _ipv6_src_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_src_prefix = {repr(_ipv6_src_prefix)}')
+        _ipv4_dst_prefix = self.ipv4_dst_prefix
+        if _ipv4_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv4_dst_prefix = {repr(_ipv4_dst_prefix)}')
+        _ipv6_dst_prefix = self.ipv6_dst_prefix
+        if _ipv6_dst_prefix is not None:
+            leaves.append(f'{self_name}.ipv6_dst_prefix = {repr(_ipv6_dst_prefix)}')
+        _l4_src_port = self.l4_src_port
+        if _l4_src_port is not None:
+            leaves.append(f'{self_name}.l4_src_port = {repr(_l4_src_port)}')
+        _target_sites = self.target_sites
+        if _target_sites is not None:
+            leaves.append(f'{self_name}.target_sites = {repr(_target_sites)}')
+        _l4_src_port_range = self.l4_src_port_range
+        if _l4_src_port_range is not None:
+            res.extend(_l4_src_port_range.prsrc(f'{self_name}.l4_src_port_range', False).splitlines())
+        _l4_dst_port = self.l4_dst_port
+        if _l4_dst_port is not None:
+            leaves.append(f'{self_name}.l4_dst_port = {repr(_l4_dst_port)}')
+        _l4_dst_port_range = self.l4_dst_port_range
+        if _l4_dst_port_range is not None:
+            res.extend(_l4_dst_port_range.prsrc(f'{self_name}.l4_dst_port_range', False).splitlines())
+        _protocol_field = self.protocol_field
+        if _protocol_field is not None:
+            leaves.append(f'{self_name}.protocol_field = {repr(_protocol_field)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule/match-flow'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
@@ -10581,6 +12830,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule({repr(self.id)})')
+        leaves = []
+        _match_flow = self.match_flow
+        if _match_flow is not None:
+            res.extend(_match_flow.prsrc(f'{self_name}.match_flow', False).splitlines())
+        _match_application = self.match_application
+        if _match_application is not None:
+            leaves.append(f'{self_name}.match_application = {repr(_match_application)}')
+        _target_class_id = self.target_class_id
+        if _target_class_id is not None:
+            leaves.append(f'{self_name}.target_class_id = {repr(_target_class_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
@@ -10727,6 +12998,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()')
+        leaves = []
+        _rule = self.rule
+        for _element in _rule.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy/rule element: {_element.to_gdata().key_str(['id'])}")
+            list_elem = f'rule_element = {self_name}.rule.create({repr(_element.id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rule_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-classification-policy'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10818,6 +13109,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/latency')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()')
+        leaves = []
+        _use_lowest_latency = self.use_lowest_latency
+        if _use_lowest_latency is not None:
+            leaves.append(f'{self_name}.use_lowest_latency = {repr(_use_lowest_latency)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/latency'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10890,6 +13200,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/jitter')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()')
+        leaves = []
+        _use_lowest_jitter = self.use_lowest_jitter
+        if _use_lowest_jitter is not None:
+            leaves.append(f'{self_name}.use_lowest_jitter = {repr(_use_lowest_jitter)}')
+        _latency_boundary = self.latency_boundary
+        if _latency_boundary is not None:
+            leaves.append(f'{self_name}.latency_boundary = {repr(_latency_boundary)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/jitter'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -10961,6 +13290,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/bandwidth')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth()')
+        leaves = []
+        _guaranteed_bw_percent = self.guaranteed_bw_percent
+        if _guaranteed_bw_percent is not None:
+            leaves.append(f'{self_name}.guaranteed_bw_percent = {repr(_guaranteed_bw_percent)}')
+        _end_to_end = self.end_to_end
+        if _end_to_end is not None:
+            leaves.append(f'{self_name}.end_to_end = {repr(_end_to_end)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class/bandwidth'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
@@ -11039,6 +13387,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_opt_container('bandwidth')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class({repr(self.class_id)})')
+        leaves = []
+        _direction = self.direction
+        if _direction is not None:
+            leaves.append(f'{self_name}.direction = {repr(_direction)}')
+        _rate_limit = self.rate_limit
+        if _rate_limit is not None:
+            leaves.append(f'{self_name}.rate_limit = {repr(_rate_limit)}')
+        _latency = self.latency
+        if _latency is not None:
+            res.extend(_latency.prsrc(f'{self_name}.latency', False).splitlines())
+        _jitter = self.jitter
+        if _jitter is not None:
+            res.extend(_jitter.prsrc(f'{self_name}.jitter', False).splitlines())
+        _bandwidth = self.bandwidth
+        if _bandwidth is not None:
+            res.extend(_bandwidth.prsrc(f'{self_name}.bandwidth', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
@@ -11197,6 +13573,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()')
+        leaves = []
+        _class_ = self.class_
+        for _element in _class_.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes/class element: {_element.to_gdata().key_str(['class-id'])}")
+            list_elem = f'class__element = {self_name}.class_.create({repr(_element.class_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'class__element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile/classes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11251,6 +13647,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()')
+        leaves = []
+        _profile = self.profile
+        if _profile is not None:
+            leaves.append(f'{self_name}.profile = {repr(_profile)}')
+        _classes = self.classes
+        if _classes is not None:
+            res.extend(_classes.prsrc(f'{self_name}.classes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos/qos-profile'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
@@ -11312,6 +13727,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()')
+        leaves = []
+        _qos_classification_policy = self.qos_classification_policy
+        if _qos_classification_policy is not None:
+            res.extend(_qos_classification_policy.prsrc(f'{self_name}.qos_classification_policy', False).splitlines())
+        _qos_profile = self.qos_profile
+        if _qos_profile is not None:
+            res.extend(_qos_profile.prsrc(f'{self_name}.qos_profile', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/qos'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(node: xml.Node) -> yang.gdata.Container:
@@ -11375,6 +13809,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/carrierscarrier')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()')
+        leaves = []
+        _signalling_type = self.signalling_type
+        if _signalling_type is not None:
+            leaves.append(f'{self_name}.signalling_type = {repr(_signalling_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/carrierscarrier'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
@@ -11448,6 +13898,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast/multicast-address-family')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()')
+        leaves = []
+        _ipv4 = self.ipv4
+        if _ipv4 is not None:
+            leaves.append(f'{self_name}.ipv4 = {repr(_ipv4)}')
+        _ipv6 = self.ipv6
+        if _ipv6 is not None:
+            leaves.append(f'{self_name}.ipv6 = {repr(_ipv6)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast/multicast-address-family'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11518,6 +13987,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()')
+        leaves = []
+        _multicast_site_type = self.multicast_site_type
+        if _multicast_site_type is not None:
+            leaves.append(f'{self_name}.multicast_site_type = {repr(_multicast_site_type)}')
+        _multicast_address_family = self.multicast_address_family
+        if _multicast_address_family is not None:
+            res.extend(_multicast_address_family.prsrc(f'{self_name}.multicast_address_family', False).splitlines())
+        _protocol_type = self.protocol_type
+        if _protocol_type is not None:
+            leaves.append(f'{self_name}.protocol_type = {repr(_protocol_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service/multicast'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(node: xml.Node) -> yang.gdata.Container:
@@ -11605,6 +14096,37 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_opt_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_opt_int('svc-output-bandwidth'), svc_mtu=n.get_opt_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_container('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service()')
+        leaves = []
+        _svc_input_bandwidth = self.svc_input_bandwidth
+        if _svc_input_bandwidth is not None:
+            leaves.append(f'{self_name}.svc_input_bandwidth = {repr(_svc_input_bandwidth)}')
+        _svc_output_bandwidth = self.svc_output_bandwidth
+        if _svc_output_bandwidth is not None:
+            leaves.append(f'{self_name}.svc_output_bandwidth = {repr(_svc_output_bandwidth)}')
+        _svc_mtu = self.svc_mtu
+        if _svc_mtu is not None:
+            leaves.append(f'{self_name}.svc_mtu = {repr(_svc_mtu)}')
+        _qos = self.qos
+        if _qos is not None:
+            res.extend(_qos.prsrc(f'{self_name}.qos', False).splitlines())
+        _carrierscarrier = self.carrierscarrier
+        if _carrierscarrier is not None:
+            res.extend(_carrierscarrier.prsrc(f'{self_name}.carrierscarrier', False).splitlines())
+        _multicast = self.multicast
+        if _multicast is not None:
+            res.extend(_multicast.prsrc(f'{self_name}.multicast', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(node: xml.Node) -> yang.gdata.Container:
@@ -11726,6 +14248,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link({repr(self.target_site)})')
+        leaves = []
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -11860,6 +14398,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()')
+        leaves = []
+        _sham_link = self.sham_link
+        for _element in _sham_link.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links/sham-link element: {_element.to_gdata().key_str(['target-site'])}")
+            list_elem = f'sham_link_element = {self_name}.sham_link.create({repr(_element.target_site)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'sham_link_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf/sham-links'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -11922,6 +14480,31 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        _area_address = self.area_address
+        if _area_address is not None:
+            leaves.append(f'{self_name}.area_address = {repr(_area_address)}')
+        _metric = self.metric
+        if _metric is not None:
+            leaves.append(f'{self_name}.metric = {repr(_metric)}')
+        _sham_links = self.sham_links
+        if _sham_links is not None:
+            res.extend(_sham_links.prsrc(f'{self_name}.sham_links', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
@@ -12006,6 +14589,25 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp()')
+        leaves = []
+        _autonomous_system = self.autonomous_system
+        if _autonomous_system is not None:
+            leaves.append(f'{self_name}.autonomous_system = {repr(_autonomous_system)}')
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12086,6 +14688,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -12254,6 +14872,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes({repr(self.lan)}, {repr(self.next_hop)})')
+        leaves = []
+        _lan_tag = self.lan_tag
+        if _lan_tag is not None:
+            leaves.append(f'{self_name}.lan_tag = {repr(_lan_tag)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12400,6 +15034,33 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()')
+        leaves = []
+        _ipv4_lan_prefixes = self.ipv4_lan_prefixes
+        for _element in _ipv4_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv4-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv4_lan_prefixes_element = {self_name}.ipv4_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv4_lan_prefixes_element', False, list_element=True).splitlines())
+        _ipv6_lan_prefixes = self.ipv6_lan_prefixes
+        for _element in _ipv6_lan_prefixes.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes/ipv6-lan-prefixes element: {_element.to_gdata().key_str(['lan', 'next-hop'])}")
+            list_elem = f'ipv6_lan_prefixes_element = {self_name}.ipv6_lan_prefixes.create({repr(_element.lan)}, {repr(_element.next_hop)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ipv6_lan_prefixes_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static/cascaded-lan-prefixes'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12457,6 +15118,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static()')
+        leaves = []
+        _cascaded_lan_prefixes = self.cascaded_lan_prefixes
+        if _cascaded_lan_prefixes is not None:
+            res.extend(_cascaded_lan_prefixes.prsrc(f'{self_name}.cascaded_lan_prefixes', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12511,6 +15188,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12563,6 +15256,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp()')
+        leaves = []
+        _address_family = self.address_family
+        if _address_family is not None:
+            leaves.append(f'{self_name}.address_family = {repr(_address_family)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
@@ -12660,6 +15369,49 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol({repr(self.type)})')
+        leaves = []
+        _ospf = self.ospf
+        if _ospf is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/ospf')
+            res.append(f'ospf = {self_name}.create_ospf()')
+            res.extend(_ospf.prsrc('ospf', False).splitlines())
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/bgp')
+            res.append(f'bgp = {self_name}.create_bgp()')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        _static = self.static
+        if _static is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/static')
+            res.append(f'static = {self_name}.create_static()')
+            res.extend(_static.prsrc('static', False).splitlines())
+        _rip = self.rip
+        if _rip is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/rip')
+            res.append(f'rip = {self_name}.create_rip()')
+            res.extend(_rip.prsrc('rip', False).splitlines())
+        _vrrp = self.vrrp
+        if _vrrp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol/vrrp')
+            res.append(f'vrrp = {self_name}.create_vrrp()')
+            res.extend(_vrrp.prsrc('vrrp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
@@ -12818,6 +15570,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()')
+        leaves = []
+        _routing_protocol = self.routing_protocol
+        for _element in _routing_protocol.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols/routing-protocol element: {_element.to_gdata().key_str(['type'])}")
+            list_elem = f'routing_protocol_element = {self_name}.routing_protocol.create({repr(_element.type)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'routing_protocol_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/routing-protocols'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -12873,6 +15645,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/availability')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()')
+        leaves = []
+        _access_priority = self.access_priority
+        if _access_priority is not None:
+            leaves.append(f'{self_name}.access_priority = {repr(_access_priority)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/availability'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(node: xml.Node) -> yang.gdata.Container:
@@ -12950,6 +15738,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_str('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/vpn-attachment')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()')
+        leaves = []
+        _vpn_policy_id = self.vpn_policy_id
+        if _vpn_policy_id is not None:
+            leaves.append(f'{self_name}.vpn_policy_id = {repr(_vpn_policy_id)}')
+        _vpn_id = self.vpn_id
+        if _vpn_id is not None:
+            leaves.append(f'{self_name}.vpn_id = {repr(_vpn_id)}')
+        _site_role = self.site_role
+        if _site_role is not None:
+            leaves.append(f'{self_name}.site_role = {repr(_site_role)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access/vpn-attachment'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(node: xml.Node) -> yang.gdata.Container:
@@ -13064,6 +15874,52 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=n.get_str('site-network-access-id'), site_network_access_type=n.get_opt_str('site-network-access-type'), location_reference=n.get_opt_str('location-reference'), device_reference=n.get_opt_str('device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(n.get_opt_container('access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(n.get_opt_container('bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(n.get_opt_container('ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(n.get_opt_container('service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(n.get_opt_container('availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(n.get_opt_container('vpn-attachment')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses/site-network-access')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access({repr(self.site_network_access_id)})')
+        leaves = []
+        _site_network_access_type = self.site_network_access_type
+        if _site_network_access_type is not None:
+            leaves.append(f'{self_name}.site_network_access_type = {repr(_site_network_access_type)}')
+        _location_reference = self.location_reference
+        if _location_reference is not None:
+            leaves.append(f'{self_name}.location_reference = {repr(_location_reference)}')
+        _device_reference = self.device_reference
+        if _device_reference is not None:
+            leaves.append(f'{self_name}.device_reference = {repr(_device_reference)}')
+        _access_diversity = self.access_diversity
+        if _access_diversity is not None:
+            res.extend(_access_diversity.prsrc(f'{self_name}.access_diversity', False).splitlines())
+        _bearer = self.bearer
+        if _bearer is not None:
+            res.extend(_bearer.prsrc(f'{self_name}.bearer', False).splitlines())
+        _ip_connection = self.ip_connection
+        if _ip_connection is not None:
+            res.extend(_ip_connection.prsrc(f'{self_name}.ip_connection', False).splitlines())
+        _security = self.security
+        if _security is not None:
+            res.extend(_security.prsrc(f'{self_name}.security', False).splitlines())
+        _service = self.service
+        if _service is not None:
+            res.extend(_service.prsrc(f'{self_name}.service', False).splitlines())
+        _routing_protocols = self.routing_protocols
+        if _routing_protocols is not None:
+            res.extend(_routing_protocols.prsrc(f'{self_name}.routing_protocols', False).splitlines())
+        _availability = self.availability
+        if _availability is not None:
+            res.extend(_availability.prsrc(f'{self_name}.availability', False).splitlines())
+        _vpn_attachment = self.vpn_attachment
+        if _vpn_attachment is not None:
+            res.extend(_vpn_attachment.prsrc(f'{self_name}.vpn_attachment', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses/site-network-access'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
@@ -13258,6 +16114,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site/site-network-accesses')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()')
+        leaves = []
+        _site_network_access = self.site_network_access
+        for _element in _site_network_access.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site/site-network-accesses/site-network-access element: {_element.to_gdata().key_str(['site-network-access-id'])}")
+            list_elem = f'site_network_access_element = {self_name}.site_network_access.create({repr(_element.site_network_access_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'site_network_access_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site/site-network-accesses'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -13375,6 +16251,61 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=n.get_str('site-id'), requested_site_start=n.get_opt_str('requested-site-start'), requested_site_stop=n.get_opt_str('requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(n.get_opt_container('locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(n.get_opt_container('devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(n.get_opt_container('site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(n.get_opt_container('management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(n.get_opt_container('vpn-policies')), site_vpn_flavor=n.get_opt_str('site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(n.get_opt_container('maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(n.get_opt_container('service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(n.get_opt_container('traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(n.get_opt_container('site-network-accesses')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites/site')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites__site({repr(self.site_id)})')
+        leaves = []
+        _requested_site_start = self.requested_site_start
+        if _requested_site_start is not None:
+            leaves.append(f'{self_name}.requested_site_start = {repr(_requested_site_start)}')
+        _requested_site_stop = self.requested_site_stop
+        if _requested_site_stop is not None:
+            leaves.append(f'{self_name}.requested_site_stop = {repr(_requested_site_stop)}')
+        _locations = self.locations
+        if _locations is not None:
+            res.extend(_locations.prsrc(f'{self_name}.locations', False).splitlines())
+        _devices = self.devices
+        if _devices is not None:
+            res.extend(_devices.prsrc(f'{self_name}.devices', False).splitlines())
+        _site_diversity = self.site_diversity
+        if _site_diversity is not None:
+            res.extend(_site_diversity.prsrc(f'{self_name}.site_diversity', False).splitlines())
+        _management = self.management
+        if _management is not None:
+            res.extend(_management.prsrc(f'{self_name}.management', False).splitlines())
+        _vpn_policies = self.vpn_policies
+        if _vpn_policies is not None:
+            res.extend(_vpn_policies.prsrc(f'{self_name}.vpn_policies', False).splitlines())
+        _site_vpn_flavor = self.site_vpn_flavor
+        if _site_vpn_flavor is not None:
+            leaves.append(f'{self_name}.site_vpn_flavor = {repr(_site_vpn_flavor)}')
+        _maximum_routes = self.maximum_routes
+        if _maximum_routes is not None:
+            res.extend(_maximum_routes.prsrc(f'{self_name}.maximum_routes', False).splitlines())
+        _security = self.security
+        if _security is not None:
+            res.extend(_security.prsrc(f'{self_name}.security', False).splitlines())
+        _service = self.service
+        if _service is not None:
+            res.extend(_service.prsrc(f'{self_name}.service', False).splitlines())
+        _traffic_protection = self.traffic_protection
+        if _traffic_protection is not None:
+            res.extend(_traffic_protection.prsrc(f'{self_name}.traffic_protection', False).splitlines())
+        _routing_protocols = self.routing_protocols
+        if _routing_protocols is not None:
+            res.extend(_routing_protocols.prsrc(f'{self_name}.routing_protocols', False).splitlines())
+        _site_network_accesses = self.site_network_accesses
+        if _site_network_accesses is not None:
+            res.extend(_site_network_accesses.prsrc(f'{self_name}.site_network_accesses', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites/site'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
@@ -13587,6 +16518,26 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc/sites')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc__sites()')
+        leaves = []
+        _site = self.site
+        for _element in _site.elements:
+            res.append('')
+            res.append(f"# List /l3vpn-svc/sites/site element: {_element.to_gdata().key_str(['site-id'])}")
+            list_elem = f'site_element = {self_name}.site.create({repr(_element.site_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'site_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc/sites'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -13646,6 +16597,28 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
         if n != None:
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_container('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_container('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_container('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpn-svc')
+            res.append(f'{self_name} = ietf_l3vpn_svc__l3vpn_svc()')
+        leaves = []
+        _vpn_profiles = self.vpn_profiles
+        if _vpn_profiles is not None:
+            res.extend(_vpn_profiles.prsrc(f'{self_name}.vpn_profiles', False).splitlines())
+        _vpn_services = self.vpn_services
+        if _vpn_services is not None:
+            res.extend(_vpn_services.prsrc(f'{self_name}.vpn_services', False).splitlines())
+        _sites = self.sites
+        if _sites is not None:
+            res.extend(_sites.prsrc(f'{self_name}.sites', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpn-svc'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml_ietf_l3vpn_svc__l3vpn_svc(node: xml.Node) -> yang.gdata.Container:
@@ -13715,6 +16688,25 @@ class root(yang.adata.MNode):
         if n != None:
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_container('l3vpn-svc')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _netinfra = self.netinfra
+        if _netinfra is not None:
+            res.extend(_netinfra.prsrc(f'{self_name}.netinfra', False).splitlines())
+        _l3vpn_svc = self.l3vpn_svc
+        if _l3vpn_svc is not None:
+            res.extend(_l3vpn_svc.prsrc(f'{self_name}.l3vpn_svc', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_1.act
+++ b/src/respnet/layers/y_1.act
@@ -79,6 +79,19 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return netinfra_inter__netinfra__router__base_config(asn=n.get_int('asn'), ipv4_address=n.get_str('ipv4-address'), ipv6_address=n.get_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router/base-config')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router__base_config({repr(self.asn)}, {repr(self.ipv4_address)}, {repr(self.ipv6_address)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/base-config'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra_inter__netinfra__router__base_config(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -152,6 +165,22 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=n.get_str('vpn-id'), ebgp_customer_address=n.get_opt_strs('ebgp-customer-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router/l3vpn-vrf')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router__l3vpn_vrf({repr(self.vpn_id)})')
+        leaves = []
+        _ebgp_customer_address = self.ebgp_customer_address
+        if _ebgp_customer_address is not None:
+            leaves.append(f'{self_name}.ebgp_customer_address = {repr(_ebgp_customer_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/l3vpn-vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
@@ -308,6 +337,36 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
         return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_container('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router')
+            res.append(f'self_base_config = netinfra_inter__netinfra__router__base_config({repr(self.base_config.asn)}, {repr(self.base_config.ipv4_address)}, {repr(self.base_config.ipv6_address)})')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router({repr(self.name)}, {repr(self.id)}, self_base_config)')
+        leaves = []
+        _role = self.role
+        if _role is not None:
+            leaves.append(f'{self_name}.role = {repr(_role)}')
+        _mock = self.mock
+        if _mock is not None:
+            leaves.append(f'{self_name}.mock = {repr(_mock)}')
+        _base_config = self.base_config
+        if _base_config is not None:
+            res.extend(_base_config.prsrc(f'{self_name}.base_config', False).splitlines())
+        _l3vpn_vrf = self.l3vpn_vrf
+        for _element in _l3vpn_vrf.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router/l3vpn-vrf element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'l3vpn_vrf_element = {self_name}.l3vpn_vrf.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'l3vpn_vrf_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
@@ -503,6 +562,19 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__backbone_link_entry:
         return netinfra_inter__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/backbone-link')
+            res.append(f'{self_name} = netinfra_inter__netinfra__backbone_link({repr(self.left_router)}, {repr(self.left_interface)}, {repr(self.right_router)}, {repr(self.right_interface)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/backbone-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -681,6 +753,19 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=n.get_str('name'), ipv4_address=n.get_str('ipv4-address'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/ibgp-fullmesh/router')
+            res.append(f'{self_name} = netinfra_inter__netinfra__ibgp_fullmesh__router({repr(self.name)}, {repr(self.ipv4_address)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/ibgp-fullmesh/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
     mut def __init__(self, elements=[]):
@@ -821,6 +906,26 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=n.get_int('asn'), authentication_key=n.get_str('authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_gdata(n.get_opt_list('router')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/ibgp-fullmesh')
+            res.append(f'{self_name} = netinfra_inter__netinfra__ibgp_fullmesh({repr(self.asn)}, {repr(self.authentication_key)})')
+        leaves = []
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/ibgp-fullmesh/router element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)}, {repr(_element.ipv4_address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/ibgp-fullmesh'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
@@ -971,6 +1076,41 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra')
+            res.append(f'{self_name} = netinfra_inter__netinfra()')
+        leaves = []
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router element: {_element.to_gdata().key_str(['name'])}")
+            res.append(f'element_base_config = netinfra_inter__netinfra__router__base_config({repr(_element.base_config.asn)}, {repr(_element.base_config.ipv4_address)}, {repr(_element.base_config.ipv6_address)})')
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)}, {repr(_element.id)}, element_base_config)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        _backbone_link = self.backbone_link
+        for _element in _backbone_link.elements:
+            res.append('')
+            res.append(f"# List /netinfra/backbone-link element: {_element.to_gdata().key_str(['left-router', 'left-interface', 'right-router', 'right-interface'])}")
+            list_elem = f'backbone_link_element = {self_name}.backbone_link.create({repr(_element.left_router)}, {repr(_element.left_interface)}, {repr(_element.right_router)}, {repr(_element.right_interface)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_link_element', False, list_element=True).splitlines())
+        _ibgp_fullmesh = self.ibgp_fullmesh
+        for _element in _ibgp_fullmesh.elements:
+            res.append('')
+            res.append(f"# List /netinfra/ibgp-fullmesh element: {_element.to_gdata().key_str(['asn'])}")
+            list_elem = f'ibgp_fullmesh_element = {self_name}.ibgp_fullmesh.create({repr(_element.asn)}, {repr(_element.authentication_key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ibgp_fullmesh_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra_inter__netinfra(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1095,6 +1235,19 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_int('as-number'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn/endpoint/bgp')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn__endpoint__bgp({repr(self.as_number)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn/endpoint/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1181,6 +1334,28 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=n.get_str('device'), interface=n.get_str('interface'), site=n.get_str('site'), site_network_access=n.get_str('site-network-access'), provider_ipv4_address=n.get_str('provider-ipv4-address'), customer_ipv4_address=n.get_opt_str('customer-ipv4-address'), ipv4_prefix_length=n.get_int('ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_gdata(n.get_opt_container('bgp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn/endpoint')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn__endpoint({repr(self.device)}, {repr(self.interface)}, {repr(self.site)}, {repr(self.site_network_access)}, {repr(self.provider_ipv4_address)}, {repr(self.ipv4_prefix_length)})')
+        leaves = []
+        _customer_ipv4_address = self.customer_ipv4_address
+        if _customer_ipv4_address is not None:
+            leaves.append(f'{self_name}.customer_ipv4_address = {repr(_customer_ipv4_address)}')
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpns/l3vpn/endpoint/bgp')
+            res.append(f'bgp = {self_name}.create_bgp({repr(_bgp.as_number)})')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn/endpoint'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
@@ -1361,6 +1536,29 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
         return l3vpn_inter__l3vpns__l3vpn_entry(name=n.get_str('name'), description=n.get_opt_str('description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_gdata(n.get_opt_list('endpoint')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _endpoint = self.endpoint
+        for _element in _endpoint.elements:
+            res.append('')
+            res.append(f"# List /l3vpns/l3vpn/endpoint element: {_element.to_gdata().key_str(['device', 'interface'])}")
+            list_elem = f'endpoint_element = {self_name}.endpoint.create({repr(_element.device)}, {repr(_element.interface)}, {repr(_element.site)}, {repr(_element.site_network_access)}, {repr(_element.provider_ipv4_address)}, {repr(_element.ipv4_prefix_length)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'endpoint_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1500,6 +1698,26 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns()')
+        leaves = []
+        _l3vpn = self.l3vpn
+        for _element in _l3vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpns/l3vpn element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'l3vpn_element = {self_name}.l3vpn.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'l3vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_l3vpn_inter__l3vpns(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1554,6 +1772,25 @@ class root(yang.adata.MNode):
         if n != None:
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_container('l3vpns')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _netinfra = self.netinfra
+        if _netinfra is not None:
+            res.extend(_netinfra.prsrc(f'{self_name}.netinfra', False).splitlines())
+        _l3vpns = self.l3vpns
+        if _l3vpns is not None:
+            res.extend(_l3vpns.prsrc(f'{self_name}.l3vpns', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_1.act
+++ b/src/respnet/layers/y_1.act
@@ -1189,7 +1189,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
         self._name = 'endpoint'
         self.elements = elements
 
-    mut def create(self, device, interface, site, site_network_access, provider_ipv4_address, ipv4_prefix_length, bgp):
+    mut def create(self, device, interface, site, site_network_access, provider_ipv4_address, ipv4_prefix_length):
         for e in self.elements:
             match = True
             if e.device != device:
@@ -1201,7 +1201,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
             if match:
                 return e
 
-        res = l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device, interface, site, site_network_access, provider_ipv4_address, ipv4_prefix_length, bgp)
+        res = l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device, interface, site, site_network_access, provider_ipv4_address, ipv4_prefix_length)
         self.elements.append(res)
         return res
 

--- a/src/respnet/layers/y_1_loose.act
+++ b/src/respnet/layers/y_1_loose.act
@@ -79,6 +79,28 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return netinfra_inter__netinfra__router__base_config(asn=n.get_opt_int('asn'), ipv4_address=n.get_opt_str('ipv4-address'), ipv6_address=n.get_opt_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router/base-config')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router__base_config()')
+        leaves = []
+        _asn = self.asn
+        if _asn is not None:
+            leaves.append(f'{self_name}.asn = {repr(_asn)}')
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv6_address = self.ipv6_address
+        if _ipv6_address is not None:
+            leaves.append(f'{self_name}.ipv6_address = {repr(_ipv6_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/base-config'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra_inter__netinfra__router__base_config(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -152,6 +174,22 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=n.get_str('vpn-id'), ebgp_customer_address=n.get_opt_strs('ebgp-customer-address'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router/l3vpn-vrf')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router__l3vpn_vrf({repr(self.vpn_id)})')
+        leaves = []
+        _ebgp_customer_address = self.ebgp_customer_address
+        if _ebgp_customer_address is not None:
+            leaves.append(f'{self_name}.ebgp_customer_address = {repr(_ebgp_customer_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/l3vpn-vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
@@ -308,6 +346,38 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
         return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_container('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/router')
+            res.append(f'{self_name} = netinfra_inter__netinfra__router({repr(self.name)})')
+        leaves = []
+        _id = self.id
+        if _id is not None:
+            leaves.append(f'{self_name}.id = {repr(_id)}')
+        _role = self.role
+        if _role is not None:
+            leaves.append(f'{self_name}.role = {repr(_role)}')
+        _mock = self.mock
+        if _mock is not None:
+            leaves.append(f'{self_name}.mock = {repr(_mock)}')
+        _base_config = self.base_config
+        if _base_config is not None:
+            res.extend(_base_config.prsrc(f'{self_name}.base_config', False).splitlines())
+        _l3vpn_vrf = self.l3vpn_vrf
+        for _element in _l3vpn_vrf.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router/l3vpn-vrf element: {_element.to_gdata().key_str(['vpn-id'])}")
+            list_elem = f'l3vpn_vrf_element = {self_name}.l3vpn_vrf.create({repr(_element.vpn_id)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'l3vpn_vrf_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
@@ -503,6 +573,19 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__backbone_link_entry:
         return netinfra_inter__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/backbone-link')
+            res.append(f'{self_name} = netinfra_inter__netinfra__backbone_link({repr(self.left_router)}, {repr(self.left_interface)}, {repr(self.right_router)}, {repr(self.right_interface)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/backbone-link'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -681,6 +764,22 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/ibgp-fullmesh/router')
+            res.append(f'{self_name} = netinfra_inter__netinfra__ibgp_fullmesh__router({repr(self.name)})')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/ibgp-fullmesh/router'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
     mut def __init__(self, elements=[]):
@@ -821,6 +920,29 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=n.get_int('asn'), authentication_key=n.get_opt_str('authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_gdata(n.get_opt_list('router')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra/ibgp-fullmesh')
+            res.append(f'{self_name} = netinfra_inter__netinfra__ibgp_fullmesh({repr(self.asn)})')
+        leaves = []
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/ibgp-fullmesh/router element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/ibgp-fullmesh'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
@@ -971,6 +1093,40 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /netinfra')
+            res.append(f'{self_name} = netinfra_inter__netinfra()')
+        leaves = []
+        _router = self.router
+        for _element in _router.elements:
+            res.append('')
+            res.append(f"# List /netinfra/router element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'router_element = {self_name}.router.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'router_element', False, list_element=True).splitlines())
+        _backbone_link = self.backbone_link
+        for _element in _backbone_link.elements:
+            res.append('')
+            res.append(f"# List /netinfra/backbone-link element: {_element.to_gdata().key_str(['left-router', 'left-interface', 'right-router', 'right-interface'])}")
+            list_elem = f'backbone_link_element = {self_name}.backbone_link.create({repr(_element.left_router)}, {repr(_element.left_interface)}, {repr(_element.right_router)}, {repr(_element.right_interface)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_link_element', False, list_element=True).splitlines())
+        _ibgp_fullmesh = self.ibgp_fullmesh
+        for _element in _ibgp_fullmesh.elements:
+            res.append('')
+            res.append(f"# List /netinfra/ibgp-fullmesh element: {_element.to_gdata().key_str(['asn'])}")
+            list_elem = f'ibgp_fullmesh_element = {self_name}.ibgp_fullmesh.create({repr(_element.asn)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ibgp_fullmesh_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_netinfra_inter__netinfra(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1095,6 +1251,22 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_opt_int('as-number'))
         return None
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn/endpoint/bgp')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn__endpoint__bgp()')
+        leaves = []
+        _as_number = self.as_number
+        if _as_number is not None:
+            leaves.append(f'{self_name}.as_number = {repr(_as_number)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn/endpoint/bgp'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1181,6 +1353,40 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=n.get_str('device'), interface=n.get_str('interface'), site=n.get_opt_str('site'), site_network_access=n.get_opt_str('site-network-access'), provider_ipv4_address=n.get_opt_str('provider-ipv4-address'), customer_ipv4_address=n.get_opt_str('customer-ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_gdata(n.get_opt_container('bgp')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn/endpoint')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn__endpoint({repr(self.device)}, {repr(self.interface)})')
+        leaves = []
+        _site = self.site
+        if _site is not None:
+            leaves.append(f'{self_name}.site = {repr(_site)}')
+        _site_network_access = self.site_network_access
+        if _site_network_access is not None:
+            leaves.append(f'{self_name}.site_network_access = {repr(_site_network_access)}')
+        _provider_ipv4_address = self.provider_ipv4_address
+        if _provider_ipv4_address is not None:
+            leaves.append(f'{self_name}.provider_ipv4_address = {repr(_provider_ipv4_address)}')
+        _customer_ipv4_address = self.customer_ipv4_address
+        if _customer_ipv4_address is not None:
+            leaves.append(f'{self_name}.customer_ipv4_address = {repr(_customer_ipv4_address)}')
+        _ipv4_prefix_length = self.ipv4_prefix_length
+        if _ipv4_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv4_prefix_length = {repr(_ipv4_prefix_length)}')
+        _bgp = self.bgp
+        if _bgp is not None:
+            res.append('')
+            res.append('# P-container: /l3vpns/l3vpn/endpoint/bgp')
+            res.append(f'bgp = {self_name}.create_bgp()')
+            res.extend(_bgp.prsrc('bgp', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn/endpoint'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
@@ -1361,6 +1567,29 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
         return l3vpn_inter__l3vpns__l3vpn_entry(name=n.get_str('name'), description=n.get_opt_str('description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_gdata(n.get_opt_list('endpoint')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns/l3vpn')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns__l3vpn({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _endpoint = self.endpoint
+        for _element in _endpoint.elements:
+            res.append('')
+            res.append(f"# List /l3vpns/l3vpn/endpoint element: {_element.to_gdata().key_str(['device', 'interface'])}")
+            list_elem = f'endpoint_element = {self_name}.endpoint.create({repr(_element.device)}, {repr(_element.interface)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'endpoint_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns/l3vpn'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1500,6 +1729,26 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /l3vpns')
+            res.append(f'{self_name} = l3vpn_inter__l3vpns()')
+        leaves = []
+        _l3vpn = self.l3vpn
+        for _element in _l3vpn.elements:
+            res.append('')
+            res.append(f"# List /l3vpns/l3vpn element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'l3vpn_element = {self_name}.l3vpn.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'l3vpn_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /l3vpns'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_l3vpn_inter__l3vpns(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1554,6 +1803,25 @@ class root(yang.adata.MNode):
         if n != None:
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_container('l3vpns')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _netinfra = self.netinfra
+        if _netinfra is not None:
+            res.extend(_netinfra.prsrc(f'{self_name}.netinfra', False).splitlines())
+        _l3vpns = self.l3vpns
+        if _l3vpns is not None:
+            res.extend(_l3vpns.prsrc(f'{self_name}.l3vpns', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_2.act
+++ b/src/respnet/layers/y_2.act
@@ -89,6 +89,19 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
         return orchestron_rfs__device__address__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/address/initial-credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__address__initial_credentials({repr(self.username)}, {repr(self.password)}, {repr(self.key)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/address/initial-credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -244,6 +257,29 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
         return orchestron_rfs__device__address_entry(name=n.get_str('name'), address=n.get_str('address'), port=n.get_opt_str('port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/address')
+            res.append(f'{self_name} = orchestron_rfs__device__address({repr(self.name)}, {repr(self.address)})')
+        leaves = []
+        _port = self.port
+        if _port is not None:
+            leaves.append(f'{self_name}.port = {repr(_port)}')
+        _initial_credentials = self.initial_credentials
+        for _element in _initial_credentials.elements:
+            res.append('')
+            res.append(f"# List /device/address/initial-credentials element: {_element.to_gdata().key_str(['username', 'password', 'key'])}")
+            list_elem = f'initial_credentials_element = {self_name}.initial_credentials.create({repr(_element.username)}, {repr(_element.password)}, {repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'initial_credentials_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device__address(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address_entry]
@@ -417,6 +453,22 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
         return orchestron_rfs__device__credentials__key_entry(key=n.get_str('key'), private_key=n.get_opt_str('private-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/credentials/key')
+            res.append(f'{self_name} = orchestron_rfs__device__credentials__key({repr(self.key)})')
+        leaves = []
+        _private_key = self.private_key
+        if _private_key is not None:
+            leaves.append(f'{self_name}.private_key = {repr(_private_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/credentials/key'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[orchestron_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -560,6 +612,29 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
             return orchestron_rfs__device__credentials(username=n.get_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__credentials({repr(self.username)})')
+        leaves = []
+        _password = self.password
+        if _password is not None:
+            leaves.append(f'{self_name}.password = {repr(_password)}')
+        _key = self.key
+        for _element in _key.elements:
+            res.append('')
+            res.append(f"# List /device/credentials/key element: {_element.to_gdata().key_str(['key'])}")
+            list_elem = f'key_element = {self_name}.key.create({repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'key_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__device__credentials(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -647,6 +722,19 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
         return orchestron_rfs__device__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/initial-credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__initial_credentials({repr(self.username)}, {repr(self.password)}, {repr(self.key)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/initial-credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__initial_credentials_entry]
@@ -832,6 +920,25 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
         return orchestron_rfs__device__mock__module_entry(name=n.get_str('name'), namespace=n.get_str('namespace'), revision=n.get_opt_str('revision'), feature=n.get_opt_strs('feature'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/mock/module')
+            res.append(f'{self_name} = orchestron_rfs__device__mock__module({repr(self.name)}, {repr(self.namespace)})')
+        leaves = []
+        _revision = self.revision
+        if _revision is not None:
+            leaves.append(f'{self_name}.revision = {repr(_revision)}')
+        _feature = self.feature
+        if _feature is not None:
+            leaves.append(f'{self_name}.feature = {repr(_feature)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/mock/module'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__mock__module(yang.adata.MNode):
     elements: list[orchestron_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -980,6 +1087,29 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/mock')
+            res.append(f'{self_name} = orchestron_rfs__device__mock()')
+        leaves = []
+        _preset = self.preset
+        if _preset is not None:
+            leaves.append(f'{self_name}.preset = {repr(_preset)}')
+        _module = self.module
+        for _element in _module.elements:
+            res.append('')
+            res.append(f"# List /device/mock/module element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'module_element = {self_name}.module.create({repr(_element.name)}, {repr(_element.namespace)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'module_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/mock'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__device__mock(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1063,6 +1193,46 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
         return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_container('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_container('mock')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device')
+            res.append(f'self_credentials = orchestron_rfs__device__credentials({repr(self.credentials.username)})')
+            res.append(f'{self_name} = orchestron_rfs__device({repr(self.name)}, self_credentials)')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _type = self.type
+        if _type is not None:
+            leaves.append(f'{self_name}.type = {repr(_type)}')
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /device/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)}, {repr(_element.address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        _credentials = self.credentials
+        if _credentials is not None:
+            res.extend(_credentials.prsrc(f'{self_name}.credentials', False).splitlines())
+        _initial_credentials = self.initial_credentials
+        for _element in _initial_credentials.elements:
+            res.append('')
+            res.append(f"# List /device/initial-credentials element: {_element.to_gdata().key_str(['username', 'password', 'key'])}")
+            list_elem = f'initial_credentials_element = {self_name}.initial_credentials.create({repr(_element.username)}, {repr(_element.password)}, {repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'initial_credentials_element', False, list_element=True).splitlines())
+        _mock = self.mock
+        if _mock is not None:
+            res.extend(_mock.prsrc(f'{self_name}.mock', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device(yang.adata.MNode):
     elements: list[orchestron_rfs__device_entry]
@@ -1281,6 +1451,19 @@ class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__base_config_entry:
         return orchestron_rfs__rfs__base_config_entry(name=n.get_str('name'), ipv4_address=n.get_str('ipv4-address'), ipv6_address=n.get_str('ipv6-address'), asn=n.get_int('asn'), ibgp_authentication_key=n.get_str('ibgp-authentication-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/base-config')
+            res.append(f'{self_name} = orchestron_rfs__rfs__base_config({repr(self.name)}, {repr(self.ipv4_address)}, {repr(self.ipv6_address)}, {repr(self.asn)}, {repr(self.ibgp_authentication_key)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/base-config'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs__base_config(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__base_config_entry]
     mut def __init__(self, elements=[]):
@@ -1479,6 +1662,19 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_str('device'), interface=n.get_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/backbone-interface/remote')
+            res.append(f'{self_name} = orchestron_rfs__rfs__backbone_interface__remote({repr(self.device)}, {repr(self.interface)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/backbone-interface/remote'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1556,6 +1752,35 @@ class orchestron_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
         return orchestron_rfs__rfs__backbone_interface_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), ipv6_address=n.get_opt_str('ipv6-address'), ipv6_prefix_length=n.get_opt_int('ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_gdata(n.get_container('remote')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/backbone-interface')
+            res.append(f'self_remote = orchestron_rfs__rfs__backbone_interface__remote({repr(self.remote.device)}, {repr(self.remote.interface)})')
+            res.append(f'{self_name} = orchestron_rfs__rfs__backbone_interface({repr(self.name)}, self_remote)')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv4_prefix_length = self.ipv4_prefix_length
+        if _ipv4_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv4_prefix_length = {repr(_ipv4_prefix_length)}')
+        _ipv6_address = self.ipv6_address
+        if _ipv6_address is not None:
+            leaves.append(f'{self_name}.ipv6_address = {repr(_ipv6_address)}')
+        _ipv6_prefix_length = self.ipv6_prefix_length
+        if _ipv6_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv6_prefix_length = {repr(_ipv6_prefix_length)}')
+        _remote = self.remote
+        if _remote is not None:
+            res.extend(_remote.prsrc(f'{self_name}.remote', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/backbone-interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__backbone_interface_entry]
@@ -1739,6 +1964,19 @@ class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
         return orchestron_rfs__rfs__ibgp_neighbor_entry(address=n.get_str('address'), asn=n.get_int('asn'), description=n.get_str('description'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/ibgp-neighbor')
+            res.append(f'{self_name} = orchestron_rfs__rfs__ibgp_neighbor({repr(self.address)}, {repr(self.asn)}, {repr(self.description)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/ibgp-neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ibgp_neighbor_entry]
@@ -1926,6 +2164,22 @@ class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_entry:
         return orchestron_rfs__rfs__vrf_entry(name=n.get_str('name'), description=n.get_opt_str('description'), id=n.get_int('id'), router_id=n.get_int('router-id'), asn=n.get_int('asn'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/vrf')
+            res.append(f'{self_name} = orchestron_rfs__rfs__vrf({repr(self.name)}, {repr(self.id)}, {repr(self.router_id)}, {repr(self.asn)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_entry]
@@ -2125,6 +2379,28 @@ class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
         return orchestron_rfs__rfs__vrf_interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), vrf=n.get_str('vrf'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/vrf-interface')
+            res.append(f'{self_name} = orchestron_rfs__rfs__vrf_interface({repr(self.name)}, {repr(self.vrf)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv4_prefix_length = self.ipv4_prefix_length
+        if _ipv4_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv4_prefix_length = {repr(_ipv4_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/vrf-interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_interface_entry]
@@ -2336,6 +2612,22 @@ class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
         return orchestron_rfs__rfs__ebgp_customer_entry(vrf=n.get_str('vrf'), address=n.get_str('address'), local_asn=n.get_int('local-asn'), peer_asn=n.get_int('peer-asn'), description=n.get_opt_str('description'), authentication_key=n.get_str('authentication-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/ebgp-customer')
+            res.append(f'{self_name} = orchestron_rfs__rfs__ebgp_customer({repr(self.vrf)}, {repr(self.address)}, {repr(self.local_asn)}, {repr(self.peer_asn)}, {repr(self.authentication_key)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/ebgp-customer'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2523,6 +2815,62 @@ class orchestron_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs_entry:
         return orchestron_rfs__rfs_entry(name=n.get_str('name'), base_config=orchestron_rfs__rfs__base_config.from_gdata(n.get_opt_list('base-config')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_gdata(n.get_opt_list('backbone-interface')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_gdata(n.get_opt_list('ibgp-neighbor')), vrf=orchestron_rfs__rfs__vrf.from_gdata(n.get_opt_list('vrf')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_gdata(n.get_opt_list('vrf-interface')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_gdata(n.get_opt_list('ebgp-customer')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs')
+            res.append(f'{self_name} = orchestron_rfs__rfs({repr(self.name)})')
+        leaves = []
+        _base_config = self.base_config
+        for _element in _base_config.elements:
+            res.append('')
+            res.append(f"# List /rfs/base-config element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'base_config_element = {self_name}.base_config.create({repr(_element.name)}, {repr(_element.ipv4_address)}, {repr(_element.ipv6_address)}, {repr(_element.asn)}, {repr(_element.ibgp_authentication_key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'base_config_element', False, list_element=True).splitlines())
+        _backbone_interface = self.backbone_interface
+        for _element in _backbone_interface.elements:
+            res.append('')
+            res.append(f"# List /rfs/backbone-interface element: {_element.to_gdata().key_str(['name'])}")
+            res.append(f'element_remote = orchestron_rfs__rfs__backbone_interface__remote({repr(_element.remote.device)}, {repr(_element.remote.interface)})')
+            list_elem = f'backbone_interface_element = {self_name}.backbone_interface.create({repr(_element.name)}, element_remote)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_interface_element', False, list_element=True).splitlines())
+        _ibgp_neighbor = self.ibgp_neighbor
+        for _element in _ibgp_neighbor.elements:
+            res.append('')
+            res.append(f"# List /rfs/ibgp-neighbor element: {_element.to_gdata().key_str(['address'])}")
+            list_elem = f'ibgp_neighbor_element = {self_name}.ibgp_neighbor.create({repr(_element.address)}, {repr(_element.asn)}, {repr(_element.description)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ibgp_neighbor_element', False, list_element=True).splitlines())
+        _vrf = self.vrf
+        for _element in _vrf.elements:
+            res.append('')
+            res.append(f"# List /rfs/vrf element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'vrf_element = {self_name}.vrf.create({repr(_element.name)}, {repr(_element.id)}, {repr(_element.router_id)}, {repr(_element.asn)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_element', False, list_element=True).splitlines())
+        _vrf_interface = self.vrf_interface
+        for _element in _vrf_interface.elements:
+            res.append('')
+            res.append(f"# List /rfs/vrf-interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'vrf_interface_element = {self_name}.vrf_interface.create({repr(_element.name)}, {repr(_element.vrf)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_interface_element', False, list_element=True).splitlines())
+        _ebgp_customer = self.ebgp_customer
+        for _element in _ebgp_customer.elements:
+            res.append('')
+            res.append(f"# List /rfs/ebgp-customer element: {_element.to_gdata().key_str(['vrf', 'address'])}")
+            list_elem = f'ebgp_customer_element = {self_name}.ebgp_customer.create({repr(_element.vrf)}, {repr(_element.address)}, {repr(_element.local_asn)}, {repr(_element.peer_asn)}, {repr(_element.authentication_key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ebgp_customer_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2690,6 +3038,34 @@ class root(yang.adata.MNode):
         if n != None:
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /device element: {_element.to_gdata().key_str(['name'])}")
+            res.append(f'element_credentials = orchestron_rfs__device__credentials({repr(_element.credentials.username)})')
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.name)}, element_credentials)'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        _rfs = self.rfs
+        for _element in _rfs.elements:
+            res.append('')
+            res.append(f"# List /rfs element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'rfs_element = {self_name}.rfs.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rfs_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_2_loose.act
+++ b/src/respnet/layers/y_2_loose.act
@@ -89,6 +89,19 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
         return orchestron_rfs__device__address__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/address/initial-credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__address__initial_credentials({repr(self.username)}, {repr(self.password)}, {repr(self.key)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/address/initial-credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -244,6 +257,32 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
         return orchestron_rfs__device__address_entry(name=n.get_str('name'), address=n.get_opt_str('address'), port=n.get_opt_str('port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/address')
+            res.append(f'{self_name} = orchestron_rfs__device__address({repr(self.name)})')
+        leaves = []
+        _address = self.address
+        if _address is not None:
+            leaves.append(f'{self_name}.address = {repr(_address)}')
+        _port = self.port
+        if _port is not None:
+            leaves.append(f'{self_name}.port = {repr(_port)}')
+        _initial_credentials = self.initial_credentials
+        for _element in _initial_credentials.elements:
+            res.append('')
+            res.append(f"# List /device/address/initial-credentials element: {_element.to_gdata().key_str(['username', 'password', 'key'])}")
+            list_elem = f'initial_credentials_element = {self_name}.initial_credentials.create({repr(_element.username)}, {repr(_element.password)}, {repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'initial_credentials_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/address'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device__address(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address_entry]
@@ -417,6 +456,22 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
         return orchestron_rfs__device__credentials__key_entry(key=n.get_str('key'), private_key=n.get_opt_str('private-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/credentials/key')
+            res.append(f'{self_name} = orchestron_rfs__device__credentials__key({repr(self.key)})')
+        leaves = []
+        _private_key = self.private_key
+        if _private_key is not None:
+            leaves.append(f'{self_name}.private_key = {repr(_private_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/credentials/key'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[orchestron_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -560,6 +615,32 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
             return orchestron_rfs__device__credentials(username=n.get_opt_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__credentials()')
+        leaves = []
+        _username = self.username
+        if _username is not None:
+            leaves.append(f'{self_name}.username = {repr(_username)}')
+        _password = self.password
+        if _password is not None:
+            leaves.append(f'{self_name}.password = {repr(_password)}')
+        _key = self.key
+        for _element in _key.elements:
+            res.append('')
+            res.append(f"# List /device/credentials/key element: {_element.to_gdata().key_str(['key'])}")
+            list_elem = f'key_element = {self_name}.key.create({repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'key_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__device__credentials(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -647,6 +728,19 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
         return orchestron_rfs__device__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/initial-credentials')
+            res.append(f'{self_name} = orchestron_rfs__device__initial_credentials({repr(self.username)}, {repr(self.password)}, {repr(self.key)})')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/initial-credentials'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__initial_credentials_entry]
@@ -832,6 +926,28 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
         return orchestron_rfs__device__mock__module_entry(name=n.get_str('name'), namespace=n.get_opt_str('namespace'), revision=n.get_opt_str('revision'), feature=n.get_opt_strs('feature'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/mock/module')
+            res.append(f'{self_name} = orchestron_rfs__device__mock__module({repr(self.name)})')
+        leaves = []
+        _namespace = self.namespace
+        if _namespace is not None:
+            leaves.append(f'{self_name}.namespace = {repr(_namespace)}')
+        _revision = self.revision
+        if _revision is not None:
+            leaves.append(f'{self_name}.revision = {repr(_revision)}')
+        _feature = self.feature
+        if _feature is not None:
+            leaves.append(f'{self_name}.feature = {repr(_feature)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/mock/module'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__device__mock__module(yang.adata.MNode):
     elements: list[orchestron_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -980,6 +1096,29 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device/mock')
+            res.append(f'{self_name} = orchestron_rfs__device__mock()')
+        leaves = []
+        _preset = self.preset
+        if _preset is not None:
+            leaves.append(f'{self_name}.preset = {repr(_preset)}')
+        _module = self.module
+        for _element in _module.elements:
+            res.append('')
+            res.append(f"# List /device/mock/module element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'module_element = {self_name}.module.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'module_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/mock'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__device__mock(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1063,6 +1202,45 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
         return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_opt_container('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_container('mock')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /device')
+            res.append(f'{self_name} = orchestron_rfs__device({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _type = self.type
+        if _type is not None:
+            leaves.append(f'{self_name}.type = {repr(_type)}')
+        _address = self.address
+        for _element in _address.elements:
+            res.append('')
+            res.append(f"# List /device/address element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'address_element = {self_name}.address.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'address_element', False, list_element=True).splitlines())
+        _credentials = self.credentials
+        if _credentials is not None:
+            res.extend(_credentials.prsrc(f'{self_name}.credentials', False).splitlines())
+        _initial_credentials = self.initial_credentials
+        for _element in _initial_credentials.elements:
+            res.append('')
+            res.append(f"# List /device/initial-credentials element: {_element.to_gdata().key_str(['username', 'password', 'key'])}")
+            list_elem = f'initial_credentials_element = {self_name}.initial_credentials.create({repr(_element.username)}, {repr(_element.password)}, {repr(_element.key)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'initial_credentials_element', False, list_element=True).splitlines())
+        _mock = self.mock
+        if _mock is not None:
+            res.extend(_mock.prsrc(f'{self_name}.mock', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__device(yang.adata.MNode):
     elements: list[orchestron_rfs__device_entry]
@@ -1281,6 +1459,31 @@ class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__base_config_entry:
         return orchestron_rfs__rfs__base_config_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv6_address=n.get_opt_str('ipv6-address'), asn=n.get_opt_int('asn'), ibgp_authentication_key=n.get_opt_str('ibgp-authentication-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/base-config')
+            res.append(f'{self_name} = orchestron_rfs__rfs__base_config({repr(self.name)})')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv6_address = self.ipv6_address
+        if _ipv6_address is not None:
+            leaves.append(f'{self_name}.ipv6_address = {repr(_ipv6_address)}')
+        _asn = self.asn
+        if _asn is not None:
+            leaves.append(f'{self_name}.asn = {repr(_asn)}')
+        _ibgp_authentication_key = self.ibgp_authentication_key
+        if _ibgp_authentication_key is not None:
+            leaves.append(f'{self_name}.ibgp_authentication_key = {repr(_ibgp_authentication_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/base-config'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs__base_config(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__base_config_entry]
     mut def __init__(self, elements=[]):
@@ -1479,6 +1682,25 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_opt_str('device'), interface=n.get_opt_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/backbone-interface/remote')
+            res.append(f'{self_name} = orchestron_rfs__rfs__backbone_interface__remote()')
+        leaves = []
+        _device = self.device
+        if _device is not None:
+            leaves.append(f'{self_name}.device = {repr(_device)}')
+        _interface = self.interface
+        if _interface is not None:
+            leaves.append(f'{self_name}.interface = {repr(_interface)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/backbone-interface/remote'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1556,6 +1778,34 @@ class orchestron_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
         return orchestron_rfs__rfs__backbone_interface_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), ipv6_address=n.get_opt_str('ipv6-address'), ipv6_prefix_length=n.get_opt_int('ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_gdata(n.get_opt_container('remote')))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/backbone-interface')
+            res.append(f'{self_name} = orchestron_rfs__rfs__backbone_interface({repr(self.name)})')
+        leaves = []
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv4_prefix_length = self.ipv4_prefix_length
+        if _ipv4_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv4_prefix_length = {repr(_ipv4_prefix_length)}')
+        _ipv6_address = self.ipv6_address
+        if _ipv6_address is not None:
+            leaves.append(f'{self_name}.ipv6_address = {repr(_ipv6_address)}')
+        _ipv6_prefix_length = self.ipv6_prefix_length
+        if _ipv6_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv6_prefix_length = {repr(_ipv6_prefix_length)}')
+        _remote = self.remote
+        if _remote is not None:
+            res.extend(_remote.prsrc(f'{self_name}.remote', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/backbone-interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__backbone_interface_entry]
@@ -1739,6 +1989,25 @@ class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
         return orchestron_rfs__rfs__ibgp_neighbor_entry(address=n.get_str('address'), asn=n.get_opt_int('asn'), description=n.get_opt_str('description'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/ibgp-neighbor')
+            res.append(f'{self_name} = orchestron_rfs__rfs__ibgp_neighbor({repr(self.address)})')
+        leaves = []
+        _asn = self.asn
+        if _asn is not None:
+            leaves.append(f'{self_name}.asn = {repr(_asn)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/ibgp-neighbor'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ibgp_neighbor_entry]
@@ -1926,6 +2195,31 @@ class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_entry:
         return orchestron_rfs__rfs__vrf_entry(name=n.get_str('name'), description=n.get_opt_str('description'), id=n.get_opt_int('id'), router_id=n.get_opt_int('router-id'), asn=n.get_opt_int('asn'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/vrf')
+            res.append(f'{self_name} = orchestron_rfs__rfs__vrf({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _id = self.id
+        if _id is not None:
+            leaves.append(f'{self_name}.id = {repr(_id)}')
+        _router_id = self.router_id
+        if _router_id is not None:
+            leaves.append(f'{self_name}.router_id = {repr(_router_id)}')
+        _asn = self.asn
+        if _asn is not None:
+            leaves.append(f'{self_name}.asn = {repr(_asn)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/vrf'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_entry]
@@ -2125,6 +2419,31 @@ class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
         return orchestron_rfs__rfs__vrf_interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), vrf=n.get_opt_str('vrf'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/vrf-interface')
+            res.append(f'{self_name} = orchestron_rfs__rfs__vrf_interface({repr(self.name)})')
+        leaves = []
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _vrf = self.vrf
+        if _vrf is not None:
+            leaves.append(f'{self_name}.vrf = {repr(_vrf)}')
+        _ipv4_address = self.ipv4_address
+        if _ipv4_address is not None:
+            leaves.append(f'{self_name}.ipv4_address = {repr(_ipv4_address)}')
+        _ipv4_prefix_length = self.ipv4_prefix_length
+        if _ipv4_prefix_length is not None:
+            leaves.append(f'{self_name}.ipv4_prefix_length = {repr(_ipv4_prefix_length)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/vrf-interface'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_interface_entry]
@@ -2336,6 +2655,31 @@ class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
         return orchestron_rfs__rfs__ebgp_customer_entry(vrf=n.get_str('vrf'), address=n.get_str('address'), local_asn=n.get_opt_int('local-asn'), peer_asn=n.get_opt_int('peer-asn'), description=n.get_opt_str('description'), authentication_key=n.get_opt_str('authentication-key'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs/ebgp-customer')
+            res.append(f'{self_name} = orchestron_rfs__rfs__ebgp_customer({repr(self.vrf)}, {repr(self.address)})')
+        leaves = []
+        _local_asn = self.local_asn
+        if _local_asn is not None:
+            leaves.append(f'{self_name}.local_asn = {repr(_local_asn)}')
+        _peer_asn = self.peer_asn
+        if _peer_asn is not None:
+            leaves.append(f'{self_name}.peer_asn = {repr(_peer_asn)}')
+        _description = self.description
+        if _description is not None:
+            leaves.append(f'{self_name}.description = {repr(_description)}')
+        _authentication_key = self.authentication_key
+        if _authentication_key is not None:
+            leaves.append(f'{self_name}.authentication_key = {repr(_authentication_key)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs/ebgp-customer'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2523,6 +2867,61 @@ class orchestron_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs_entry:
         return orchestron_rfs__rfs_entry(name=n.get_str('name'), base_config=orchestron_rfs__rfs__base_config.from_gdata(n.get_opt_list('base-config')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_gdata(n.get_opt_list('backbone-interface')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_gdata(n.get_opt_list('ibgp-neighbor')), vrf=orchestron_rfs__rfs__vrf.from_gdata(n.get_opt_list('vrf')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_gdata(n.get_opt_list('vrf-interface')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_gdata(n.get_opt_list('ebgp-customer')))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /rfs')
+            res.append(f'{self_name} = orchestron_rfs__rfs({repr(self.name)})')
+        leaves = []
+        _base_config = self.base_config
+        for _element in _base_config.elements:
+            res.append('')
+            res.append(f"# List /rfs/base-config element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'base_config_element = {self_name}.base_config.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'base_config_element', False, list_element=True).splitlines())
+        _backbone_interface = self.backbone_interface
+        for _element in _backbone_interface.elements:
+            res.append('')
+            res.append(f"# List /rfs/backbone-interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'backbone_interface_element = {self_name}.backbone_interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'backbone_interface_element', False, list_element=True).splitlines())
+        _ibgp_neighbor = self.ibgp_neighbor
+        for _element in _ibgp_neighbor.elements:
+            res.append('')
+            res.append(f"# List /rfs/ibgp-neighbor element: {_element.to_gdata().key_str(['address'])}")
+            list_elem = f'ibgp_neighbor_element = {self_name}.ibgp_neighbor.create({repr(_element.address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ibgp_neighbor_element', False, list_element=True).splitlines())
+        _vrf = self.vrf
+        for _element in _vrf.elements:
+            res.append('')
+            res.append(f"# List /rfs/vrf element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'vrf_element = {self_name}.vrf.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_element', False, list_element=True).splitlines())
+        _vrf_interface = self.vrf_interface
+        for _element in _vrf_interface.elements:
+            res.append('')
+            res.append(f"# List /rfs/vrf-interface element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'vrf_interface_element = {self_name}.vrf_interface.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'vrf_interface_element', False, list_element=True).splitlines())
+        _ebgp_customer = self.ebgp_customer
+        for _element in _ebgp_customer.elements:
+            res.append('')
+            res.append(f"# List /rfs/ebgp-customer element: {_element.to_gdata().key_str(['vrf', 'address'])}")
+            list_elem = f'ebgp_customer_element = {self_name}.ebgp_customer.create({repr(_element.vrf)}, {repr(_element.address)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'ebgp_customer_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /rfs'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_rfs__rfs(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2690,6 +3089,33 @@ class root(yang.adata.MNode):
         if n != None:
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /device element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        _rfs = self.rfs
+        for _element in _rfs.elements:
+            res.append('')
+            res.append(f"# List /rfs element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'rfs_element = {self_name}.rfs.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'rfs_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_3.act
+++ b/src/respnet/layers/y_3.act
@@ -42,6 +42,22 @@ class orchestron_device__devices__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_device__devices__device_entry:
         return orchestron_device__devices__device_entry(name=n.get_str('name'), modset_id=n.get_opt_str('modset_id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /devices/device')
+            res.append(f'{self_name} = orchestron_device__devices__device({repr(self.name)})')
+        leaves = []
+        _modset_id = self.modset_id
+        if _modset_id is not None:
+            leaves.append(f'{self_name}.modset_id = {repr(_modset_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /devices/device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_device__devices__device(yang.adata.MNode):
     elements: list[orchestron_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -175,6 +191,26 @@ class orchestron_device__devices(yang.adata.MNode):
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /devices')
+            res.append(f'{self_name} = orchestron_device__devices()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /devices/device element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /devices'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_device__devices(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -224,6 +260,22 @@ class root(yang.adata.MNode):
         if n != None:
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_container('devices')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _devices = self.devices
+        if _devices is not None:
+            res.extend(_devices.prsrc(f'{self_name}.devices', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/respnet/layers/y_3_loose.act
+++ b/src/respnet/layers/y_3_loose.act
@@ -42,6 +42,22 @@ class orchestron_device__devices__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_device__devices__device_entry:
         return orchestron_device__devices__device_entry(name=n.get_str('name'), modset_id=n.get_opt_str('modset_id'))
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /devices/device')
+            res.append(f'{self_name} = orchestron_device__devices__device({repr(self.name)})')
+        leaves = []
+        _modset_id = self.modset_id
+        if _modset_id is not None:
+            leaves.append(f'{self_name}.modset_id = {repr(_modset_id)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /devices/device'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 class orchestron_device__devices__device(yang.adata.MNode):
     elements: list[orchestron_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -175,6 +191,26 @@ class orchestron_device__devices(yang.adata.MNode):
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /devices')
+            res.append(f'{self_name} = orchestron_device__devices()')
+        leaves = []
+        _device = self.device
+        for _element in _device.elements:
+            res.append('')
+            res.append(f"# List /devices/device element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = f'device_element = {self_name}.device.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc(f'device_element', False, list_element=True).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /devices'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
 
 mut def from_xml_orchestron_device__devices(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -224,6 +260,22 @@ class root(yang.adata.MNode):
         if n != None:
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_container('devices')))
         return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append(f'# Top node: /root')
+            res.append(f'{self_name} = root()')
+        leaves = []
+        _devices = self.devices
+        if _devices is not None:
+            res.extend(_devices.prsrc(f'{self_name}.devices', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/src/test_respnet.act
+++ b/src/test_respnet.act
@@ -10,6 +10,8 @@ import orchestron.device as odev
 
 import respnet.layers
 import respnet.layers.y_0 as cfs_layer
+from respnet.devices.CiscoIosXr_24_1_ncs55a1 import root as xr24
+from respnet.devices.JuniperCRPD_23_4R1_9 import root as crpd23
 
 def rfs_for_device(dev):
     return gdata.Container({
@@ -375,6 +377,32 @@ def _test_l3vpn_svc(t: testing.AsyncT):
 
 def _test_l3vpn_svc_json(t: testing.AsyncT):
     l3vpn_tester(t, lambda n: n.to_json())
+
+def _test_l3vpn_svc_adata(t: testing.AsyncT):
+    def adata_formatter(n: gdata.Node) -> str:
+        res = {}
+        device_list = n.get_container("devices").get_list("device")
+        # We must sort the elements to ensure the output is deterministic
+        for device_entry in gdata.sorted_elements(device_list.elements, device_list.keys):
+            config = device_entry.get_container("config")
+            device_name = str(device_entry.get_leaf("name").val)
+            if device_name == "AMS-CORE-1" or device_name == "FRA-CORE-1":
+                config_ad = xr24.from_gdata(config)
+                res[device_name] = config_ad.prsrc()
+            elif device_name == "STO-CORE-1" or device_name == "LJU-CORE-1":
+                config_ad = crpd23.from_gdata(config)
+                res[device_name] = config_ad.prsrc()
+            else:
+                raise ValueError(f"Unknown device {device_name}")
+
+        # Convert the result to a string representation
+        text = ""
+        for device, adata in res.items():
+            indented_lines = "\n".join([" " * 4 + line for line in adata.splitlines()])
+            text += f"def adata_{device.replace('-', '_')}():\n{indented_lines}\n\n"
+        return text
+
+    l3vpn_tester(t, adata_formatter)
 
 # TODO: enable once gdata after transform is valid (= sorted where it needs to be)
 # def _test_l3vpn_svc_gdata(t: testing.AsyncT):

--- a/test/golden/test_respnet/l3vpn_svc_adata
+++ b/test/golden/test_respnet/l3vpn_svc_adata
@@ -1,0 +1,915 @@
+def adata_AMS_CORE_1():
+    # Top node: /root
+    ad = root()
+    
+    # List /vrfs/vrf element: acme-65501
+    vrf_element = ad.vrfs.vrf.create('acme-65501')
+    vrf_element.description = 'Customer VPN for CUSTOMER-1'
+    
+    # P-container: /vrfs/vrf/address-family/ipv4/unicast
+    unicast = vrf_element.address_family.ipv4.create_unicast()
+    
+    # List /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt element: 65001,65501,False
+    two_byte_as_rt_element = unicast.import_.route_target.two_byte_as_rts.two_byte_as_rt.create(65001, 65501, False)
+    
+    # List /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt element: 65001,65501,False
+    two_byte_as_rt_element = unicast.export.route_target.two_byte_as_rts.two_byte_as_rt.create(65001, 65501, False)
+    
+    # List /router/isis/processes/process element: 1
+    process_element = ad.um_router_isis_cfg_router.isis.processes.process.create('1')
+    process_element.is_type = 'level-2-only'
+    
+    # List /router/isis/processes/process/nets/net element: 49.0001.0100.0000.0001.00
+    net_element = process_element.nets.net.create('49.0001.0100.0000.0001.00')
+    
+    # List /router/isis/processes/process/address-families/address-family element: ipv4,unicast
+    address_family_element = process_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # P-container: /router/isis/processes/process/address-families/address-family/metric-style/wide
+    wide = address_family_element.metric_style.create_wide()
+    
+    # List /router/isis/processes/process/interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = process_element.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    interface_element.circuit_type = 'level-2-only'
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/point-to-point
+    point_to_point = interface_element.create_point_to_point()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: 2
+    level_element = address_family_element.metric.levels.level.create(2)
+    level_element.default_metric = 5000
+    
+    # List /router/isis/processes/process/interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = process_element.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    interface_element.circuit_type = 'level-2-only'
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/point-to-point
+    point_to_point = interface_element.create_point_to_point()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: 2
+    level_element = address_family_element.metric.levels.level.create(2)
+    level_element.default_metric = 5000
+    
+    # List /router/isis/processes/process/interfaces/interface element: Loopback0
+    interface_element = process_element.interfaces.interface.create('Loopback0')
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/passive
+    passive = interface_element.create_passive()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/bgp/as element: 65001
+    as__element = ad.um_router_bgp_cfg_router.bgp.as_.create('65001')
+    
+    # List /router/bgp/as/address-families/address-family element: vpnv4-unicast
+    address_family_element = as__element.address_families.address_family.create('vpnv4-unicast')
+    
+    # List /router/bgp/as/address-families/address-family element: vpnv6-unicast
+    address_family_element = as__element.address_families.address_family.create('vpnv6-unicast')
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.2
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.2')
+    neighbor_element.description = 'FRA-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.3
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.3')
+    neighbor_element.description = 'STO-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.4
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.4')
+    neighbor_element.description = 'LJU-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group element: IPV4-IBGP
+    neighbor_group_element = as__element.neighbor_groups.neighbor_group.create('IPV4-IBGP')
+    neighbor_group_element.remote_as = '65001'
+    neighbor_group_element.update_source = 'Loopback0'
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family element: vpnv4-unicast
+    address_family_element = neighbor_group_element.address_families.address_family.create('vpnv4-unicast')
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family element: vpnv6-unicast
+    address_family_element = neighbor_group_element.address_families.address_family.create('vpnv6-unicast')
+    
+    # P-container: /router/bgp/as/neighbor-groups/neighbor-group/password
+    password = neighbor_group_element.create_password()
+    
+    # Container: /router/bgp/as/neighbor-groups/neighbor-group/password
+    password.encrypted = '045209011F6C4D5B1D11001906020F053E222B267E3E270A'
+    
+    # Container: /router/bgp/as/bgp
+    as__element.bgp.router_id = '10.0.0.1'
+    
+    # List /router/bgp/as/vrfs/vrf element: acme-65501
+    vrf_element = as__element.vrfs.vrf.create('acme-65501')
+    
+    # List /router/bgp/as/vrfs/vrf/address-families/address-family element: ipv4-unicast
+    address_family_element = vrf_element.address_families.address_family.create('ipv4-unicast')
+    
+    # List /router/bgp/as/vrfs/vrf/neighbors/neighbor element: 10.201.1.2
+    neighbor_element = vrf_element.neighbors.neighbor.create('10.201.1.2')
+    neighbor_element.remote_as = '65501'
+    neighbor_element.description = 'Customer eBGP SITE-1 [SNA-1-1] in VPN acme-65501 to 10.201.1.2'
+    
+    # List /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family element: ipv4-unicast
+    address_family_element = neighbor_element.address_families.address_family.create('ipv4-unicast')
+    
+    # Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy
+    address_family_element.route_policy.in_ = 'ACCEPT'
+    address_family_element.route_policy.out = 'ACCEPT'
+    
+    # P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override
+    as_override = address_family_element.create_as_override()
+    
+    # P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password
+    password = neighbor_element.create_password()
+    
+    # Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password
+    password.encrypted = '045A080B0A6C1A1B5C4954'
+    
+    # P-container: /router/bgp/as/vrfs/vrf/rd
+    rd = vrf_element.create_rd()
+    
+    # P-container: /router/bgp/as/vrfs/vrf/rd/two-byte-as
+    two_byte_as = rd.create_two_byte_as()
+    
+    # Container: /router/bgp/as/vrfs/vrf/rd/two-byte-as
+    two_byte_as.as_number = '65001'
+    two_byte_as.index = 655011
+    
+    # P-container: /mpls/ldp
+    ldp = ad.mpls.create_ldp()
+    
+    # List /mpls/ldp/address-families/address-family element: ipv4
+    address_family_element = ldp.address_families.address_family.create('ipv4')
+    
+    # List /mpls/ldp/interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = ldp.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    
+    # List /mpls/ldp/interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = ldp.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    interface_element.shutdown = False
+    interface_element.description = 'Link to FRA-CORE-1 [GigabitEthernet0/0/0/0]'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.7.1'
+    address.netmask = '255.255.255.252'
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    interface_element.shutdown = False
+    interface_element.description = 'Link to STO-CORE-1 [eth1]'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.20.1'
+    address.netmask = '255.255.255.252'
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/2
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/2')
+    interface_element.shutdown = False
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/2.100
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/2.100')
+    interface_element.shutdown = False
+    interface_element.description = 'Customer VPN access SITE-1 [SNA-1-1] in VPN acme-65501'
+    interface_element.vrf = 'acme-65501'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.201.1.1'
+    address.netmask = '255.255.255.252'
+    
+    # Container: /interfaces/interface/um-l2-ethernet-cfg:encapsulation/dot1q
+    interface_element.um_l2_ethernet_cfg_encapsulation.dot1q.vlan_id = 100
+    
+    # List /interfaces/interface element: Loopback0
+    interface_element = ad.interfaces.interface.create('Loopback0')
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.0.1'
+    address.netmask = '255.255.255.255'
+    
+    # Container: /hostname
+    ad.hostname.system_network_name = 'AMS-CORE-1'
+    
+    # List /routing-policy/route-policies/route-policy element: ACCEPT
+    route_policy_element = ad.routing_policy.route_policies.route_policy.create('ACCEPT')
+    route_policy_element.rpl_route_policy = 'route-policy ACCEPT\n  done\nend-policy'
+
+def adata_FRA_CORE_1():
+    # Top node: /root
+    ad = root()
+    
+    # List /vrfs/vrf element: acme-65501
+    vrf_element = ad.vrfs.vrf.create('acme-65501')
+    vrf_element.description = 'Customer VPN for CUSTOMER-1'
+    
+    # P-container: /vrfs/vrf/address-family/ipv4/unicast
+    unicast = vrf_element.address_family.ipv4.create_unicast()
+    
+    # List /vrfs/vrf/address-family/ipv4/unicast/import/route-target/two-byte-as-rts/two-byte-as-rt element: 65001,65501,False
+    two_byte_as_rt_element = unicast.import_.route_target.two_byte_as_rts.two_byte_as_rt.create(65001, 65501, False)
+    
+    # List /vrfs/vrf/address-family/ipv4/unicast/export/route-target/two-byte-as-rts/two-byte-as-rt element: 65001,65501,False
+    two_byte_as_rt_element = unicast.export.route_target.two_byte_as_rts.two_byte_as_rt.create(65001, 65501, False)
+    
+    # List /router/isis/processes/process element: 1
+    process_element = ad.um_router_isis_cfg_router.isis.processes.process.create('1')
+    process_element.is_type = 'level-2-only'
+    
+    # List /router/isis/processes/process/nets/net element: 49.0001.0100.0000.0002.00
+    net_element = process_element.nets.net.create('49.0001.0100.0000.0002.00')
+    
+    # List /router/isis/processes/process/address-families/address-family element: ipv4,unicast
+    address_family_element = process_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # P-container: /router/isis/processes/process/address-families/address-family/metric-style/wide
+    wide = address_family_element.metric_style.create_wide()
+    
+    # List /router/isis/processes/process/interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = process_element.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    interface_element.circuit_type = 'level-2-only'
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/point-to-point
+    point_to_point = interface_element.create_point_to_point()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: 2
+    level_element = address_family_element.metric.levels.level.create(2)
+    level_element.default_metric = 5000
+    
+    # List /router/isis/processes/process/interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = process_element.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    interface_element.circuit_type = 'level-2-only'
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/point-to-point
+    point_to_point = interface_element.create_point_to_point()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: 2
+    level_element = address_family_element.metric.levels.level.create(2)
+    level_element.default_metric = 5000
+    
+    # List /router/isis/processes/process/interfaces/interface element: GigabitEthernet0/0/0/2
+    interface_element = process_element.interfaces.interface.create('GigabitEthernet0/0/0/2')
+    interface_element.circuit_type = 'level-2-only'
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/point-to-point
+    point_to_point = interface_element.create_point_to_point()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family/metric/levels/level element: 2
+    level_element = address_family_element.metric.levels.level.create(2)
+    level_element.default_metric = 5000
+    
+    # List /router/isis/processes/process/interfaces/interface element: Loopback0
+    interface_element = process_element.interfaces.interface.create('Loopback0')
+    
+    # P-container: /router/isis/processes/process/interfaces/interface/passive
+    passive = interface_element.create_passive()
+    
+    # List /router/isis/processes/process/interfaces/interface/address-families/address-family element: ipv4,unicast
+    address_family_element = interface_element.address_families.address_family.create('ipv4', 'unicast')
+    
+    # List /router/bgp/as element: 65001
+    as__element = ad.um_router_bgp_cfg_router.bgp.as_.create('65001')
+    
+    # List /router/bgp/as/address-families/address-family element: vpnv4-unicast
+    address_family_element = as__element.address_families.address_family.create('vpnv4-unicast')
+    
+    # List /router/bgp/as/address-families/address-family element: vpnv6-unicast
+    address_family_element = as__element.address_families.address_family.create('vpnv6-unicast')
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.1
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.1')
+    neighbor_element.description = 'AMS-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.3
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.3')
+    neighbor_element.description = 'STO-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbors/neighbor element: 10.0.0.4
+    neighbor_element = as__element.neighbors.neighbor.create('10.0.0.4')
+    neighbor_element.description = 'LJU-CORE-1'
+    
+    # Container: /router/bgp/as/neighbors/neighbor/use
+    neighbor_element.use.neighbor_group = 'IPV4-IBGP'
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group element: IPV4-IBGP
+    neighbor_group_element = as__element.neighbor_groups.neighbor_group.create('IPV4-IBGP')
+    neighbor_group_element.remote_as = '65001'
+    neighbor_group_element.update_source = 'Loopback0'
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family element: vpnv4-unicast
+    address_family_element = neighbor_group_element.address_families.address_family.create('vpnv4-unicast')
+    
+    # List /router/bgp/as/neighbor-groups/neighbor-group/address-families/address-family element: vpnv6-unicast
+    address_family_element = neighbor_group_element.address_families.address_family.create('vpnv6-unicast')
+    
+    # P-container: /router/bgp/as/neighbor-groups/neighbor-group/password
+    password = neighbor_group_element.create_password()
+    
+    # Container: /router/bgp/as/neighbor-groups/neighbor-group/password
+    password.encrypted = '045209011F6C4D5B1D11001906020F053E222B267E3E270A'
+    
+    # Container: /router/bgp/as/bgp
+    as__element.bgp.router_id = '10.0.0.2'
+    
+    # List /router/bgp/as/vrfs/vrf element: acme-65501
+    vrf_element = as__element.vrfs.vrf.create('acme-65501')
+    
+    # List /router/bgp/as/vrfs/vrf/address-families/address-family element: ipv4-unicast
+    address_family_element = vrf_element.address_families.address_family.create('ipv4-unicast')
+    
+    # List /router/bgp/as/vrfs/vrf/neighbors/neighbor element: 10.202.1.2
+    neighbor_element = vrf_element.neighbors.neighbor.create('10.202.1.2')
+    neighbor_element.remote_as = '65501'
+    neighbor_element.description = 'Customer eBGP SITE-2 [SNA-2-1] in VPN acme-65501 to 10.202.1.2'
+    
+    # List /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family element: ipv4-unicast
+    address_family_element = neighbor_element.address_families.address_family.create('ipv4-unicast')
+    
+    # Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/route-policy
+    address_family_element.route_policy.in_ = 'ACCEPT'
+    address_family_element.route_policy.out = 'ACCEPT'
+    
+    # P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/address-families/address-family/as-override
+    as_override = address_family_element.create_as_override()
+    
+    # P-container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password
+    password = neighbor_element.create_password()
+    
+    # Container: /router/bgp/as/vrfs/vrf/neighbors/neighbor/password
+    password.encrypted = '045A080B0A6C1A1B5C4954'
+    
+    # P-container: /router/bgp/as/vrfs/vrf/rd
+    rd = vrf_element.create_rd()
+    
+    # P-container: /router/bgp/as/vrfs/vrf/rd/two-byte-as
+    two_byte_as = rd.create_two_byte_as()
+    
+    # Container: /router/bgp/as/vrfs/vrf/rd/two-byte-as
+    two_byte_as.as_number = '65001'
+    two_byte_as.index = 655012
+    
+    # P-container: /mpls/ldp
+    ldp = ad.mpls.create_ldp()
+    
+    # List /mpls/ldp/address-families/address-family element: ipv4
+    address_family_element = ldp.address_families.address_family.create('ipv4')
+    
+    # List /mpls/ldp/interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = ldp.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    
+    # List /mpls/ldp/interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = ldp.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    
+    # List /mpls/ldp/interfaces/interface element: GigabitEthernet0/0/0/2
+    interface_element = ldp.interfaces.interface.create('GigabitEthernet0/0/0/2')
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/0
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/0')
+    interface_element.shutdown = False
+    interface_element.description = 'Link to AMS-CORE-1 [GigabitEthernet0/0/0/0]'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.7.2'
+    address.netmask = '255.255.255.252'
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/1
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/1')
+    interface_element.shutdown = False
+    interface_element.description = 'Link to STO-CORE-1 [eth2]'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.25.1'
+    address.netmask = '255.255.255.252'
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/2
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/2')
+    interface_element.shutdown = False
+    interface_element.description = 'Link to LJU-CORE-1 [eth1]'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.18.1'
+    address.netmask = '255.255.255.252'
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/3
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/3')
+    interface_element.shutdown = False
+    
+    # List /interfaces/interface element: GigabitEthernet0/0/0/3.100
+    interface_element = ad.interfaces.interface.create('GigabitEthernet0/0/0/3.100')
+    interface_element.shutdown = False
+    interface_element.description = 'Customer VPN access SITE-2 [SNA-2-1] in VPN acme-65501'
+    interface_element.vrf = 'acme-65501'
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.202.1.1'
+    address.netmask = '255.255.255.252'
+    
+    # Container: /interfaces/interface/um-l2-ethernet-cfg:encapsulation/dot1q
+    interface_element.um_l2_ethernet_cfg_encapsulation.dot1q.vlan_id = 100
+    
+    # List /interfaces/interface element: Loopback0
+    interface_element = ad.interfaces.interface.create('Loopback0')
+    
+    # P-container: /interfaces/interface/ipv4/addresses/address
+    address = interface_element.ipv4.addresses.create_address()
+    
+    # Container: /interfaces/interface/ipv4/addresses/address
+    address.address = '10.0.0.2'
+    address.netmask = '255.255.255.255'
+    
+    # Container: /hostname
+    ad.hostname.system_network_name = 'FRA-CORE-1'
+    
+    # List /routing-policy/route-policies/route-policy element: ACCEPT
+    route_policy_element = ad.routing_policy.route_policies.route_policy.create('ACCEPT')
+    route_policy_element.rpl_route_policy = 'route-policy ACCEPT\n  done\nend-policy'
+
+def adata_LJU_CORE_1():
+    # Top node: /root
+    ad = root()
+    
+    # Container: /configuration/system
+    ad.configuration.system.host_name = 'LJU-CORE-1'
+    
+    # List /configuration/interfaces/interface element: eth1
+    interface_element = ad.configuration.interfaces.interface.create('eth1')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    unit_element.description = 'Link to FRA-CORE-1 [GigabitEthernet0/0/0/2]'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.18.2/30
+    address_element = inet.address.create('10.0.18.2/30')
+    
+    # List /configuration/interfaces/interface element: eth2
+    interface_element = ad.configuration.interfaces.interface.create('eth2')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    unit_element.description = 'Link to STO-CORE-1 [eth3]'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.31.2/30
+    address_element = inet.address.create('10.0.31.2/30')
+    
+    # List /configuration/interfaces/interface element: eth3
+    interface_element = ad.configuration.interfaces.interface.create('eth3')
+    interface_element.description = 'Customer VPN access SITE-4 [SNA-4-1] in VPN acme-65501'
+    interface_element.encapsulation = 'flexible-ethernet-services'
+    interface_element.flexible_vlan_tagging = True
+    
+    # List /configuration/interfaces/interface/unit element: 100
+    unit_element = interface_element.unit.create('100')
+    unit_element.description = 'Customer VPN access SITE-4 [SNA-4-1] in VPN acme-65501'
+    unit_element.vlan_id = '100'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.204.1.1/30
+    address_element = inet.address.create('10.204.1.1/30')
+    
+    # List /configuration/interfaces/interface element: lo0
+    interface_element = ad.configuration.interfaces.interface.create('lo0')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.0.4/32
+    address_element = inet.address.create('10.0.0.4/32')
+    
+    # P-container: /configuration/interfaces/interface/unit/family/iso
+    iso = unit_element.family.create_iso()
+    
+    # List /configuration/interfaces/interface/unit/family/iso/address element: 49.0001.0100.0000.0004.00
+    address_element = iso.address.create('49.0001.0100.0000.0004.00')
+    
+    # List /configuration/routing-instances/instance element: acme-65501
+    instance_element = ad.configuration.routing_instances.instance.create('acme-65501')
+    instance_element.apply_groups = []
+    instance_element.apply_groups_except = []
+    instance_element.instance_type = 'vrf'
+    
+    # List /configuration/routing-instances/instance/interface element: eth3.100
+    interface_element = instance_element.interface.create('eth3.100')
+    
+    # Container: /configuration/routing-instances/instance/route-distinguisher
+    instance_element.route_distinguisher.rd_type = '65001:655014'
+    
+    # Container: /configuration/routing-instances/instance/vrf-target
+    instance_element.vrf_target.community = 'target:65001:65501'
+    
+    # P-container: /configuration/routing-instances/instance/vrf-table-label
+    vrf_table_label = instance_element.create_vrf_table_label()
+    
+    # List /configuration/routing-instances/instance/protocols/bgp/group element: customer
+    group_element = instance_element.protocols.bgp.group.create('customer')
+    group_element.passive = True
+    group_element.import_ = []
+    group_element.export = []
+    
+    # List /configuration/routing-instances/instance/protocols/bgp/group/neighbor element: 10.204.1.2
+    neighbor_element = group_element.neighbor.create('10.204.1.2')
+    neighbor_element.description = 'Customer eBGP SITE-4 [SNA-4-1] in VPN acme-65501 to 10.204.1.2'
+    neighbor_element.peer_as = '65501'
+    neighbor_element.authentication_key = 'acme-65501'
+    neighbor_element.as_override = True
+    
+    # Container: /configuration/routing-options/autonomous-system
+    ad.configuration.routing_options.autonomous_system.as_number = '65001'
+    
+    # Container: /configuration/protocols/bgp
+    ad.configuration.protocols.bgp.log_updown = True
+    
+    # List /configuration/protocols/bgp/group element: IPV4-IBGP
+    group_element = ad.configuration.protocols.bgp.group.create('IPV4-IBGP')
+    group_element.type = 'internal'
+    group_element.local_address = '10.0.0.4'
+    group_element.hold_time = 90
+    group_element.authentication_key = 'ibgp-authentication-key'
+    group_element.export = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast
+    unicast = group_element.family.inet_vpn.create_unicast()
+    
+    # Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/extended-route-retention
+    unicast.graceful_restart.long_lived.extended_route_retention.retention_policy = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast
+    unicast = group_element.family.inet6_vpn.create_unicast()
+    
+    # Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/extended-route-retention
+    unicast.graceful_restart.long_lived.extended_route_retention.retention_policy = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/route-target
+    route_target = group_element.family.create_route_target()
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.1
+    neighbor_element = group_element.neighbor.create('10.0.0.1')
+    neighbor_element.description = 'AMS-CORE-1'
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.2
+    neighbor_element = group_element.neighbor.create('10.0.0.2')
+    neighbor_element.description = 'FRA-CORE-1'
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.3
+    neighbor_element = group_element.neighbor.create('10.0.0.3')
+    neighbor_element.description = 'STO-CORE-1'
+    
+    # Container: /configuration/protocols/isis
+    ad.configuration.protocols.isis.lsp_lifetime = 65535
+    
+    # List /configuration/protocols/isis/interface element: eth1
+    interface_element = ad.configuration.protocols.isis.interface.create('eth1')
+    interface_element.point_to_point = True
+    
+    # List /configuration/protocols/isis/interface/level element: 1
+    level_element = interface_element.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/interface/level element: 2
+    level_element = interface_element.level.create(2)
+    level_element.metric = 5000
+    
+    # List /configuration/protocols/isis/interface element: eth2
+    interface_element = ad.configuration.protocols.isis.interface.create('eth2')
+    interface_element.point_to_point = True
+    
+    # List /configuration/protocols/isis/interface/level element: 1
+    level_element = interface_element.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/interface/level element: 2
+    level_element = interface_element.level.create(2)
+    level_element.metric = 5000
+    
+    # List /configuration/protocols/isis/interface element: lo0.0
+    interface_element = ad.configuration.protocols.isis.interface.create('lo0.0')
+    
+    # P-container: /configuration/protocols/isis/interface/passive
+    passive = interface_element.create_passive()
+    
+    # List /configuration/protocols/isis/level element: 1
+    level_element = ad.configuration.protocols.isis.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/level element: 2
+    level_element = ad.configuration.protocols.isis.level.create(2)
+    level_element.wide_metrics_only = True
+    
+    # List /configuration/protocols/ldp/interface element: eth1
+    interface_element = ad.configuration.protocols.ldp.interface.create('eth1')
+    
+    # List /configuration/protocols/ldp/interface element: eth2
+    interface_element = ad.configuration.protocols.ldp.interface.create('eth2')
+    
+    # List /configuration/protocols/mpls/interface element: eth1
+    interface_element = ad.configuration.protocols.mpls.interface.create('eth1')
+    interface_element.srlg = []
+    interface_element.admin_group = []
+    interface_element.admin_group_extended = []
+    
+    # List /configuration/protocols/mpls/interface element: eth2
+    interface_element = ad.configuration.protocols.mpls.interface.create('eth2')
+    interface_element.srlg = []
+    interface_element.admin_group = []
+    interface_element.admin_group_extended = []
+
+def adata_STO_CORE_1():
+    # Top node: /root
+    ad = root()
+    
+    # Container: /configuration/system
+    ad.configuration.system.host_name = 'STO-CORE-1'
+    
+    # List /configuration/interfaces/interface element: eth1
+    interface_element = ad.configuration.interfaces.interface.create('eth1')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    unit_element.description = 'Link to AMS-CORE-1 [GigabitEthernet0/0/0/1]'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.20.2/30
+    address_element = inet.address.create('10.0.20.2/30')
+    
+    # List /configuration/interfaces/interface element: eth2
+    interface_element = ad.configuration.interfaces.interface.create('eth2')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    unit_element.description = 'Link to FRA-CORE-1 [GigabitEthernet0/0/0/1]'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.25.2/30
+    address_element = inet.address.create('10.0.25.2/30')
+    
+    # List /configuration/interfaces/interface element: eth3
+    interface_element = ad.configuration.interfaces.interface.create('eth3')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    unit_element.description = 'Link to LJU-CORE-1 [eth2]'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.31.1/30
+    address_element = inet.address.create('10.0.31.1/30')
+    
+    # List /configuration/interfaces/interface element: eth4
+    interface_element = ad.configuration.interfaces.interface.create('eth4')
+    interface_element.description = 'Customer VPN access SITE-3 [SNA-3-1] in VPN acme-65501'
+    interface_element.encapsulation = 'flexible-ethernet-services'
+    interface_element.flexible_vlan_tagging = True
+    
+    # List /configuration/interfaces/interface/unit element: 100
+    unit_element = interface_element.unit.create('100')
+    unit_element.description = 'Customer VPN access SITE-3 [SNA-3-1] in VPN acme-65501'
+    unit_element.vlan_id = '100'
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.203.1.1/30
+    address_element = inet.address.create('10.203.1.1/30')
+    
+    # List /configuration/interfaces/interface element: lo0
+    interface_element = ad.configuration.interfaces.interface.create('lo0')
+    
+    # List /configuration/interfaces/interface/unit element: 0
+    unit_element = interface_element.unit.create('0')
+    
+    # P-container: /configuration/interfaces/interface/unit/family/inet
+    inet = unit_element.family.create_inet()
+    
+    # List /configuration/interfaces/interface/unit/family/inet/address element: 10.0.0.3/32
+    address_element = inet.address.create('10.0.0.3/32')
+    
+    # P-container: /configuration/interfaces/interface/unit/family/iso
+    iso = unit_element.family.create_iso()
+    
+    # List /configuration/interfaces/interface/unit/family/iso/address element: 49.0001.0100.0000.0003.00
+    address_element = iso.address.create('49.0001.0100.0000.0003.00')
+    
+    # List /configuration/routing-instances/instance element: acme-65501
+    instance_element = ad.configuration.routing_instances.instance.create('acme-65501')
+    instance_element.apply_groups = []
+    instance_element.apply_groups_except = []
+    instance_element.instance_type = 'vrf'
+    
+    # List /configuration/routing-instances/instance/interface element: eth4.100
+    interface_element = instance_element.interface.create('eth4.100')
+    
+    # Container: /configuration/routing-instances/instance/route-distinguisher
+    instance_element.route_distinguisher.rd_type = '65001:655013'
+    
+    # Container: /configuration/routing-instances/instance/vrf-target
+    instance_element.vrf_target.community = 'target:65001:65501'
+    
+    # P-container: /configuration/routing-instances/instance/vrf-table-label
+    vrf_table_label = instance_element.create_vrf_table_label()
+    
+    # List /configuration/routing-instances/instance/protocols/bgp/group element: customer
+    group_element = instance_element.protocols.bgp.group.create('customer')
+    group_element.passive = True
+    group_element.import_ = []
+    group_element.export = []
+    
+    # List /configuration/routing-instances/instance/protocols/bgp/group/neighbor element: 10.203.1.2
+    neighbor_element = group_element.neighbor.create('10.203.1.2')
+    neighbor_element.description = 'Customer eBGP SITE-3 [SNA-3-1] in VPN acme-65501 to 10.203.1.2'
+    neighbor_element.peer_as = '65501'
+    neighbor_element.authentication_key = 'acme-65501'
+    neighbor_element.as_override = True
+    
+    # Container: /configuration/routing-options/autonomous-system
+    ad.configuration.routing_options.autonomous_system.as_number = '65001'
+    
+    # Container: /configuration/protocols/bgp
+    ad.configuration.protocols.bgp.log_updown = True
+    
+    # List /configuration/protocols/bgp/group element: IPV4-IBGP
+    group_element = ad.configuration.protocols.bgp.group.create('IPV4-IBGP')
+    group_element.type = 'internal'
+    group_element.local_address = '10.0.0.3'
+    group_element.hold_time = 90
+    group_element.authentication_key = 'ibgp-authentication-key'
+    group_element.export = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/inet-vpn/unicast
+    unicast = group_element.family.inet_vpn.create_unicast()
+    
+    # Container: /configuration/protocols/bgp/group/family/inet-vpn/unicast/graceful-restart/long-lived/extended-route-retention
+    unicast.graceful_restart.long_lived.extended_route_retention.retention_policy = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast
+    unicast = group_element.family.inet6_vpn.create_unicast()
+    
+    # Container: /configuration/protocols/bgp/group/family/inet6-vpn/unicast/graceful-restart/long-lived/extended-route-retention
+    unicast.graceful_restart.long_lived.extended_route_retention.retention_policy = []
+    
+    # P-container: /configuration/protocols/bgp/group/family/route-target
+    route_target = group_element.family.create_route_target()
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.1
+    neighbor_element = group_element.neighbor.create('10.0.0.1')
+    neighbor_element.description = 'AMS-CORE-1'
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.2
+    neighbor_element = group_element.neighbor.create('10.0.0.2')
+    neighbor_element.description = 'FRA-CORE-1'
+    
+    # List /configuration/protocols/bgp/group/neighbor element: 10.0.0.4
+    neighbor_element = group_element.neighbor.create('10.0.0.4')
+    neighbor_element.description = 'LJU-CORE-1'
+    
+    # Container: /configuration/protocols/isis
+    ad.configuration.protocols.isis.lsp_lifetime = 65535
+    
+    # List /configuration/protocols/isis/interface element: eth1
+    interface_element = ad.configuration.protocols.isis.interface.create('eth1')
+    interface_element.point_to_point = True
+    
+    # List /configuration/protocols/isis/interface/level element: 1
+    level_element = interface_element.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/interface/level element: 2
+    level_element = interface_element.level.create(2)
+    level_element.metric = 5000
+    
+    # List /configuration/protocols/isis/interface element: eth2
+    interface_element = ad.configuration.protocols.isis.interface.create('eth2')
+    interface_element.point_to_point = True
+    
+    # List /configuration/protocols/isis/interface/level element: 1
+    level_element = interface_element.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/interface/level element: 2
+    level_element = interface_element.level.create(2)
+    level_element.metric = 5000
+    
+    # List /configuration/protocols/isis/interface element: eth3
+    interface_element = ad.configuration.protocols.isis.interface.create('eth3')
+    interface_element.point_to_point = True
+    
+    # List /configuration/protocols/isis/interface/level element: 1
+    level_element = interface_element.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/interface/level element: 2
+    level_element = interface_element.level.create(2)
+    level_element.metric = 5000
+    
+    # List /configuration/protocols/isis/interface element: lo0.0
+    interface_element = ad.configuration.protocols.isis.interface.create('lo0.0')
+    
+    # P-container: /configuration/protocols/isis/interface/passive
+    passive = interface_element.create_passive()
+    
+    # List /configuration/protocols/isis/level element: 1
+    level_element = ad.configuration.protocols.isis.level.create(1)
+    level_element.disable = True
+    
+    # List /configuration/protocols/isis/level element: 2
+    level_element = ad.configuration.protocols.isis.level.create(2)
+    level_element.wide_metrics_only = True
+    
+    # List /configuration/protocols/ldp/interface element: eth1
+    interface_element = ad.configuration.protocols.ldp.interface.create('eth1')
+    
+    # List /configuration/protocols/ldp/interface element: eth2
+    interface_element = ad.configuration.protocols.ldp.interface.create('eth2')
+    
+    # List /configuration/protocols/ldp/interface element: eth3
+    interface_element = ad.configuration.protocols.ldp.interface.create('eth3')
+    
+    # List /configuration/protocols/mpls/interface element: eth1
+    interface_element = ad.configuration.protocols.mpls.interface.create('eth1')
+    interface_element.srlg = []
+    interface_element.admin_group = []
+    interface_element.admin_group_extended = []
+    
+    # List /configuration/protocols/mpls/interface element: eth2
+    interface_element = ad.configuration.protocols.mpls.interface.create('eth2')
+    interface_element.srlg = []
+    interface_element.admin_group = []
+    interface_element.admin_group_extended = []
+    
+    # List /configuration/protocols/mpls/interface element: eth3
+    interface_element = ad.configuration.protocols.mpls.interface.create('eth3')
+    interface_element.srlg = []
+    interface_element.admin_group = []
+    interface_element.admin_group_extended = []
+


### PR DESCRIPTION
Track adata.prsrc() output for device layer as golden config. This ensures we're able to print the adata for the supported device models.

I will extend the REST API to support fetching adata code for an arbitrary layer in a separate PR.