### PR TITLE
Run apt update before installing packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
           # IOS XRd
           sudo sysctl -w fs.inotify.max_user_instances=64000
           # cRPD
+          sudo apt-get update
           sudo apt-get install -qy linux-modules-extra-$(uname -r)
           sudo modprobe mpls_router mpls_gso vrf
       - name: "Check out repository code"


### PR DESCRIPTION
Fixes failing build. Only ARM runners were affected, but it was only a matter of time before one of the local repos drifted out of sync.