### PR TITLE
Decouple ping (network) test from get-config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,10 @@ jobs:
       IMAGE_PATH: ${{ secrets.IMAGE_PATH || format('ghcr.io/{0}/', github.repository) }}
     needs: build-and-test
     steps:
+      # Pre-fetch the notconf:debug image so that we can use netconf-console later for get-config
+      - name: Pre-fetch ghcr.io/notconf/notconf:debug image
+        run: |
+          docker pull ghcr.io/notconf/notconf:debug &
       - name: Set up env for containers
         run: |
           # IOS XRd
@@ -128,12 +132,12 @@ jobs:
       - name: "Configure quicklab"
         run: |
           make -C test/${{ matrix.TESTENV }} copy run-and-configure
-      - name: "Run quicklab tests"
-        run: |
-          timeout 120 bash -c 'until make -C test/${{ matrix.TESTENV }} test-ping; do echo "Retrying..."; sleep 2; done'
       - name: "Get device configs"
         run: |
           make -C test/${{ matrix.TESTENV }} test-get-config
+      - name: "Run quicklab tests"
+        run: |
+          timeout 120 bash -c 'until make -C test/${{ matrix.TESTENV }} test-ping; do echo "Retrying..."; sleep 2; done'
       - run: |
           make -C test/${{ matrix.TESTENV }} save-logs
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,10 @@ jobs:
           make -C test/${{ matrix.TESTENV }} copy run-and-configure
       - name: "Run quicklab tests"
         run: |
-          timeout 120 bash -c 'until make -C test/${{ matrix.TESTENV }} test; do echo "Retrying..."; sleep 2; done'
+          timeout 120 bash -c 'until make -C test/${{ matrix.TESTENV }} test-ping; do echo "Retrying..."; sleep 2; done'
+      - name: "Get device configs"
+        run: |
+          make -C test/${{ matrix.TESTENV }} test-get-config
       - run: |
           make -C test/${{ matrix.TESTENV }} save-logs
         if: ${{ always() }}

--- a/test/common/containers.mk
+++ b/test/common/containers.mk
@@ -30,14 +30,12 @@ $(addprefix platform-cli-,$(ROUTERS_FRR)):
 	docker exec -it $(TESTENV)-$(subst platform-cli-,,$@) vtysh
 
 
-test:: test-ping
-
 $(addprefix test-ping-,$(ROUTERS_FRR)):
 # brew install coreutils on MacOS
 	timeout --foreground 10s bash -c "until docker exec -t $(TESTENV)-$(@:test-ping-%=%) ping -c 1 -W 1 -I $(SRC) $(IP); do sleep 1; done"
 
 .PHONY: test-ping
-test-ping:
+test-ping::
 # Do a full mesh of ping between all cust-X routers loopbacks
 	@set -e; for i in 1 2 3 4; do \
 		for j in 1 2 3 4; do \

--- a/test/common/quicklab.mk
+++ b/test/common/quicklab.mk
@@ -139,8 +139,16 @@ $(addprefix cli-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL) $(ROUTERS_FRR)): c
 $(addprefix get-dev-config-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
 	docker run $(INTERACTIVE) --rm --network container:$(TESTENV)-otron ghcr.io/notconf/notconf:debug netconf-console2 --host $(@:get-dev-config-%=%) --port 830 --user clab --pass clab@123 --get-config
 
-.phony: test
-test::
+.PHONY: test
+test:
+	$(MAKE) test-ping
+	$(MAKE) test-get-config
+
+.PHONY: test-ping
+test-ping::
+
+.PHONY: test-get-config
+test-get-config:
 	$(MAKE) $(addprefix get-dev-config-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL))
 
 .PHONY: save-logs


### PR DESCRIPTION
Right now we get the device running configuration via NETCONF directly from the device. This may take some time, first to pull the notconf container (for netconf-console2) and also to fetch the configs. We now only limit the duration of `test-ping` to two minutes.

A more proper solution would be to use Orchestron itself to get config which we can then save to disk via curl, but as of right now, we can't fully parse the <get-config> response for all supported device types ...