### PR TITLE
Refactor API for getting device config

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/3f191dabce4690014fe2350a65ddc5a91276d748.zip",
-            "hash": "1220fa4a8fa1cffce15893a491b036adcb105a9e7d6b45cbf3657dbf444ccd2aabe9"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f425c61cc74e243c80b895758e51281ad7297fe0.zip",
+            "hash": "12209d971cc5d563ae4879c1ff223f5467945db029c520afcf480a2d0c37776c6360"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/3f191dabce4690014fe2350a65ddc5a91276d748.zip",
-            "hash": "1220fa4a8fa1cffce15893a491b036adcb105a9e7d6b45cbf3657dbf444ccd2aabe9"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f425c61cc74e243c80b895758e51281ad7297fe0.zip",
+            "hash": "12209d971cc5d563ae4879c1ff223f5467945db029c520afcf480a2d0c37776c6360"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/src/respnet.act
+++ b/src/respnet.act
@@ -26,8 +26,7 @@ import respnet.layers.y_1_loose
 import respnet.layers.y_2_loose
 import respnet.layers.y_3_loose
 
-from respnet.devices.CiscoIosXr_24_1_ncs55a1 import root as xr24
-from respnet.devices.JuniperCRPD_23_4R1_9 import root as crpd23
+import respnet.sysspec
 
 import testing
 
@@ -146,7 +145,9 @@ actor main(env):
         if request.method == "GET":
             if len(path_elements) > 3 and path_elements[1] == "device":
                 try:
-                    dev_name = path_elements[2]
+                    # We use upper case for device names in our configs
+                    # TODO: maybe we should somehow normalize that?!
+                    dev_name = path_elements[2].upper()
                     dev = dev_mgr.get(dev_name)
                     if path_elements[3] == "capabilities":
                         respond(200, {}, str(dev.get_capabilities()))
@@ -159,28 +160,30 @@ actor main(env):
                         txt += r"}"
                         respond(200, {}, txt)
                         return
-                    if path_elements[3] == 'adata':
+                    if path_elements[3] == 'running':
                         modset, _ = dev.get_modules()
+                        device_type = None
                         if "Cisco-IOS-XR-um-hostname-cfg" in modset:
+                            device_type = respnet.sysspec.device_types["CiscoIosXr_24_1_ncs55a1"]
+                        elif "http://xml.juniper.net/netconf/junos/1.0" in modset or "junos-conf-root" in modset:
+                            device_type = respnet.sysspec.device_types["JuniperCRPD_23_4R1_9"]
+                        if device_type is not None:
                             session = cfs.newsession()
                             device_layer = session.below().below().below().get()
                             device_entry = device_layer.get_cnt("devices").get_list("device").get_list_entry(dev_name)
-                            config = device_entry.get_cnt("config")
-                            config_ad = xr24.from_gdata(config)
-                            respond(200, {}, config_ad.prsrc())
-                            return
-                        if "http://xml.juniper.net/netconf/junos/1.0" in modset or "junos-conf-root" in modset:
-                            session = cfs.newsession()
-                            device_layer = session.below().below().below().get()
-                            device_entry = device_layer.get_cnt("devices").get_list("device").get_list_entry(dev_name)
-                            config = device_entry.get_cnt("config")
-                            config_ad = crpd23.from_gdata(config)
-                            respond(200, {}, config_ad.prsrc())
+                            config_gd = device_entry.get_cnt("config")
+                            if request.headers.get("accept") == "application/adata+text":
+                                config_ad = device_type.from_gdata(config_gd)
+                                response = config_ad.prsrc()
+                            else:
+                                response = config_gd.to_xmlstr()
+                            respond(200, {"Content-type": request.headers.get_def("accept", "application/xml+text")}, response)
                             return
 
                     respond(404, {}, "Not found")
                     return
                 except Exception as e:
+                    log.error(str(e))
                     respond(404, {}, "Not found")
                     return
             elif len(path_elements) == 3 and path_elements[1] == "layer":

--- a/src/respnet/sysspec.act
+++ b/src/respnet/sysspec.act
@@ -1,16 +1,20 @@
 import orchestron.device as odev
 
 import respnet.devices.CiscoIosXr_24_1_ncs55a1
+from respnet.devices.CiscoIosXr_24_1_ncs55a1 import root as CiscoIosXr_24_1_ncs55a1_root
 import respnet.devices.JuniperCRPD_23_4R1_9
+from respnet.devices.JuniperCRPD_23_4R1_9 import root as JuniperCRPD_23_4R1_9_root
 device_types = {
     "CiscoIosXr_24_1_ncs55a1": odev.DeviceType(name="CiscoIosXr_24_1_ncs55a1",
             schema_namespaces=respnet.devices.CiscoIosXr_24_1_ncs55a1.schema_namespaces,
             root=respnet.devices.CiscoIosXr_24_1_ncs55a1.root,
+            from_gdata=CiscoIosXr_24_1_ncs55a1_root.from_gdata,
             from_xml=respnet.devices.CiscoIosXr_24_1_ncs55a1.from_xml
         ),
     "JuniperCRPD_23_4R1_9": odev.DeviceType(name="JuniperCRPD_23_4R1_9",
             schema_namespaces=respnet.devices.JuniperCRPD_23_4R1_9.schema_namespaces,
             root=respnet.devices.JuniperCRPD_23_4R1_9.root,
+            from_gdata=JuniperCRPD_23_4R1_9_root.from_gdata,
             from_xml=respnet.devices.JuniperCRPD_23_4R1_9.from_xml
         ),
 }

--- a/test/common/quicklab.mk
+++ b/test/common/quicklab.mk
@@ -85,6 +85,14 @@ get-config-json0 get-config-json1 get-config-json2 get-config-json3:
 get-config-adata0 get-config-adata1 get-config-adata2 get-config-adata3:
 	@curl -H "Accept: application/adata+text" http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/layer/$(subst get-config-adata,,$@)
 
+.PHONY: $(addprefix get-running-,$(ROUTERS_XR) $(ROUTERS_CRPD))
+$(addprefix get-running-,$(ROUTERS_XR) $(ROUTERS_CRPD)):
+	@curl $(HEADERS) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/device/$(subst get-running-,,$@)/running
+
+.PHONY: $(addprefix get-running-adata-,$(ROUTERS_XR) $(ROUTERS_CRPD))
+$(addprefix get-running-adata-,$(ROUTERS_XR) $(ROUTERS_CRPD)):
+	@$(MAKE) HEADERS="-H \"Accept: application/adata+text\"" $(subst adata-,,$@)
+
 .PHONY: delete-config
 delete-config:
 	curl -X DELETE http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf/netinfra:netinfra/routers=STO-CORE-1


### PR DESCRIPTION
Support retrieval of XML or adata. At the moment the "running" config is
still just the merged output of all RFS transforms, so not precisely
what is running on the device.

We use the `DeviceType` spec from *sysspec.act* to get access to the device model parsers. Once `DeviceType` is more integrated with the device actors, the module checking hack can go away ...