### PR TITLE
Include CPU arch in build targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           name: sorespo-linux-x86_64
           path: out/bin/sorespo
-      - run: acton build --target aarch64-linux-gnu.2.27
+      - run: make build-linux-aarch64
       - uses: actions/upload-artifact@v4
         with:
           name: sorespo-linux-aarch64
           path: out/bin/sorespo
-      - run: acton build --target aarch64-macos
+      - run: make build-macos-aarch64
       - uses: actions/upload-artifact@v4
         with:
           name: sorespo-macos-aarch64

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,17 @@ build:
 build-ldep:
 	$(MAKE) build DEP_OVERRIDES="--dep netconf=../netconf --dep orchestron=../orchestron --dep yang=../acton-yang"
 
-.PHONY: build-linux
-build-linux:
+.PHONY: build-linux-x86_64
+build-linux-x86_64:
 	$(MAKE) build TARGET="--target x86_64-linux-gnu.2.27"
 
-.PHONY: build-aarch64
-build-aarch64:
+.PHONY: build-linux-aarch64
+build-linux-aarch64:
 	$(MAKE) build TARGET="--target aarch64-linux-gnu.2.27"
+
+.PHONY: build-macos-aarch64
+build-macos-aarch64:
+	$(MAKE) build TARGET="--target aarch64-macos"
 
 .PHONY: test
 test:

--- a/docs/tutorials/develop-on-macos.md
+++ b/docs/tutorials/develop-on-macos.md
@@ -149,11 +149,11 @@ SORESPO is running.
 Then in the same terminal window trigger a build.
 * If you are running macOS on Apple Silicon use:
 ```shell
-make -C ../../ build-aarch64
+make -C ../../ build-linux-aarch64
 ```
 * If you are running macOS on Intel use:
 ```shell
-make -C ../../ build-linux
+make -C ../../ build-linux-x86_64
 ```
 *NOTE*: With `-C ../../` we instruct `make` to run the `build-<arch>` recipe
 two levels up from the current directory, saving us the hassle of moving around in
@@ -337,11 +337,11 @@ make -C ../../ gen
 Then in the same terminal window trigger a build.
 * If you are running macOS on Apple Silicon use:
 ```shell
-make -C ../../ build-aarch64
+make -C ../../ build-linux-aarch64
 ```
 * If you are running macOS on Intel use:
 ```shell
-make -C ../../ build-linux
+make -C ../../ build-linux-x86_64
 ```
 
 After the build has completed you can copy your updated binary into the lab and

--- a/docs/tutorials/develop-on-windows.md
+++ b/docs/tutorials/develop-on-windows.md
@@ -157,9 +157,9 @@ SORESPO is running.
 
 Then in the same terminal window trigger a build:
 ```shell
-make -C ../../ build-linux
+make -C ../../ build-linux-x86_64
 ```
-*NOTE*: With `-C ../../` we instruct `make` to run the `build-linux` recipe
+*NOTE*: With `-C ../../` we instruct `make` to run the `build-linux-x86_64` recipe
 two levels up from the current directory, saving us the hassle of moving around in
 the directory structure.
 
@@ -340,7 +340,7 @@ make -C ../../ gen
 
 Then in the same terminal window trigger a build:
 ```shell
-make -C ../../ build-linux
+make -C ../../ build-linux-x86_64
 ```
 
 After the build has completed you can copy your updated binary into the lab and


### PR DESCRIPTION
Avoids ambiguities when cross-compiling for Linux x86_64 on Apple Silicon. Closes #120 