### PR TITLE
Update netconf

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/25123d231ddcf79151b076b6a4b5fc0ea9ed74ea.zip",
-            "hash": "1220fce85a504e2cbc7b2eb938dbd8eba92a8b52191f45219ceb01d32cb937b82339"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c9482557dc80201c476957ea1958210e0d33b9b2.zip",
+            "hash": "12207bd9f5a135b4589c43ab1de3cfd613efde7051e827d791ae5d90c68bcb5a9874"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
@@ -12,8 +12,8 @@
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/a6028f08f1c7d14e933becc489755896d771ec07.zip",
-            "hash": "12200463c69c02abd2dcbf4a3ff7c83b2bc5885c3c42d9c88f136ffe2c8c394970de"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/85723dc92bc9e3c6e6ceb864e0517e2520fcc9ac.zip",
+            "hash": "1220c45e1a79d14c49703062e4777c0fa5ee2fd6f7c6d4d10dc78306f5e9f7abc1a1"
         },
         "actmf": {
             "repo_url": "https://github.com/orchestron-orchestrator/actmf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/25123d231ddcf79151b076b6a4b5fc0ea9ed74ea.zip",
-            "hash": "1220fce85a504e2cbc7b2eb938dbd8eba92a8b52191f45219ceb01d32cb937b82339"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c9482557dc80201c476957ea1958210e0d33b9b2.zip",
+            "hash": "12207bd9f5a135b4589c43ab1de3cfd613efde7051e827d791ae5d90c68bcb5a9874"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
@@ -12,8 +12,8 @@
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/a6028f08f1c7d14e933becc489755896d771ec07.zip",
-            "hash": "12200463c69c02abd2dcbf4a3ff7c83b2bc5885c3c42d9c88f136ffe2c8c394970de"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/85723dc92bc9e3c6e6ceb864e0517e2520fcc9ac.zip",
+            "hash": "1220c45e1a79d14c49703062e4777c0fa5ee2fd6f7c6d4d10dc78306f5e9f7abc1a1"
         }
     },
     "zig_dependencies": {}

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -77,7 +77,7 @@ actor main(env):
 
     log = logging.Logger(logh)
 
-    dev_mgr = odev.DeviceManager(env.cap, logh_dev)
+    dev_mgr = odev.DeviceManager(sorespo.sysspec.device_types, env.cap, logh_dev)
     cfs = sorespo.layers.get_layers(dev_mgr, logh_ttt)
     rfs = cfs.below().below()
     dev_mgr.on_reconf(lambda dev: rfs.edit_config(rfs_for_device(dev), force=True))

--- a/src/sorespo/sysspec.act
+++ b/src/sorespo/sysspec.act
@@ -5,18 +5,21 @@ import sorespo.devices.JuniperCRPD_23_4R1_9
 import sorespo.devices.NokiaSRLinux_25_3_2
 device_types = {
     "CiscoIosXr_24_1_ncs55a1": odev.DeviceType(name="CiscoIosXr_24_1_ncs55a1",
+            adapter_type=odev.NetconfAdapter,
             schema_namespaces=sorespo.devices.CiscoIosXr_24_1_ncs55a1.schema_namespaces,
             root=sorespo.devices.CiscoIosXr_24_1_ncs55a1.root,
             from_gdata=sorespo.devices.CiscoIosXr_24_1_ncs55a1.root.from_gdata,
             from_xml=sorespo.devices.CiscoIosXr_24_1_ncs55a1.from_xml
         ),
     "JuniperCRPD_23_4R1_9": odev.DeviceType(name="JuniperCRPD_23_4R1_9",
+            adapter_type=odev.NetconfAdapter,
             schema_namespaces=sorespo.devices.JuniperCRPD_23_4R1_9.schema_namespaces,
             root=sorespo.devices.JuniperCRPD_23_4R1_9.root,
             from_gdata=sorespo.devices.JuniperCRPD_23_4R1_9.root.from_gdata,
             from_xml=sorespo.devices.JuniperCRPD_23_4R1_9.from_xml
         ),
     "NokiaSRLinux_25_3_2": odev.DeviceType(name="NokiaSRLinux_25_3_2",
+            adapter_type=odev.NetconfAdapter,
             schema_namespaces=sorespo.devices.NokiaSRLinux_25_3_2.schema_namespaces,
             root=sorespo.devices.NokiaSRLinux_25_3_2.root,
             from_gdata=sorespo.devices.NokiaSRLinux_25_3_2.root.from_gdata,


### PR DESCRIPTION
Fix pattern matching for NETCONF 1.0 end-of-message magic bytes. Now orchestron correctly receives the `<get-config>` response from cRPD as valid XML. It doesn't parse to gdata yet, but progress 🎉 