### PR TITLE
Remove unnecessary import for staticmethod ref

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/39261f69fcdac1fd805f2e806621ffdfb59b65c0.zip",
-            "hash": "12208af9617647ca5041f748151c353dd70625ef3f5db249141f676c7a549eb7a987"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/3d3fcc23ca723e73147375cadcfcc0f46a076316.zip",
+            "hash": "1220c142d5dc2c09e8d0ae0f6cb9608047130e64096aa082ad04aea47c1a750f3550"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/7cc4357edbaf052885b56c4b88c0eff89bf19e04.zip",
-            "hash": "12205cf1a3590484b28a59d6d3eb3f8a7dea09324c6263763213dea8e41c46abce3b"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/894f2b3150d2be0c3eaef41bcbc1a3b1a1e23d4f.zip",
+            "hash": "1220dee0f1f7529f3a59f854e2b9bc10e2f999b5b03da39f5dd2a961dd90ac6defbe"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/39261f69fcdac1fd805f2e806621ffdfb59b65c0.zip",
-            "hash": "12208af9617647ca5041f748151c353dd70625ef3f5db249141f676c7a549eb7a987"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/3d3fcc23ca723e73147375cadcfcc0f46a076316.zip",
+            "hash": "1220c142d5dc2c09e8d0ae0f6cb9608047130e64096aa082ad04aea47c1a750f3550"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/7cc4357edbaf052885b56c4b88c0eff89bf19e04.zip",
-            "hash": "12205cf1a3590484b28a59d6d3eb3f8a7dea09324c6263763213dea8e41c46abce3b"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/894f2b3150d2be0c3eaef41bcbc1a3b1a1e23d4f.zip",
+            "hash": "1220dee0f1f7529f3a59f854e2b9bc10e2f999b5b03da39f5dd2a961dd90ac6defbe"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/src/respnet/sysspec.act
+++ b/src/respnet/sysspec.act
@@ -1,20 +1,18 @@
 import orchestron.device as odev
 
 import respnet.devices.CiscoIosXr_24_1_ncs55a1
-from respnet.devices.CiscoIosXr_24_1_ncs55a1 import root as CiscoIosXr_24_1_ncs55a1_root
 import respnet.devices.JuniperCRPD_23_4R1_9
-from respnet.devices.JuniperCRPD_23_4R1_9 import root as JuniperCRPD_23_4R1_9_root
 device_types = {
     "CiscoIosXr_24_1_ncs55a1": odev.DeviceType(name="CiscoIosXr_24_1_ncs55a1",
             schema_namespaces=respnet.devices.CiscoIosXr_24_1_ncs55a1.schema_namespaces,
             root=respnet.devices.CiscoIosXr_24_1_ncs55a1.root,
-            from_gdata=CiscoIosXr_24_1_ncs55a1_root.from_gdata,
+            from_gdata=respnet.devices.CiscoIosXr_24_1_ncs55a1.root.from_gdata,
             from_xml=respnet.devices.CiscoIosXr_24_1_ncs55a1.from_xml
         ),
     "JuniperCRPD_23_4R1_9": odev.DeviceType(name="JuniperCRPD_23_4R1_9",
             schema_namespaces=respnet.devices.JuniperCRPD_23_4R1_9.schema_namespaces,
             root=respnet.devices.JuniperCRPD_23_4R1_9.root,
-            from_gdata=JuniperCRPD_23_4R1_9_root.from_gdata,
+            from_gdata=respnet.devices.JuniperCRPD_23_4R1_9.root.from_gdata,
             from_xml=respnet.devices.JuniperCRPD_23_4R1_9.from_xml
         ),
 }


### PR DESCRIPTION
We no longer need to directly import a class containing a static method to create a reference to a static method.