### PR TITLE
Add device-type to get dev config

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,18 +2,18 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c9482557dc80201c476957ea1958210e0d33b9b2.zip",
-            "hash": "12207bd9f5a135b4589c43ab1de3cfd613efde7051e827d791ae5d90c68bcb5a9874"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/d4bee6490ff26924c540660c7346fe67e45dffa1.zip",
+            "hash": "1220ff090463c50228386094f4c61c56ee5da549c4ad8d30166567bf878dc704f616"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5b0cf16b2f69edc58bea086eb71986eaeb5e289a.zip",
-            "hash": "12201e055684d4f896530a52595be6d504b9554b4a9b9646d575efe4b6d9e0a7f887"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/cb6d6ecb866f401adbdcdb6e77ed01d14471bf4e.zip",
+            "hash": "122039b117cdcc2958dd28d93d0a61912127192ce2794bd87e76b03417b82901a367"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/85723dc92bc9e3c6e6ceb864e0517e2520fcc9ac.zip",
-            "hash": "1220c45e1a79d14c49703062e4777c0fa5ee2fd6f7c6d4d10dc78306f5e9f7abc1a1"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/cb18a53ddfdc4e57618ffef58b00b68373f32255.zip",
+            "hash": "12204afd801089b1983b5d2f90528c85e84d9f834c3fd1c30faa1e2a0a45dffd5551"
         },
         "actmf": {
             "repo_url": "https://github.com/orchestron-orchestrator/actmf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,18 +2,18 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c9482557dc80201c476957ea1958210e0d33b9b2.zip",
-            "hash": "12207bd9f5a135b4589c43ab1de3cfd613efde7051e827d791ae5d90c68bcb5a9874"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/d4bee6490ff26924c540660c7346fe67e45dffa1.zip",
+            "hash": "1220ff090463c50228386094f4c61c56ee5da549c4ad8d30166567bf878dc704f616"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5b0cf16b2f69edc58bea086eb71986eaeb5e289a.zip",
-            "hash": "12201e055684d4f896530a52595be6d504b9554b4a9b9646d575efe4b6d9e0a7f887"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/cb6d6ecb866f401adbdcdb6e77ed01d14471bf4e.zip",
+            "hash": "122039b117cdcc2958dd28d93d0a61912127192ce2794bd87e76b03417b82901a367"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/85723dc92bc9e3c6e6ceb864e0517e2520fcc9ac.zip",
-            "hash": "1220c45e1a79d14c49703062e4777c0fa5ee2fd6f7c6d4d10dc78306f5e9f7abc1a1"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/cb18a53ddfdc4e57618ffef58b00b68373f32255.zip",
+            "hash": "12204afd801089b1983b5d2f90528c85e84d9f834c3fd1c30faa1e2a0a45dffd5551"
         }
     },
     "zig_dependencies": {}

--- a/gen/yang/cfs/netinfra.yang
+++ b/gen/yang/cfs/netinfra.yang
@@ -26,6 +26,9 @@ module netinfra {
         description "router id";
         mandatory true;
       }
+      leaf type {
+        type string;
+      }
       leaf role {
         type string;
       }

--- a/gen/yang/inter/netinfra-inter.yang
+++ b/gen/yang/inter/netinfra-inter.yang
@@ -26,6 +26,9 @@ module netinfra-inter {
         description "router id";
         mandatory true;
       }
+      leaf type {
+        type string;
+      }
       leaf role {
         type string;
       }

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -30,6 +30,10 @@ import sorespo.sysspec
 
 import testing
 
+class Unreachable(Exception):
+    """Exception raised when code is unreachable."""
+    pass
+
 def rfs_for_device(dev):
     return yang.gdata.Container({
         'rfs': yang.gdata.List(["name"], [
@@ -141,6 +145,23 @@ actor main(env):
 
         if request.method == "GET":
             if len(path_elements) > 3 and path_elements[1] == "device":
+                def respond_with_data(data: ?yang.gdata.Node, schema: odev.DeviceSchema, accept_header: ?str):
+                    aheader = accept_header if accept_header is not None else "application/yang-data+json"
+                    if data is not None:
+                        if aheader == "application/yang-data+json":
+                            out_data = data.to_json()
+                        elif aheader == "application/yang-data+xml":
+                            out_data = data.to_xmlstr()
+                        elif aheader == "application/yang-data+acton-adata":
+                            adata = schema.from_gdata(data)
+                            out_data = adata.prsrc()
+                        else:
+                            respond(404, {}, "Unsupported media type")
+                            return
+                        respond(200, {"Content-type": aheader}, out_data)
+                    else:
+                        respond(500, {}, "No data")
+
                 try:
                     # We use upper case for device names in our configs
                     # TODO: maybe we should somehow normalize that?!
@@ -158,46 +179,16 @@ actor main(env):
                         respond(200, {}, txt)
                         return
                     if path_elements[3] == 'target':
-                        modset, _ = dev.get_modules()
-                        device_type = None
-                        if "Cisco-IOS-XR-um-hostname-cfg" in modset:
-                            device_type = sorespo.sysspec.device_types["CiscoIosXr_24_1_ncs55a1"]
-                        elif "http://xml.juniper.net/netconf/junos/1.0" in modset or "junos-conf-root" in modset:
-                            device_type = sorespo.sysspec.device_types["JuniperCRPD_23_4R1_9"]
-                        if device_type is not None:
-                            session = cfs.newsession()
-                            device_layer = session.below().below().below().get()
-                            device_entry = device_layer.get_cnt("devices").get_list("device").get_list_entry(dev_name)
-                            config_gd = device_entry.get_cnt("config")
-                            if request.headers.get("accept") == "application/adata+text":
-                                config_ad = device_type.from_gdata(config_gd)
-                                response = config_ad.prsrc()
-                            else:
-                                response = config_gd.to_xmlstr()
-                            respond(200, {"Content-type": request.headers.get_def("accept", "application/xml+text")}, response)
-                            return
+                        session = cfs.newsession()
+                        device_layer = session.below().below().below().get()
+                        device_entry = device_layer.get_cnt("devices").get_list("device").get_list_entry(dev_name)
+                        config_gd = device_entry.get_cnt("config")
+                        respond_with_data(config_gd, dev.get_schema(), request.headers.get("accept"))
+                        return
                     if path_elements[3] == 'running':
-                        modset, _ = dev.get_modules()
-                        device_type = None
-                        if "Cisco-IOS-XR-um-hostname-cfg" in modset:
-                            device_type = sorespo.sysspec.device_types["CiscoIosXr_24_1_ncs55a1"]
-                        elif "http://xml.juniper.net/netconf/junos/1.0" in modset or "junos-conf-root" in modset:
-                            device_type = sorespo.sysspec.device_types["JuniperCRPD_23_4R1_9"]
-                        if "srl_nokia-system" in modset:
-                            device_type = sorespo.sysspec.device_types["NokiaSRLinux_25_3_2"]
-                        if device_type is not None:
-                            config_xml = dev.get_running_config()
-                            if config_xml is not None:
-                                config_gd = device_type.from_xml(config_xml)
-                                if request.headers.get("accept") == "application/adata+text":
-                                    config_ad = device_type.from_gdata(config_gd)
-                                    response = config_ad.prsrc()
-                                else:
-                                    response = config_gd.to_xmlstr()
-                                respond(200, {"Content-type": request.headers.get_def("accept", "application/xml+text")}, response)
-                                return
-                            else:
-                                respond(500, {}, "no config")
+                        config_gd = dev.get_running_config()
+                        respond_with_data(config_gd, dev.get_schema(), request.headers.get("accept"))
+                        return
 
                     respond(404, {}, "Not found")
                     return

--- a/src/sorespo/cfs.act
+++ b/src/sorespo/cfs.act
@@ -11,6 +11,7 @@ class Router(base.Router):
         o = base.o_root()
         print("CFS router transform running", i.name, i.id)
         o_router = o.netinfra.router.create(i.name)
+        o_router.type = i.type
         o_router.id = i.id
         o_router.role = i.role
         o_router.mock = i.mock

--- a/src/sorespo/devices/CiscoIosXr_24_1_ncs55a1.act
+++ b/src/sorespo/devices/CiscoIosXr_24_1_ncs55a1.act
@@ -25,7 +25,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast()
         return None
 
@@ -142,7 +142,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(yang.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies()
 
@@ -189,7 +189,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies.from_gdata(n.get_opt_cnt('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast()
 
@@ -242,7 +242,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast.from_gdata(n.get_opt_cnt('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast.from_gdata(n.get_opt_cnt('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4()
 
@@ -289,7 +289,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast()
         return None
 
@@ -406,7 +406,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(yang.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies()
 
@@ -453,7 +453,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies.from_gdata(n.get_opt_cnt('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast()
 
@@ -506,7 +506,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast.from_gdata(n.get_opt_cnt('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast.from_gdata(n.get_opt_cnt('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6()
 
@@ -562,7 +562,7 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4.from_gdata(n.get_opt_cnt('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6.from_gdata(n.get_opt_cnt('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family()
 
@@ -718,7 +718,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts()
 
@@ -765,7 +765,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_cnt('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target()
 
@@ -808,7 +808,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target.from_gdata(n.get_opt_cnt('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import()
 
@@ -956,7 +956,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts()
 
@@ -1003,7 +1003,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_cnt('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target()
 
@@ -1046,7 +1046,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target.from_gdata(n.get_opt_cnt('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export()
 
@@ -1094,7 +1094,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import.from_gdata(n.get_opt_cnt('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export.from_gdata(n.get_opt_cnt('export')))
         return None
 
@@ -1138,7 +1138,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast()
         return None
 
@@ -1172,7 +1172,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec()
         return None
 
@@ -1235,7 +1235,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast.from_gdata(n.get_opt_cnt('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast.from_gdata(n.get_opt_cnt('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec.from_gdata(n.get_opt_cnt('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4()
 
@@ -1402,7 +1402,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts()
 
@@ -1449,7 +1449,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_cnt('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target()
 
@@ -1492,7 +1492,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target.from_gdata(n.get_opt_cnt('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import()
 
@@ -1640,7 +1640,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts()
 
@@ -1687,7 +1687,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_cnt('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target()
 
@@ -1730,7 +1730,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target.from_gdata(n.get_opt_cnt('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export()
 
@@ -1778,7 +1778,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import.from_gdata(n.get_opt_cnt('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export.from_gdata(n.get_opt_cnt('export')))
         return None
 
@@ -1822,7 +1822,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast()
         return None
 
@@ -1856,7 +1856,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec()
         return None
 
@@ -1919,7 +1919,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast.from_gdata(n.get_opt_cnt('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast.from_gdata(n.get_opt_cnt('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec.from_gdata(n.get_opt_cnt('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6()
 
@@ -1986,7 +1986,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4.from_gdata(n.get_opt_cnt('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6.from_gdata(n.get_opt_cnt('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family()
 
@@ -2030,7 +2030,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big()
         return None
 
@@ -2073,7 +2073,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(big=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big.from_gdata(n.get_opt_cnt('big')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode()
 
@@ -2122,7 +2122,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(id=n.get_opt_str('id'))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn()
 
@@ -2164,7 +2164,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable()
         return None
 
@@ -2207,7 +2207,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(disable=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable.from_gdata(n.get_opt_cnt('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering()
 
@@ -2267,7 +2267,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
@@ -2326,7 +2326,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
@@ -2385,7 +2385,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
 
@@ -2458,7 +2458,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(two_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_cnt('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_cnt('four-byte-as')), ip_address=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_cnt('ip-address')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd()
 
@@ -2666,7 +2666,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs()
 
@@ -2709,7 +2709,7 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable()
         return None
 
@@ -2752,7 +2752,7 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(disable=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable.from_gdata(n.get_opt_cnt('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download()
 
@@ -2903,7 +2903,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__names:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__names()
 
@@ -2956,7 +2956,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(yang
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(priority=n.get_opt_str('priority'))
         return None
 
@@ -3104,7 +3104,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes()
 
@@ -3230,7 +3230,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(yang.adata.MNo
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names()
 
@@ -3369,7 +3369,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(yang.adata.MN
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group.from_gdata(n.get_opt_list('group')))
         return None
 
@@ -3548,7 +3548,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(interface=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces()
 
@@ -3703,7 +3703,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes()
 
@@ -3836,7 +3836,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group.from_gdata(n.get_opt_list('group')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups()
 
@@ -3991,7 +3991,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes()
 
@@ -4124,7 +4124,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(inherit_location=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location.from_gdata(n.get_opt_list('inherit-location')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations()
 
@@ -4186,7 +4186,7 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__srlg(names=Cisco_IOS_XR_um_vrf_cfg__srlg__names.from_gdata(n.get_opt_cnt('names')), interfaces=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces.from_gdata(n.get_opt_cnt('interfaces')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__groups.from_gdata(n.get_opt_cnt('groups')), inherit_locations=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations.from_gdata(n.get_opt_cnt('inherit-locations')))
         return None
 
@@ -4326,7 +4326,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs()
 
@@ -4459,7 +4459,7 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups(vrf_group=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group.from_gdata(n.get_opt_list('vrf-group')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups()
 
@@ -4591,7 +4591,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(ya
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(net=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net.from_gdata(n.get_opt_list('net')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets()
 
@@ -4647,7 +4647,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(sr_prefer=n.get_opt_bool('sr-prefer'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls()
 
@@ -4690,7 +4690,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(mpls=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls.from_gdata(n.get_opt_cnt('mpls')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing()
 
@@ -4729,7 +4729,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow()
         return None
 
@@ -4763,7 +4763,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide()
         return None
 
@@ -4797,7 +4797,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition()
         return None
 
@@ -4834,7 +4834,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow()
         return None
 
@@ -4868,7 +4868,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide()
         return None
 
@@ -4902,7 +4902,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition()
         return None
 
@@ -5070,7 +5070,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels()
 
@@ -5147,7 +5147,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow.from_gdata(n.get_opt_cnt('narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide.from_gdata(n.get_opt_cnt('wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition.from_gdata(n.get_opt_cnt('transition')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels.from_gdata(n.get_opt_cnt('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style()
 
@@ -5320,7 +5320,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families()
 
@@ -5369,7 +5369,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point()
         return None
 
@@ -5403,7 +5403,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4()
         return None
 
@@ -5437,7 +5437,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6()
         return None
 
@@ -5490,7 +5490,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(ipv4=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4.from_gdata(n.get_opt_cnt('ipv4')), ipv6=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6.from_gdata(n.get_opt_cnt('ipv6')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect()
 
@@ -5560,7 +5560,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(fast_detect=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect.from_gdata(n.get_opt_cnt('fast-detect')), minimum_interval=n.get_opt_int('minimum-interval'), multiplier=n.get_opt_int('multiplier'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd()
 
@@ -5609,7 +5609,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive()
         return None
 
@@ -5652,7 +5652,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum()
         return None
 
@@ -5692,7 +5692,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum()
         return None
 
@@ -5834,7 +5834,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels()
 
@@ -5896,7 +5896,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(default_metric=n.get_opt_int('default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum.from_gdata(n.get_opt_cnt('maximum')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels.from_gdata(n.get_opt_cnt('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric()
 
@@ -5955,7 +5955,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(sid_index=n.get_opt_int('sid-index'))
         return None
 
@@ -6003,7 +6003,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(index=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index.from_gdata(n.get_opt_cnt('index')))
         return None
 
@@ -6054,7 +6054,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid.from_gdata(n.get_opt_cnt('sid')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid()
 
@@ -6206,7 +6206,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families()
 
@@ -6395,7 +6395,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(interface=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces()
 
@@ -6558,7 +6558,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(process=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process.from_gdata(n.get_opt_list('process')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes()
 
@@ -6605,7 +6605,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis(processes=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes.from_gdata(n.get_opt_cnt('processes')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis()
 
@@ -6648,7 +6648,7 @@ class Cisco_IOS_XR_um_router_isis_cfg__router(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_isis_cfg__router(isis=Cisco_IOS_XR_um_router_isis_cfg__router__isis.from_gdata(n.get_opt_cnt('isis')))
         return Cisco_IOS_XR_um_router_isis_cfg__router()
 
@@ -6687,7 +6687,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot()
         return None
 
@@ -6721,7 +6721,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain()
         return None
 
@@ -6774,7 +6774,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__as_format:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format(asdot=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot.from_gdata(n.get_opt_cnt('asdot')), asplain=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain.from_gdata(n.get_opt_cnt('asplain')))
         return Cisco_IOS_XR_um_router_bgp_cfg__as_format()
 
@@ -6827,7 +6827,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown()
         return None
 
@@ -6876,7 +6876,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(host_name=n.get_opt_str('host-name'), port=n.get_opt_int('port'))
         return None
 
@@ -6944,7 +6944,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__del
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(initial_delay=n.get_opt_int('initial-delay'), spread=n.get_opt_int('spread'))
         return None
 
@@ -6988,7 +6988,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__ski
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip()
         return None
 
@@ -7041,7 +7041,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(yang
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(delay=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay.from_gdata(n.get_opt_cnt('delay')), skip=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip.from_gdata(n.get_opt_cnt('skip')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh()
 
@@ -7124,7 +7124,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(yang.adata.MNode
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(keep_alive=n.get_opt_int('keep-alive'), mss=n.get_opt_int('mss'))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp()
 
@@ -7502,7 +7502,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(bmp_mode=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode.from_gdata(n.get_opt_list('bmp-mode')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes()
 
@@ -7549,7 +7549,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(bmp_modes=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes.from_gdata(n.get_opt_cnt('bmp-modes')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring()
 
@@ -7597,7 +7597,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(max_buffer_size=n.get_opt_int('max-buffer-size'), route_monitoring=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring.from_gdata(n.get_opt_cnt('route-monitoring')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all()
 
@@ -7650,7 +7650,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server.from_gdata(n.get_opt_list('server')), all=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all.from_gdata(n.get_opt_cnt('all')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers()
 
@@ -7702,7 +7702,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp(servers=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers.from_gdata(n.get_opt_cnt('servers')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp()
 
@@ -7754,7 +7754,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(interface_name=n.get_opt_str('interface-name'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface()
 
@@ -7797,7 +7797,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(interface=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface.from_gdata(n.get_opt_cnt('interface')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source()
 
@@ -7842,7 +7842,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off()
         return None
 
@@ -7890,7 +7890,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(refresh_time_value=n.get_opt_int('refresh-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off.from_gdata(n.get_opt_cnt('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time()
 
@@ -7940,7 +7940,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off()
         return None
 
@@ -7988,7 +7988,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(response_time_value=n.get_opt_int('response-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off.from_gdata(n.get_opt_cnt('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time()
 
@@ -8051,7 +8051,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp()
 
@@ -8097,7 +8097,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh()
 
@@ -8145,7 +8145,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(tcp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp.from_gdata(n.get_opt_cnt('tcp')), ssh=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh.from_gdata(n.get_opt_cnt('ssh')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport()
 
@@ -8189,7 +8189,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__sh
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown()
         return None
 
@@ -8401,7 +8401,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server.from_gdata(n.get_opt_list('server')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers()
 
@@ -8566,7 +8566,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(route=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route.from_gdata(n.get_opt_list('route')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes()
 
@@ -8626,7 +8626,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(servers=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers.from_gdata(n.get_opt_cnt('servers')), routes=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes.from_gdata(n.get_opt_cnt('routes')), datafile=n.get_opt_str('datafile'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki()
 
@@ -8758,7 +8758,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families()
 
@@ -8819,7 +8819,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(session_group=n.get_opt_str('session-group'), neighbor_group=n.get_opt_str('neighbor-group'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use()
 
@@ -8966,7 +8966,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors()
 
@@ -9095,7 +9095,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families()
 
@@ -9147,7 +9147,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable()
         return None
 
@@ -9195,7 +9195,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable.from_gdata(n.get_opt_cnt('inheritance-disable')))
         return None
 
@@ -9383,7 +9383,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(neighbor_group=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group.from_gdata(n.get_opt_list('neighbor-group')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups()
 
@@ -9433,7 +9433,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(router_id=n.get_opt_str('router-id'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp()
 
@@ -9558,7 +9558,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families()
 
@@ -9628,7 +9628,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(route_policy_name=n.get_opt_str('route-policy-name'), retention_time=n.get_opt_int('retention-time'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention()
 
@@ -9686,7 +9686,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(in_=n.get_opt_str('in'), out=n.get_opt_str('out'), retention=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention.from_gdata(n.get_opt_cnt('retention')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy()
 
@@ -9735,7 +9735,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable()
         return None
 
@@ -9778,7 +9778,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable.from_gdata(n.get_opt_cnt('inheritance-disable')))
         return None
 
@@ -9928,7 +9928,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families()
 
@@ -9980,7 +9980,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable()
         return None
 
@@ -10028,7 +10028,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable.from_gdata(n.get_opt_cnt('inheritance-disable')))
         return None
 
@@ -10203,7 +10203,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(yang
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors()
 
@@ -10246,7 +10246,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(yang.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto()
         return None
 
@@ -10295,7 +10295,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
@@ -10354,7 +10354,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
@@ -10413,7 +10413,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
 
@@ -10496,7 +10496,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(auto=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto.from_gdata(n.get_opt_cnt('auto')), two_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_cnt('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_cnt('four-byte-as')), ip_address=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_cnt('ip-address')))
         return None
 
@@ -10680,7 +10680,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(vrf=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs()
 
@@ -10863,7 +10863,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(as_=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as.from_gdata(n.get_opt_list('as')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp()
 
@@ -10910,7 +10910,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_router_bgp_cfg__router(bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp.from_gdata(n.get_opt_cnt('bgp')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router()
 
@@ -11032,7 +11032,7 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(yang.adata.MNode
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(address_family=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families()
 
@@ -11158,7 +11158,7 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(interface=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces()
 
@@ -11210,7 +11210,7 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(address_families=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families.from_gdata(n.get_opt_cnt('address-families')), interfaces=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces.from_gdata(n.get_opt_cnt('interfaces')))
         return None
 
@@ -11263,7 +11263,7 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(ldp=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp.from_gdata(n.get_opt_cnt('ldp')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls()
 
@@ -11308,7 +11308,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport()
         return None
 
@@ -11342,7 +11342,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point()
         return None
 
@@ -11376,7 +11376,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint()
         return None
 
@@ -11439,7 +11439,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(y
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(l2transport=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport.from_gdata(n.get_opt_cnt('l2transport')), point_to_point=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point.from_gdata(n.get_opt_cnt('point-to-point')), multipoint=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint.from_gdata(n.get_opt_cnt('multipoint')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type()
 
@@ -11528,7 +11528,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__add
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(address=n.get_opt_str('address'), netmask=n.get_opt_str('netmask'), route_tag=n.get_opt_int('route-tag'), algorithm=n.get_opt_int('algorithm'))
         return None
 
@@ -11704,7 +11704,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(secondary=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary.from_gdata(n.get_opt_list('secondary')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries()
 
@@ -11750,7 +11750,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp()
         return None
 
@@ -11813,7 +11813,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(yang
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(address=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address.from_gdata(n.get_opt_cnt('address')), secondaries=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries.from_gdata(n.get_opt_cnt('secondaries')), unnumbered=n.get_opt_str('unnumbered'), dhcp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp.from_gdata(n.get_opt_cnt('dhcp')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses()
 
@@ -11877,7 +11877,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(addresses=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses.from_gdata(n.get_opt_cnt('addresses')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4()
 
@@ -11916,7 +11916,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
 
@@ -11950,7 +11950,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp()
         return None
 
@@ -11984,7 +11984,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc()
         return None
 
@@ -12018,7 +12018,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr()
         return None
 
@@ -12052,7 +12052,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF()
         return None
 
@@ -12095,7 +12095,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(IETF=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF.from_gdata(n.get_opt_cnt('IETF')))
         return None
 
@@ -12176,7 +12176,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(ppp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp.from_gdata(n.get_opt_cnt('ppp')), hdlc=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc.from_gdata(n.get_opt_cnt('hdlc')), mfr=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr.from_gdata(n.get_opt_cnt('mfr')), frame_relay=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay.from_gdata(n.get_opt_cnt('frame-relay')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation()
 
@@ -12269,7 +12269,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(vlan_id=n.get_opt_int('vlan-id'), second_dot1q=n.get_opt_int('second-dot1q'))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q()
 
@@ -12317,7 +12317,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(dot1q=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q.from_gdata(n.get_opt_cnt('dot1q')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation()
 
@@ -12526,7 +12526,7 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_interface_cfg__interfaces(interface=Cisco_IOS_XR_um_interface_cfg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces()
 
@@ -12569,7 +12569,7 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict()
         return None
 
@@ -12612,7 +12612,7 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(yang.adata.MNode)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(strict=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict.from_gdata(n.get_opt_cnt('strict')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter()
 
@@ -12658,7 +12658,7 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(egress_filter=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter.from_gdata(n.get_opt_cnt('egress-filter')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet()
 
@@ -12704,7 +12704,7 @@ class Cisco_IOS_XR_um_hostname_cfg__hostname(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_um_hostname_cfg__hostname:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_um_hostname_cfg__hostname(system_network_name=n.get_opt_str('system-network-name'))
         return Cisco_IOS_XR_um_hostname_cfg__hostname()
 
@@ -12839,7 +12839,7 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(route_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy.from_gdata(n.get_opt_list('route-policy')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies()
 
@@ -12886,7 +12886,7 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy:
-        if n != None:
+        if n is not None:
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy(route_policies=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies.from_gdata(n.get_opt_cnt('route-policies')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy()
 
@@ -12999,7 +12999,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(address_family=Cisco_IOS_XR_um_vrf_cfg__address_family.from_gdata(n.get_opt_cnt('address-family')), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrfs.from_gdata(n.get_opt_cnt('vrfs')), selective_vrf_download=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download.from_gdata(n.get_opt_cnt('selective-vrf-download')), srlg=Cisco_IOS_XR_um_vrf_cfg__srlg.from_gdata(n.get_opt_cnt('srlg')), vrf_groups=Cisco_IOS_XR_um_vrf_cfg__vrf_groups.from_gdata(n.get_opt_cnt('vrf-groups')), um_router_isis_cfg_router=Cisco_IOS_XR_um_router_isis_cfg__router.from_gdata(n.get_opt_cnt('um-router-isis-cfg:router')), as_format=Cisco_IOS_XR_um_router_bgp_cfg__as_format.from_gdata(n.get_opt_cnt('as-format')), bmp=Cisco_IOS_XR_um_router_bgp_cfg__bmp.from_gdata(n.get_opt_cnt('bmp')), um_router_bgp_cfg_router=Cisco_IOS_XR_um_router_bgp_cfg__router.from_gdata(n.get_opt_cnt('um-router-bgp-cfg:router')), mpls=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls.from_gdata(n.get_opt_cnt('mpls')), interfaces=Cisco_IOS_XR_um_interface_cfg__interfaces.from_gdata(n.get_opt_cnt('interfaces')), ethernet=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet.from_gdata(n.get_opt_cnt('ethernet')), hostname=Cisco_IOS_XR_um_hostname_cfg__hostname.from_gdata(n.get_opt_cnt('hostname')), routing_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy.from_gdata(n.get_opt_cnt('routing-policy')))
         return root()
 

--- a/src/sorespo/devices/JuniperCRPD_23_4R1_9.act
+++ b/src/sorespo/devices/JuniperCRPD_23_4R1_9.act
@@ -38,7 +38,7 @@ class junos_conf_root__configuration__system(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__system:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__system()
 
@@ -190,7 +190,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__inet:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -316,7 +316,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__inet6:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -442,7 +442,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso(y
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__iso:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -514,7 +514,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces__interface__unit__family(inet=junos_conf_root__configuration__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_cnt('inet')), inet6=junos_conf_root__configuration__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_cnt('inet6')), iso=junos_conf_root__configuration__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_cnt('iso')))
         return junos_conf_root__configuration__interfaces__interface__unit__family()
 
@@ -748,7 +748,7 @@ class junos_conf_root__configuration__interfaces__interface__hierarchical_schedu
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler()
         return None
 
@@ -1014,7 +1014,7 @@ class junos_conf_root__configuration__interfaces(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__interfaces:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__interfaces(interface=junos_conf_root__configuration__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__interfaces()
 
@@ -1207,7 +1207,7 @@ class junos_conf_root__configuration__routing_instances__instance__route_disting
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__route_distinguisher:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__routing_instances__instance__route_distinguisher()
 
@@ -1283,7 +1283,7 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_target(ya
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__vrf_target:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_empty('auto'))
         return junos_conf_root__configuration__routing_instances__instance__vrf_target()
 
@@ -1355,7 +1355,7 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_table_lab
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__routing_instances__instance__vrf_table_label:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_empty('source-class-usage'))
         return None
 
@@ -1444,7 +1444,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_empty('no-nexthop-change'))
         return None
 
@@ -1752,7 +1752,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp()
 
@@ -1810,7 +1810,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__ev
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__routing_instances__instance__protocols__evpn:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__protocols__evpn(control_word=n.get_opt_empty('control-word'), no_mac_learning=n.get_opt_empty('no-mac-learning'))
         return None
 
@@ -1868,7 +1868,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols(yan
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_cnt('bgp')), evpn=junos_conf_root__configuration__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_cnt('evpn')))
         return junos_conf_root__configuration__routing_instances__instance__protocols()
 
@@ -2113,7 +2113,7 @@ class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_instances:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_instances(instance=junos_conf_root__configuration__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__routing_instances()
 
@@ -2169,7 +2169,7 @@ class junos_conf_root__configuration__groups__when__time__to(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__when__time__to:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__when__time__to(end_time=n.get_opt_str('end-time'))
         return junos_conf_root__configuration__groups__when__time__to()
 
@@ -2217,7 +2217,7 @@ class junos_conf_root__configuration__groups__when__time(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__when__time:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__when__time(start_time=n.get_opt_str('start-time'), to=junos_conf_root__configuration__groups__when__time__to.from_gdata(n.get_opt_cnt('to')))
         return junos_conf_root__configuration__groups__when__time()
 
@@ -2305,7 +2305,7 @@ class junos_conf_root__configuration__groups__when(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__when:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__when(time=junos_conf_root__configuration__groups__when__time.from_gdata(n.get_opt_cnt('time')), chassis=n.get_opt_str('chassis'), model=n.get_opt_str('model'), routing_engine=n.get_opt_str('routing-engine'), member=n.get_opt_str('member'), node=n.get_opt_str('node'))
         return junos_conf_root__configuration__groups__when()
 
@@ -2382,7 +2382,7 @@ class junos_conf_root__configuration__groups__system(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__system:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__groups__system()
 
@@ -2534,7 +2534,7 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -2660,7 +2660,7 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -2786,7 +2786,7 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
@@ -2858,7 +2858,7 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family(inet=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_cnt('inet')), inet6=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_cnt('inet6')), iso=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_cnt('iso')))
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family()
 
@@ -3092,7 +3092,7 @@ class junos_conf_root__configuration__groups__interfaces__interface__hierarchica
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler()
         return None
 
@@ -3358,7 +3358,7 @@ class junos_conf_root__configuration__groups__interfaces(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__interfaces(interface=junos_conf_root__configuration__groups__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__groups__interfaces()
 
@@ -3551,7 +3551,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__route
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher()
 
@@ -3627,7 +3627,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__vrf_target:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_empty('auto'))
         return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target()
 
@@ -3699,7 +3699,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_empty('source-class-usage'))
         return None
 
@@ -3788,7 +3788,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_empty('no-nexthop-change'))
         return None
 
@@ -4096,7 +4096,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp()
 
@@ -4154,7 +4154,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(control_word=n.get_opt_empty('control-word'), no_mac_learning=n.get_opt_empty('no-mac-learning'))
         return None
 
@@ -4212,7 +4212,7 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_cnt('bgp')), evpn=junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_cnt('evpn')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols()
 
@@ -4457,7 +4457,7 @@ class junos_conf_root__configuration__groups__routing_instances(yang.adata.MNode
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__groups__routing_instances(instance=junos_conf_root__configuration__groups__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__groups__routing_instances()
 
@@ -4643,7 +4643,7 @@ class junos_conf_root__configuration__routing_options__autonomous_system(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_options__autonomous_system:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_options__autonomous_system(as_number=n.get_opt_str('as-number'))
         return junos_conf_root__configuration__routing_options__autonomous_system()
 
@@ -4686,7 +4686,7 @@ class junos_conf_root__configuration__routing_options(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__routing_options:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__routing_options(autonomous_system=junos_conf_root__configuration__routing_options__autonomous_system.from_gdata(n.get_opt_cnt('autonomous-system')))
         return junos_conf_root__configuration__routing_options()
 
@@ -4749,7 +4749,7 @@ class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=n.get_opt_value('med-multiplier'), igp_multiplier=n.get_opt_value('igp-multiplier'))
         return None
 
@@ -4833,7 +4833,7 @@ class junos_conf_root__configuration__protocols__bgp__path_selection(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__path_selection:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__path_selection(l2vpn_use_bgp_rules=n.get_opt_empty('l2vpn-use-bgp-rules'), cisco_non_deterministic=n.get_opt_empty('cisco-non-deterministic'), always_compare_med=n.get_opt_empty('always-compare-med'), med_plus_igp=junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp.from_gdata(n.get_opt_cnt('med-plus-igp')), external_router_id=n.get_opt_empty('external-router-id'), as_path_ignore=n.get_opt_empty('as-path-ignore'))
         return junos_conf_root__configuration__protocols__bgp__path_selection()
 
@@ -4936,7 +4936,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_empty('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
@@ -4994,7 +4994,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_cnt('idle-timeout')))
         return None
 
@@ -5048,7 +5048,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -5094,7 +5094,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -5167,7 +5167,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_cnt('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_cnt('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_cnt('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
@@ -5251,7 +5251,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_empty('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
@@ -5309,7 +5309,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_cnt('idle-timeout')))
         return None
 
@@ -5363,7 +5363,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -5409,7 +5409,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -5482,7 +5482,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_cnt('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_cnt('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_cnt('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
@@ -5552,7 +5552,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group()
 
@@ -5609,7 +5609,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_empty('all-paths'), equal_cost_paths=n.get_opt_empty('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode()
 
@@ -5687,7 +5687,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_cnt('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_empty('multipath'))
         return None
 
@@ -5760,7 +5760,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(receive=n.get_opt_empty('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send.from_gdata(n.get_opt_cnt('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path()
 
@@ -5814,7 +5814,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(disable=n.get_opt_empty('disable'))
         return None
 
@@ -5866,7 +5866,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
 
@@ -5923,7 +5923,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
@@ -5982,7 +5982,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
@@ -6040,7 +6040,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_empty('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_cnt('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_cnt('maximum-delay')))
         return None
 
@@ -6104,7 +6104,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_empty('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_empty('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution()
 
@@ -6155,7 +6155,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
 
@@ -6209,7 +6209,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_empty('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter()
 
@@ -6274,7 +6274,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_empty('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
@@ -6332,7 +6332,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_cnt('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_cnt('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived()
 
@@ -6388,7 +6388,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_cnt('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart()
 
@@ -6462,7 +6462,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
@@ -6521,7 +6521,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
 
@@ -6580,7 +6580,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
@@ -6637,7 +6637,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
@@ -6683,7 +6683,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier()
 
@@ -6732,7 +6732,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_cnt('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
 
@@ -6936,7 +6936,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit.from_gdata(n.get_opt_cnt('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_cnt('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group.from_gdata(n.get_opt_cnt('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path.from_gdata(n.get_opt_cnt('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp.from_gdata(n.get_opt_cnt('aigp')), damping=n.get_opt_empty('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops.from_gdata(n.get_opt_cnt('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_cnt('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_cnt('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_cnt('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart.from_gdata(n.get_opt_cnt('graceful-restart')), extended_nexthop=n.get_opt_empty('extended-nexthop'), extended_nexthop_color=n.get_opt_empty('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_empty('extended-nexthop-tunnel'), no_install=n.get_opt_empty('no-install'), route_age_bgp_view=n.get_opt_empty('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_cnt('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_cnt('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_cnt('withdraw-priority')), advertise_srv6_service=n.get_opt_empty('advertise-srv6-service'), accept_srv6_service=n.get_opt_empty('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label.from_gdata(n.get_opt_cnt('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection.from_gdata(n.get_opt_cnt('egress-protection')), accept_local_nexthop=n.get_opt_empty('accept-local-nexthop'), accept_own=n.get_opt_empty('accept-own'))
         return None
 
@@ -7124,7 +7124,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast.from_gdata(n.get_opt_cnt('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn()
 
@@ -7187,7 +7187,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_empty('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
@@ -7245,7 +7245,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_cnt('idle-timeout')))
         return None
 
@@ -7299,7 +7299,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -7345,7 +7345,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -7418,7 +7418,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_cnt('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_cnt('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_cnt('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
@@ -7502,7 +7502,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_empty('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
@@ -7560,7 +7560,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_cnt('idle-timeout')))
         return None
 
@@ -7614,7 +7614,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -7660,7 +7660,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
@@ -7733,7 +7733,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_cnt('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_cnt('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_cnt('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
@@ -7803,7 +7803,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group()
 
@@ -7860,7 +7860,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_empty('all-paths'), equal_cost_paths=n.get_opt_empty('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode()
 
@@ -7938,7 +7938,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_cnt('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_empty('multipath'))
         return None
 
@@ -8011,7 +8011,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(receive=n.get_opt_empty('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send.from_gdata(n.get_opt_cnt('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path()
 
@@ -8065,7 +8065,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(disable=n.get_opt_empty('disable'))
         return None
 
@@ -8117,7 +8117,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
 
@@ -8174,7 +8174,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
@@ -8233,7 +8233,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
@@ -8291,7 +8291,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_empty('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_cnt('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_cnt('maximum-delay')))
         return None
 
@@ -8355,7 +8355,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_empty('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_empty('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution()
 
@@ -8406,7 +8406,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
 
@@ -8460,7 +8460,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_empty('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter()
 
@@ -8525,7 +8525,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_empty('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
@@ -8583,7 +8583,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_cnt('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_cnt('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived()
 
@@ -8639,7 +8639,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_cnt('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart()
 
@@ -8713,7 +8713,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
@@ -8772,7 +8772,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
 
@@ -8831,7 +8831,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_empty('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
@@ -8888,7 +8888,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
@@ -8934,7 +8934,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier()
 
@@ -8983,7 +8983,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_cnt('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
 
@@ -9187,7 +9187,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit.from_gdata(n.get_opt_cnt('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_cnt('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group.from_gdata(n.get_opt_cnt('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path.from_gdata(n.get_opt_cnt('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp.from_gdata(n.get_opt_cnt('aigp')), damping=n.get_opt_empty('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops.from_gdata(n.get_opt_cnt('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_cnt('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_cnt('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_cnt('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart.from_gdata(n.get_opt_cnt('graceful-restart')), extended_nexthop=n.get_opt_empty('extended-nexthop'), extended_nexthop_color=n.get_opt_empty('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_empty('extended-nexthop-tunnel'), no_install=n.get_opt_empty('no-install'), route_age_bgp_view=n.get_opt_empty('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_cnt('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_cnt('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_cnt('withdraw-priority')), advertise_srv6_service=n.get_opt_empty('advertise-srv6-service'), accept_srv6_service=n.get_opt_empty('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label.from_gdata(n.get_opt_cnt('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection.from_gdata(n.get_opt_cnt('egress-protection')), accept_local_nexthop=n.get_opt_empty('accept-local-nexthop'), accept_own=n.get_opt_empty('accept-own'))
         return None
 
@@ -9375,7 +9375,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(y
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast.from_gdata(n.get_opt_cnt('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn()
 
@@ -9417,7 +9417,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling()
         return None
 
@@ -9460,7 +9460,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__evpn:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn(signaling=junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling.from_gdata(n.get_opt_cnt('signaling')))
         return junos_conf_root__configuration__protocols__bgp__group__family__evpn()
 
@@ -9502,7 +9502,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__route_targe
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__route_target:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family__route_target()
         return None
 
@@ -9560,7 +9560,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp__group__family(inet_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn.from_gdata(n.get_opt_cnt('inet-vpn')), inet6_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn.from_gdata(n.get_opt_cnt('inet6-vpn')), evpn=junos_conf_root__configuration__protocols__bgp__group__family__evpn.from_gdata(n.get_opt_cnt('evpn')), route_target=junos_conf_root__configuration__protocols__bgp__group__family__route_target.from_gdata(n.get_opt_cnt('route-target')))
         return junos_conf_root__configuration__protocols__bgp__group__family()
 
@@ -9955,7 +9955,7 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__bgp(path_selection=junos_conf_root__configuration__protocols__bgp__path_selection.from_gdata(n.get_opt_cnt('path-selection')), group=junos_conf_root__configuration__protocols__bgp__group.from_gdata(n.get_opt_list('group')), log_updown=n.get_opt_empty('log-updown'))
         return junos_conf_root__configuration__protocols__bgp()
 
@@ -10026,7 +10026,7 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=n.get_opt_empty('disable'), hold_time=n.get_opt_value('hold-time'))
         return None
 
@@ -10203,7 +10203,7 @@ class junos_conf_root__configuration__protocols__isis__interface__passive(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__passive:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__passive(remote_node_iso=n.get_opt_str('remote-node-iso'), remote_node_id=n.get_opt_str('remote-node-id'))
         return None
 
@@ -10289,7 +10289,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=n.get_opt_value('minimum-interval'), threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
@@ -10340,7 +10340,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
 
@@ -10402,7 +10402,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(key_chain=n.get_opt_str('key-chain'), algorithm=n.get_opt_str('algorithm'), loose_check=n.get_opt_empty('loose-check'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication()
 
@@ -10458,7 +10458,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
@@ -10504,7 +10504,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
 
@@ -10615,7 +10615,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=n.get_opt_str('version'), minimum_interval=n.get_opt_value('minimum-interval'), minimum_transmit_interval=n.get_opt_value('minimum-transmit-interval'), minimum_receive_interval=n.get_opt_value('minimum-receive-interval'), multiplier=n.get_opt_value('multiplier'), inline_disable=n.get_opt_empty('inline-disable'), pdu_size=n.get_opt_value('pdu-size'), no_adaptation=n.get_opt_empty('no-adaptation'), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_gdata(n.get_opt_cnt('transmit-interval')), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_gdata(n.get_opt_cnt('detection-time')), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_gdata(n.get_opt_cnt('authentication')), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_gdata(n.get_opt_cnt('echo')), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_gdata(n.get_opt_cnt('echo-lite')), holddown_interval=n.get_opt_value('holddown-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
@@ -10972,7 +10972,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=n.get_opt_value('hold-time'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
@@ -11026,7 +11026,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ud
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(encapsulation=n.get_opt_empty('encapsulation'), decapsulation=n.get_opt_empty('decapsulation'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling()
 
@@ -11085,7 +11085,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=n.get_opt_value('start-label'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
 
@@ -11152,7 +11152,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__no
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=n.get_opt_value('ipv4-index'), ipv6_index=n.get_opt_value('ipv6-index'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
 
@@ -11260,7 +11260,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(psp=n.get_opt_empty('psp'), usp=n.get_opt_empty('usp'), usd=n.get_opt_empty('usd'))
         return None
 
@@ -11426,7 +11426,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(psp=n.get_opt_empty('psp'), usp=n.get_opt_empty('usp'), usd=n.get_opt_empty('usd'))
         return None
 
@@ -11484,7 +11484,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor.from_gdata(n.get_opt_cnt('flavor')))
         return None
 
@@ -11661,7 +11661,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(locator=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator.from_gdata(n.get_opt_list('locator')))
         return None
 
@@ -11719,7 +11719,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(ingress=n.get_opt_empty('ingress'), egress=n.get_opt_empty('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link()
 
@@ -11778,7 +11778,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(ingress=n.get_opt_empty('ingress'), egress=n.get_opt_empty('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid()
 
@@ -11829,7 +11829,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=n.get_opt_value('interval'))
         return None
 
@@ -11887,7 +11887,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(per_interface_per_member_link=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link.from_gdata(n.get_opt_cnt('per-interface-per-member-link')), per_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid.from_gdata(n.get_opt_cnt('per-sid')), subscribe=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe.from_gdata(n.get_opt_cnt('subscribe')))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats()
 
@@ -11946,7 +11946,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(per_interface=n.get_opt_empty('per-interface'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity()
 
@@ -12005,7 +12005,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(statistics_granularity=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity.from_gdata(n.get_opt_cnt('statistics-granularity')), congestion_protection=n.get_opt_empty('congestion-protection'), auto_bandwidth=n.get_opt_str('auto-bandwidth'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics()
 
@@ -12136,7 +12136,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_gdata(n.get_opt_cnt('adjacency-segment')), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_gdata(n.get_opt_cnt('udp-tunneling')), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_gdata(n.get_opt_cnt('srgb')), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_gdata(n.get_opt_cnt('node-segment')), flex_algorithm=n.get_opt_values('flex-algorithm'), use_flex_algorithm_metric_always=n.get_opt_empty('use-flex-algorithm-metric-always'), strict_asla_based_flex_algorithm=n.get_opt_empty('strict-asla-based-flex-algorithm'), new_capability_subtlv=n.get_opt_empty('new-capability-subtlv'), explicit_null=n.get_opt_empty('explicit-null'), mapping_server=n.get_opt_str('mapping-server'), no_strict_spf=n.get_opt_empty('no-strict-spf'), no_binding_sid_leaking=n.get_opt_empty('no-binding-sid-leaking'), ldp_stitching=n.get_opt_empty('ldp-stitching'), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_gdata(n.get_opt_cnt('srv6')), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_gdata(n.get_opt_cnt('sensor-based-stats')), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_gdata(n.get_opt_cnt('traffic-statistics')))
         return None
 
@@ -12457,7 +12457,7 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_gdata(n.get_opt_list('interface')), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_gdata(n.get_opt_cnt('source-packet-routing')), level=junos_conf_root__configuration__protocols__isis__level.from_gdata(n.get_opt_list('level')), lsp_lifetime=n.get_opt_value('lsp-lifetime'))
         return junos_conf_root__configuration__protocols__isis()
 
@@ -12577,7 +12577,7 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics__file:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=n.get_opt_str('filename'), replace=n.get_opt_empty('replace'), size=n.get_opt_str('size'), files=n.get_opt_value('files'), no_stamp=n.get_opt_empty('no-stamp'), world_readable=n.get_opt_empty('world-readable'), no_world_readable=n.get_opt_empty('no-world-readable'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
@@ -12674,7 +12674,7 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_gdata(n.get_opt_cnt('file')), interval=n.get_opt_value('interval'), sensor_based_stats=n.get_opt_empty('sensor-based-stats'), no_penultimate_hop=n.get_opt_empty('no-penultimate-hop'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
@@ -12754,7 +12754,7 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__transport_address:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp__transport_address(router_id=n.get_opt_empty('router-id'), interface=n.get_opt_empty('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__transport_address()
 
@@ -12830,7 +12830,7 @@ class junos_conf_root__configuration__protocols__ldp__interface__link_protection
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__ldp__interface__link_protection:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp__interface__link_protection(disable=n.get_opt_empty('disable'), dynamic_rsvp_lsp=n.get_opt_empty('dynamic-rsvp-lsp'))
         return None
 
@@ -12897,7 +12897,7 @@ class junos_conf_root__configuration__protocols__ldp__interface__transport_addre
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__interface__transport_address:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp__interface__transport_address(router_id=n.get_opt_empty('router-id'), interface=n.get_opt_empty('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__interface__transport_address()
 
@@ -13125,7 +13125,7 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_gdata(n.get_opt_cnt('traffic-statistics')), preference=n.get_opt_value('preference'), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(n.get_opt_cnt('transport-address')), interface=junos_conf_root__configuration__protocols__ldp__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__ldp()
 
@@ -13217,7 +13217,7 @@ class junos_conf_root__configuration__protocols__mpls__interface__static(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__mpls__interface__static:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=n.get_opt_value('protection-revert-time'))
         return junos_conf_root__configuration__protocols__mpls__interface__static()
 
@@ -13410,7 +13410,7 @@ class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__mpls:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols__mpls(no_propagate_ttl=n.get_opt_empty('no-propagate-ttl'), ipv6_tunneling=n.get_opt_empty('ipv6-tunneling'), interface=junos_conf_root__configuration__protocols__mpls__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__mpls()
 
@@ -13482,7 +13482,7 @@ class junos_conf_root__configuration__protocols(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration__protocols(bgp=junos_conf_root__configuration__protocols__bgp.from_gdata(n.get_opt_cnt('bgp')), isis=junos_conf_root__configuration__protocols__isis.from_gdata(n.get_opt_cnt('isis')), ldp=junos_conf_root__configuration__protocols__ldp.from_gdata(n.get_opt_cnt('ldp')), mpls=junos_conf_root__configuration__protocols__mpls.from_gdata(n.get_opt_cnt('mpls')))
         return junos_conf_root__configuration__protocols()
 
@@ -13575,7 +13575,7 @@ class junos_conf_root__configuration(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration:
-        if n != None:
+        if n is not None:
             return junos_conf_root__configuration(rcsid=n.get_opt_str('rcsid'), version=n.get_opt_str('version'), system=junos_conf_root__configuration__system.from_gdata(n.get_opt_cnt('system')), interfaces=junos_conf_root__configuration__interfaces.from_gdata(n.get_opt_cnt('interfaces')), routing_instances=junos_conf_root__configuration__routing_instances.from_gdata(n.get_opt_cnt('routing-instances')), groups=junos_conf_root__configuration__groups.from_gdata(n.get_opt_list('groups')), routing_options=junos_conf_root__configuration__routing_options.from_gdata(n.get_opt_cnt('routing-options')), protocols=junos_conf_root__configuration__protocols.from_gdata(n.get_opt_cnt('protocols')))
         return junos_conf_root__configuration()
 
@@ -13657,7 +13657,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(configuration=junos_conf_root__configuration.from_gdata(n.get_opt_cnt('configuration')))
         return root()
 

--- a/src/sorespo/devices/NokiaSRLinux_25_3_2.act
+++ b/src/sorespo/devices/NokiaSRLinux_25_3_2.act
@@ -25,7 +25,7 @@ class srl_nokia_tunnel__tunnel(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_tunnel__tunnel:
-        if n != None:
+        if n is not None:
             return srl_nokia_tunnel__tunnel()
         return srl_nokia_tunnel__tunnel()
 
@@ -62,7 +62,7 @@ class srl_nokia_system__system__management(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__management:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__management()
         return srl_nokia_system__system__management()
 
@@ -96,7 +96,7 @@ class srl_nokia_system__system__control_plane_traffic__output(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__control_plane_traffic__output:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__control_plane_traffic__output()
         return srl_nokia_system__system__control_plane_traffic__output()
 
@@ -130,7 +130,7 @@ class srl_nokia_system__system__control_plane_traffic__input(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__control_plane_traffic__input:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__control_plane_traffic__input()
         return srl_nokia_system__system__control_plane_traffic__input()
 
@@ -173,7 +173,7 @@ class srl_nokia_system__system__control_plane_traffic(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__control_plane_traffic:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__control_plane_traffic(output=srl_nokia_system__system__control_plane_traffic__output.from_gdata(n.get_opt_cnt('output')), input=srl_nokia_system__system__control_plane_traffic__input.from_gdata(n.get_opt_cnt('input')))
         return srl_nokia_system__system__control_plane_traffic()
 
@@ -224,7 +224,7 @@ class srl_nokia_system__system__protocols__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_system__system__protocols__bgp:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__protocols__bgp(restart_max_wait=n.get_opt_int('restart-max-wait'))
         return None
 
@@ -272,7 +272,7 @@ class srl_nokia_system__system__protocols(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__protocols:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__protocols(bgp=srl_nokia_system__system__protocols__bgp.from_gdata(n.get_opt_cnt('bgp')))
         return srl_nokia_system__system__protocols()
 
@@ -329,7 +329,7 @@ class srl_nokia_system__system__name(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system__name:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system__name(domain_name=n.get_opt_str('domain-name'), host_name=n.get_opt_str('host-name'))
         return srl_nokia_system__system__name()
 
@@ -395,7 +395,7 @@ class srl_nokia_system__system(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_system__system:
-        if n != None:
+        if n is not None:
             return srl_nokia_system__system(trace_options=n.get_opt_strs('trace-options'), management=srl_nokia_system__system__management.from_gdata(n.get_opt_cnt('management')), control_plane_traffic=srl_nokia_system__system__control_plane_traffic.from_gdata(n.get_opt_cnt('control-plane-traffic')), protocols=srl_nokia_system__system__protocols.from_gdata(n.get_opt_cnt('protocols')), name=srl_nokia_system__system__name.from_gdata(n.get_opt_cnt('name')))
         return srl_nokia_system__system()
 
@@ -614,7 +614,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv4__unnumbered(yang.adata
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_interfaces__interface__subinterface__ipv4__unnumbered:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__ipv4__unnumbered(admin_state=n.get_opt_str('admin-state'), interface=n.get_opt_str('interface'))
         return srl_nokia_interfaces__interface__subinterface__ipv4__unnumbered()
 
@@ -677,7 +677,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv4(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_interfaces__interface__subinterface__ipv4:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__ipv4(admin_state=n.get_opt_str('admin-state'), address=srl_nokia_interfaces__interface__subinterface__ipv4__address.from_gdata(n.get_opt_list('address')), allow_directed_broadcast=n.get_opt_bool('allow-directed-broadcast'), unnumbered=srl_nokia_interfaces__interface__subinterface__ipv4__unnumbered.from_gdata(n.get_opt_cnt('unnumbered')))
         return srl_nokia_interfaces__interface__subinterface__ipv4()
 
@@ -865,7 +865,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv6(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_interfaces__interface__subinterface__ipv6:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__ipv6(admin_state=n.get_opt_str('admin-state'), address=srl_nokia_interfaces__interface__subinterface__ipv6__address.from_gdata(n.get_opt_list('address')))
         return srl_nokia_interfaces__interface__subinterface__ipv6()
 
@@ -920,7 +920,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged(
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged(vlan_id=n.get_opt_value('vlan-id'))
         return None
 
@@ -968,7 +968,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_interfaces__interface__subinterface__vlan__encap:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__vlan__encap(single_tagged=srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged.from_gdata(n.get_opt_cnt('single-tagged')))
         return srl_nokia_interfaces__interface__subinterface__vlan__encap()
 
@@ -1014,7 +1014,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_interfaces__interface__subinterface__vlan:
-        if n != None:
+        if n is not None:
             return srl_nokia_interfaces__interface__subinterface__vlan(encap=srl_nokia_interfaces__interface__subinterface__vlan__encap.from_gdata(n.get_opt_cnt('encap')))
         return srl_nokia_interfaces__interface__subinterface__vlan()
 
@@ -1386,7 +1386,7 @@ class srl_nokia_network_instance__network_instance__interface__interface_ref(yan
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__interface__interface_ref:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__interface__interface_ref(interface=n.get_opt_str('interface'), subinterface=n.get_opt_str('subinterface'))
         return srl_nokia_network_instance__network_instance__interface__interface_ref()
 
@@ -1717,7 +1717,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_evpn(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp_evpn:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp_evpn(bgp_instance=srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance.from_gdata(n.get_opt_list('bgp-instance')))
         return None
 
@@ -1760,7 +1760,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_ipvpn(yang.ad
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp_ipvpn:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp_ipvpn()
         return None
 
@@ -1794,7 +1794,7 @@ class srl_nokia_network_instance__network_instance__protocols__directly_connecte
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__directly_connected:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__directly_connected()
         return srl_nokia_network_instance__network_instance__protocols__directly_connected()
 
@@ -1882,7 +1882,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__attached_bit:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__attached_bit(ignore=n.get_opt_bool('ignore'), suppress=n.get_opt_bool('suppress'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__attached_bit()
 
@@ -1933,7 +1933,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__t
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__transport:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__transport(lsp_mtu_size=n.get_opt_int('lsp-mtu-size'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__transport()
 
@@ -1979,7 +1979,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast(admin_state=n.get_opt_str('admin-state'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast()
 
@@ -2025,7 +2025,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv6_unicast:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv6_unicast(admin_state=n.get_opt_str('admin-state'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv6_unicast()
 
@@ -2079,7 +2079,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__csnp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__csnp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__csnp_authentication()
 
@@ -2138,7 +2138,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__psnp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__psnp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__psnp_authentication()
 
@@ -2197,7 +2197,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__hello_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__hello_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__hello_authentication()
 
@@ -2256,7 +2256,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__lsp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__lsp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__lsp_authentication()
 
@@ -2318,7 +2318,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__key:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__key(crypto_algorithm=n.get_opt_str('crypto-algorithm'), auth_password=n.get_opt_str('auth-password'))
         raise ValueError('Missing required subtree srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__key')
 
@@ -2391,7 +2391,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication(csnp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__csnp_authentication.from_gdata(n.get_opt_cnt('csnp-authentication')), psnp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__psnp_authentication.from_gdata(n.get_opt_cnt('psnp-authentication')), hello_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__hello_authentication.from_gdata(n.get_opt_cnt('hello-authentication')), lsp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__lsp_authentication.from_gdata(n.get_opt_cnt('lsp-authentication')), keychain=n.get_opt_str('keychain'), key=srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication__key.from_gdata(n.get_opt_cnt('key')))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__authentication()
 
@@ -2473,7 +2473,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__interface_ref:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__interface_ref(interface=n.get_opt_str('interface'), subinterface=n.get_opt_str('subinterface'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__interface_ref()
 
@@ -2530,7 +2530,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__delay:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__delay(delay_selection=n.get_opt_str('delay-selection'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__delay()
 
@@ -2598,7 +2598,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv4_unicast:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv4_unicast(admin_state=n.get_opt_str('admin-state'), enable_bfd=n.get_opt_bool('enable-bfd'), include_bfd_tlv=n.get_opt_bool('include-bfd-tlv'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv4_unicast()
 
@@ -2670,7 +2670,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv6_unicast:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv6_unicast(admin_state=n.get_opt_str('admin-state'), enable_bfd=n.get_opt_bool('enable-bfd'), include_bfd_tlv=n.get_opt_bool('include-bfd-tlv'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__ipv6_unicast()
 
@@ -2752,7 +2752,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__hello_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__hello_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__hello_authentication()
 
@@ -2814,7 +2814,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__key:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__key(crypto_algorithm=n.get_opt_str('crypto-algorithm'), auth_password=n.get_opt_str('auth-password'))
         raise ValueError('Missing required subtree srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__key')
 
@@ -2872,7 +2872,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication(hello_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__hello_authentication.from_gdata(n.get_opt_cnt('hello-authentication')), keychain=n.get_opt_str('keychain'), key=srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication__key.from_gdata(n.get_opt_cnt('key')))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level__authentication()
 
@@ -3072,7 +3072,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__hello_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__hello_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__hello_authentication()
 
@@ -3134,7 +3134,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__key:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__key(crypto_algorithm=n.get_opt_str('crypto-algorithm'), auth_password=n.get_opt_str('auth-password'))
         raise ValueError('Missing required subtree srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__key')
 
@@ -3192,7 +3192,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication(hello_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__hello_authentication.from_gdata(n.get_opt_cnt('hello-authentication')), keychain=n.get_opt_str('keychain'), key=srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication__key.from_gdata(n.get_opt_cnt('key')))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__authentication()
 
@@ -3445,7 +3445,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__route_preference:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__route_preference(external=n.get_opt_int('external'), internal=n.get_opt_int('internal'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__route_preference()
 
@@ -3504,7 +3504,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__csnp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__csnp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__csnp_authentication()
 
@@ -3563,7 +3563,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__psnp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__psnp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__psnp_authentication()
 
@@ -3622,7 +3622,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__hello_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__hello_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__hello_authentication()
 
@@ -3681,7 +3681,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__lsp_authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__lsp_authentication(generate=n.get_opt_bool('generate'), check_received=n.get_opt_str('check-received'))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__lsp_authentication()
 
@@ -3743,7 +3743,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__key:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__key(crypto_algorithm=n.get_opt_str('crypto-algorithm'), auth_password=n.get_opt_str('auth-password'))
         raise ValueError('Missing required subtree srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__key')
 
@@ -3816,7 +3816,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__l
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication(csnp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__csnp_authentication.from_gdata(n.get_opt_cnt('csnp-authentication')), psnp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__psnp_authentication.from_gdata(n.get_opt_cnt('psnp-authentication')), hello_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__hello_authentication.from_gdata(n.get_opt_cnt('hello-authentication')), lsp_authentication=srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__lsp_authentication.from_gdata(n.get_opt_cnt('lsp-authentication')), keychain=n.get_opt_str('keychain'), key=srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication__key.from_gdata(n.get_opt_cnt('key')))
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__level__authentication()
 
@@ -4272,7 +4272,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__isis:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__isis(instance=srl_nokia_network_instance__network_instance__protocols__isis__instance.from_gdata(n.get_opt_list('instance')))
         return None
 
@@ -4353,7 +4353,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__as_path_opti
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options__remove_private_as:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options__remove_private_as(mode=n.get_opt_str('mode'), leading_only=n.get_opt_bool('leading-only'), ignore_peer_as=n.get_opt_bool('ignore-peer-as'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options__remove_private_as()
 
@@ -4411,7 +4411,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__as_path_opti
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options(allow_own_as=n.get_opt_int('allow-own-as'), remove_private_as=srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options__remove_private_as.from_gdata(n.get_opt_cnt('remove-private-as')))
         return srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options()
 
@@ -4470,7 +4470,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__authenticati
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__authentication(keychain=n.get_opt_str('keychain'), password=n.get_opt_str('password'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__authentication()
 
@@ -4529,7 +4529,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy(import_reject_all=n.get_opt_bool('import-reject-all'), export_reject_all=n.get_opt_bool('export-reject-all'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy()
 
@@ -4681,7 +4681,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__preference(y
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__preference:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__preference(ebgp=n.get_opt_int('ebgp'), ibgp=n.get_opt_int('ibgp'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__preference()
 
@@ -4822,7 +4822,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__rib_manageme
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__rib_management:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__rib_management(table=srl_nokia_network_instance__network_instance__protocols__bgp__rib_management__table.from_gdata(n.get_opt_list('table')))
         return srl_nokia_network_instance__network_instance__protocols__bgp__rib_management()
 
@@ -4880,7 +4880,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__route_advert
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__route_advertisement:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__route_advertisement(rapid_withdrawal=n.get_opt_bool('rapid-withdrawal'), wait_for_fib_install=n.get_opt_bool('wait-for-fib-install'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__route_advertisement()
 
@@ -4955,7 +4955,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__route_flap_d
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__route_flap_damping:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__route_flap_damping(half_life=n.get_opt_int('half-life'), max_suppress_time=n.get_opt_int('max-suppress-time'), reuse_threshold=n.get_opt_int('reuse-threshold'), suppress_threshold=n.get_opt_int('suppress-threshold'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__route_flap_damping()
 
@@ -5024,7 +5024,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__route_reflec
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__route_reflector:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__route_reflector(client=n.get_opt_bool('client'), cluster_id=n.get_opt_value('cluster-id'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__route_reflector()
 
@@ -5075,7 +5075,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__segment_rout
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__segment_routing_mpls:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__segment_routing_mpls(admin_state=n.get_opt_str('admin-state'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__segment_routing_mpls()
 
@@ -5129,7 +5129,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__send_communi
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__send_community:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__send_community(standard=n.get_opt_bool('standard'), large=n.get_opt_bool('large'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__send_community()
 
@@ -5196,7 +5196,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__transport(ya
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__transport:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__transport(single_hop_connected_check=n.get_opt_bool('single-hop-connected-check'), mtu_discovery=n.get_opt_bool('mtu-discovery'), tcp_mss=n.get_opt_int('tcp-mss'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__transport()
 
@@ -5289,7 +5289,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__as_pa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options__remove_private_as:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options__remove_private_as(mode=n.get_opt_str('mode'), leading_only=n.get_opt_bool('leading-only'), ignore_peer_as=n.get_opt_bool('ignore-peer-as'))
         return None
 
@@ -5360,7 +5360,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__as_pa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options(allow_own_as=n.get_opt_int('allow-own-as'), remove_private_as=srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options__remove_private_as.from_gdata(n.get_opt_cnt('remove-private-as')), replace_peer_as=n.get_opt_bool('replace-peer-as'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__as_path_options()
 
@@ -5427,7 +5427,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__authe
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__authentication(keychain=n.get_opt_str('keychain'), password=n.get_opt_str('password'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__authentication()
 
@@ -5486,7 +5486,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__failu
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__failure_detection:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__failure_detection(enable_bfd=n.get_opt_bool('enable-bfd'), fast_failover=n.get_opt_bool('fast-failover'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__failure_detection()
 
@@ -5545,7 +5545,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__multi
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__multihop:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__multihop(admin_state=n.get_opt_str('admin-state'), maximum_hops=n.get_opt_int('maximum-hops'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__multihop()
 
@@ -5705,7 +5705,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__local
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__local_as:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__local_as(as_number=n.get_opt_int('as-number'), prepend_global_as=n.get_opt_bool('prepend-global-as'), prepend_local_as=n.get_opt_bool('prepend-local-as'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__local_as()
 
@@ -5772,7 +5772,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__route
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__route_reflector:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__route_reflector(client=n.get_opt_bool('client'), cluster_id=n.get_opt_value('cluster-id'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__route_reflector()
 
@@ -5831,7 +5831,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__send_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__send_community:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__send_community(standard=n.get_opt_bool('standard'), large=n.get_opt_bool('large'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__send_community()
 
@@ -5898,7 +5898,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__send_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route(ipv4_unicast=n.get_opt_bool('ipv4-unicast'), ipv6_unicast=n.get_opt_bool('ipv6-unicast'), export_policy=n.get_opt_str('export-policy'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route()
 
@@ -6224,7 +6224,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options__remove_private_as:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options__remove_private_as(mode=n.get_opt_str('mode'), leading_only=n.get_opt_bool('leading-only'), ignore_peer_as=n.get_opt_bool('ignore-peer-as'))
         return None
 
@@ -6295,7 +6295,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options(allow_own_as=n.get_opt_int('allow-own-as'), remove_private_as=srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options__remove_private_as.from_gdata(n.get_opt_cnt('remove-private-as')), replace_peer_as=n.get_opt_bool('replace-peer-as'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__as_path_options()
 
@@ -6362,7 +6362,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__au
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication(keychain=n.get_opt_str('keychain'), password=n.get_opt_str('password'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication()
 
@@ -6421,7 +6421,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__fa
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__failure_detection:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__failure_detection(enable_bfd=n.get_opt_bool('enable-bfd'), fast_failover=n.get_opt_bool('fast-failover'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__failure_detection()
 
@@ -6488,7 +6488,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__graceful_restart:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__graceful_restart(admin_state=n.get_opt_str('admin-state'), stale_routes_time=n.get_opt_int('stale-routes-time'), requested_restart_time=n.get_opt_int('requested-restart-time'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__graceful_restart()
 
@@ -6552,7 +6552,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__mu
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__multihop:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__multihop(admin_state=n.get_opt_str('admin-state'), maximum_hops=n.get_opt_int('maximum-hops'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__multihop()
 
@@ -6712,7 +6712,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__lo
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__local_as:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__local_as(as_number=n.get_opt_int('as-number'), prepend_global_as=n.get_opt_bool('prepend-global-as'), prepend_local_as=n.get_opt_bool('prepend-local-as'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__local_as()
 
@@ -6779,7 +6779,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__ro
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__route_reflector:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__route_reflector(client=n.get_opt_bool('client'), cluster_id=n.get_opt_value('cluster-id'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__route_reflector()
 
@@ -6838,7 +6838,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_community:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_community(standard=n.get_opt_bool('standard'), large=n.get_opt_bool('large'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_community()
 
@@ -6905,7 +6905,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__se
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_default_route:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_default_route(ipv4_unicast=n.get_opt_bool('ipv4-unicast'), ipv6_unicast=n.get_opt_bool('ipv6-unicast'), export_policy=n.get_opt_str('export-policy'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__send_default_route()
 
@@ -6993,7 +6993,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__ti
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__timers:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__timers(connect_retry=n.get_opt_int('connect-retry'), hold_time=n.get_opt_int('hold-time'), keepalive_interval=n.get_opt_int('keepalive-interval'), minimum_advertisement_interval=n.get_opt_int('minimum-advertisement-interval'), prefix_limit_restart_timer=n.get_opt_int('prefix-limit-restart-timer'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__timers()
 
@@ -7083,7 +7083,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__tr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__transport:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__transport(mtu_discovery=n.get_opt_bool('mtu-discovery'), tcp_mss=n.get_opt_int('tcp-mss'), passive_mode=n.get_opt_bool('passive-mode'), local_address=n.get_opt_str('local-address'))
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__transport()
 
@@ -7496,7 +7496,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp(yang.adata.MN
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp(admin_state=n.get_opt_str('admin-state'), autonomous_system=n.get_opt_int('autonomous-system'), local_preference=n.get_opt_int('local-preference'), router_id=n.get_opt_str('router-id'), as_path_options=srl_nokia_network_instance__network_instance__protocols__bgp__as_path_options.from_gdata(n.get_opt_cnt('as-path-options')), authentication=srl_nokia_network_instance__network_instance__protocols__bgp__authentication.from_gdata(n.get_opt_cnt('authentication')), ebgp_default_policy=srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy.from_gdata(n.get_opt_cnt('ebgp-default-policy')), afi_safi=srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi.from_gdata(n.get_opt_list('afi-safi')), preference=srl_nokia_network_instance__network_instance__protocols__bgp__preference.from_gdata(n.get_opt_cnt('preference')), rib_management=srl_nokia_network_instance__network_instance__protocols__bgp__rib_management.from_gdata(n.get_opt_cnt('rib-management')), route_advertisement=srl_nokia_network_instance__network_instance__protocols__bgp__route_advertisement.from_gdata(n.get_opt_cnt('route-advertisement')), route_flap_damping=srl_nokia_network_instance__network_instance__protocols__bgp__route_flap_damping.from_gdata(n.get_opt_cnt('route-flap-damping')), route_reflector=srl_nokia_network_instance__network_instance__protocols__bgp__route_reflector.from_gdata(n.get_opt_cnt('route-reflector')), segment_routing_mpls=srl_nokia_network_instance__network_instance__protocols__bgp__segment_routing_mpls.from_gdata(n.get_opt_cnt('segment-routing-mpls')), send_community=srl_nokia_network_instance__network_instance__protocols__bgp__send_community.from_gdata(n.get_opt_cnt('send-community')), transport=srl_nokia_network_instance__network_instance__protocols__bgp__transport.from_gdata(n.get_opt_cnt('transport')), group=srl_nokia_network_instance__network_instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')), neighbor=srl_nokia_network_instance__network_instance__protocols__bgp__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return None
 
@@ -7642,7 +7642,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_distinguisher:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_distinguisher(rd=n.get_opt_str('rd'))
         return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_distinguisher()
 
@@ -7696,7 +7696,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target(export_rt=n.get_opt_str('export-rt'), import_rt=n.get_opt_str('import-rt'))
         return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target()
 
@@ -7840,7 +7840,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?srl_nokia_network_instance__network_instance__protocols__bgp_vpn:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols__bgp_vpn(bgp_instance=srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance.from_gdata(n.get_opt_list('bgp-instance')))
         return None
 
@@ -7937,7 +7937,7 @@ class srl_nokia_network_instance__network_instance__protocols(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_network_instance__network_instance__protocols:
-        if n != None:
+        if n is not None:
             return srl_nokia_network_instance__network_instance__protocols(bgp_evpn=srl_nokia_network_instance__network_instance__protocols__bgp_evpn.from_gdata(n.get_opt_cnt('bgp-evpn')), bgp_ipvpn=srl_nokia_network_instance__network_instance__protocols__bgp_ipvpn.from_gdata(n.get_opt_cnt('bgp-ipvpn')), directly_connected=srl_nokia_network_instance__network_instance__protocols__directly_connected.from_gdata(n.get_opt_cnt('directly-connected')), isis=srl_nokia_network_instance__network_instance__protocols__isis.from_gdata(n.get_opt_cnt('isis')), bgp=srl_nokia_network_instance__network_instance__protocols__bgp.from_gdata(n.get_opt_cnt('bgp')), bgp_vpn=srl_nokia_network_instance__network_instance__protocols__bgp_vpn.from_gdata(n.get_opt_cnt('bgp-vpn')))
         return srl_nokia_network_instance__network_instance__protocols()
 
@@ -8187,7 +8187,7 @@ class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress(ya
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress:
-        if n != None:
+        if n is not None:
             return srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress(vni=n.get_opt_int('vni'))
         raise ValueError('Missing required subtree srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress')
 
@@ -8436,7 +8436,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(tunnel=srl_nokia_tunnel__tunnel.from_gdata(n.get_opt_cnt('tunnel')), system=srl_nokia_system__system.from_gdata(n.get_opt_cnt('system')), interface=srl_nokia_interfaces__interface.from_gdata(n.get_opt_list('interface')), network_instance=srl_nokia_network_instance__network_instance.from_gdata(n.get_opt_list('network-instance')), tunnel_interface=srl_nokia_tunnel_interfaces__tunnel_interface.from_gdata(n.get_opt_list('tunnel-interface')))
         return root()
 

--- a/src/sorespo/inter.act
+++ b/src/sorespo/inter.act
@@ -21,7 +21,7 @@ class Router(base.Router):
         o = base.o_root()
         print("Intermediate router transform running", i.name, i.id)
         dev = o.device.create(i.name)
-        #dev.type = "netconf"
+        dev.type = i.type
         oob_addr = dev.address.create("oob")
         oob_addr.address = i.name
         dev.credentials.username = "clab"

--- a/src/sorespo/layers/y_0.act
+++ b/src/sorespo/layers/y_0.act
@@ -25,6 +25,12 @@ mut def from_json_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
 mut def from_xml_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_json_netinfra__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -46,14 +52,16 @@ mut def from_xml_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: int
+    type: ?str
     role: ?str
     asn: int
     mock: ?str
 
-    mut def __init__(self, name: str, id: int, asn: int, role: ?str, mock: ?str):
+    mut def __init__(self, name: str, id: int, asn: int, type: ?str, role: ?str, mock: ?str):
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
+        self.type = type
         self.role = role
         self.asn = asn
         self.mock = mock
@@ -66,6 +74,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('uint32', _id)
+        _type = self.type
+        if _type is not None:
+            children['type'] = yang.gdata.Leaf('string', _type)
         _role = self.role
         if _role is not None:
             children['role'] = yang.gdata.Leaf('string', _role)
@@ -79,7 +90,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'))
+        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -87,6 +98,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
             res.append('# Top node: /netinfra/router')
             res.append('{self_name} = netinfra__netinfra__router({repr(self.name)}, {repr(self.id)}, {repr(self.asn)})')
         leaves = []
+        _type = self.type
+        if _type is not None:
+            leaves.append('{self_name}.type = {repr(_type)}')
         _role = self.role
         if _role is not None:
             leaves.append('{self_name}.role = {repr(_role)}')
@@ -141,6 +155,8 @@ mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdat
     yang.gdata.maybe_add(children, 'name', from_xml_netinfra__netinfra__router__name, child_name)
     child_id = yang.gdata.from_xml_int(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_netinfra__netinfra__router__id, child_id)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_netinfra__netinfra__router__type, child_type)
     child_role = yang.gdata.from_xml_opt_str(node, 'role')
     yang.gdata.maybe_add(children, 'role', from_xml_netinfra__netinfra__router__role, child_role)
     child_asn = yang.gdata.from_xml_int(node, 'asn')
@@ -171,6 +187,8 @@ mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_netinfra__netinfra__router__name(keys[0])
         if point == 'id':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'type':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'role':
             raise ValueError("Invalid json path to non-inner node")
@@ -212,6 +230,8 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     yang.gdata.maybe_add(children, 'name', from_json_netinfra__netinfra__router__name, child_name)
     child_id = yang.gdata.take_json_int(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_netinfra__netinfra__router__id, child_id)
+    child_type = yang.gdata.take_json_opt_str(jd, 'type')
+    yang.gdata.maybe_add(children, 'type', from_json_netinfra__netinfra__router__type, child_type)
     child_role = yang.gdata.take_json_opt_str(jd, 'role')
     yang.gdata.maybe_add(children, 'role', from_json_netinfra__netinfra__router__role, child_role)
     child_asn = yang.gdata.take_json_int(jd, 'asn')
@@ -439,7 +459,7 @@ class netinfra__netinfra(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra:
-        if n != None:
+        if n is not None:
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
@@ -1086,7 +1106,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
@@ -1198,7 +1218,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_cnt('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
@@ -1325,7 +1345,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
@@ -1399,7 +1419,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_cnt('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
@@ -1648,7 +1668,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
@@ -1730,7 +1750,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_Identityrefs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
@@ -1829,7 +1849,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
@@ -2115,7 +2135,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
@@ -2355,7 +2375,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
@@ -2437,7 +2457,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
@@ -2507,7 +2527,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_Identityref('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_cnt('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
@@ -2587,7 +2607,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_cnt('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_cnt('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
@@ -2673,7 +2693,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_cnt('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_cnt('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
@@ -2923,7 +2943,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
@@ -3208,7 +3228,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
@@ -3533,7 +3553,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
@@ -3632,7 +3652,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
@@ -3860,7 +3880,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
@@ -4068,7 +4088,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
@@ -4138,7 +4158,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_cnt('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
@@ -4212,7 +4232,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__management:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_Identityref('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
@@ -4479,7 +4499,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
@@ -5020,7 +5040,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
@@ -5255,7 +5275,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
@@ -5321,7 +5341,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
@@ -5417,7 +5437,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
@@ -5510,7 +5530,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_cnt('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
@@ -5599,7 +5619,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_cnt('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_cnt('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
@@ -5746,7 +5766,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
@@ -5843,7 +5863,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
@@ -5976,7 +5996,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_cnt('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_cnt('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
@@ -6329,7 +6349,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
@@ -6442,7 +6462,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_empty('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
@@ -6533,7 +6553,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_empty('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
@@ -6624,7 +6644,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_empty('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
@@ -6897,7 +6917,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
@@ -6973,7 +6993,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_cnt('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
@@ -7053,7 +7073,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_cnt('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_cnt('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
@@ -7135,7 +7155,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
@@ -7223,7 +7243,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
@@ -7313,7 +7333,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_cnt('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
@@ -7407,7 +7427,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_cnt('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_cnt('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_cnt('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
@@ -7499,7 +7519,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
@@ -7747,7 +7767,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
@@ -7830,7 +7850,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_cnt('sham-links')))
         return None
 
@@ -7932,7 +7952,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_strs('address-family'))
         return None
 
@@ -8357,7 +8377,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
@@ -8441,7 +8461,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_cnt('cascaded-lan-prefixes')))
         return None
 
@@ -8511,7 +8531,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_strs('address-family'))
         return None
 
@@ -8577,7 +8597,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_strs('address-family'))
         return None
 
@@ -8880,7 +8900,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
@@ -9113,7 +9133,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
@@ -9350,7 +9370,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_empty('all-other-accesses'), all_other_groups=n.get_opt_empty('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
@@ -9583,7 +9603,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
@@ -9658,7 +9678,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_cnt('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_cnt('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
@@ -9751,7 +9771,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
@@ -9847,7 +9867,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_cnt('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
@@ -10134,7 +10154,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
@@ -10219,7 +10239,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_cnt('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
@@ -10328,7 +10348,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
@@ -10403,7 +10423,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_cnt('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
@@ -10515,7 +10535,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
@@ -10613,7 +10633,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_Identityref('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_cnt('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_cnt('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_cnt('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
@@ -10911,7 +10931,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
@@ -10996,7 +11016,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_cnt('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
@@ -11105,7 +11125,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
@@ -11180,7 +11200,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_cnt('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
@@ -11292,7 +11312,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
@@ -11390,7 +11410,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_Identityref('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_cnt('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_cnt('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_cnt('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
@@ -11513,7 +11533,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
@@ -11596,7 +11616,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_cnt('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
@@ -11672,7 +11692,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_cnt('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_cnt('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_cnt('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
@@ -11754,7 +11774,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
@@ -11850,7 +11870,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
@@ -11943,7 +11963,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_cnt('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
@@ -12032,7 +12052,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_cnt('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_cnt('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
@@ -12197,7 +12217,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
@@ -12294,7 +12314,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
@@ -12427,7 +12447,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_cnt('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_cnt('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
@@ -12780,7 +12800,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
@@ -12893,7 +12913,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_empty('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
@@ -12984,7 +13004,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_empty('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
@@ -13075,7 +13095,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_empty('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
@@ -13348,7 +13368,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
@@ -13424,7 +13444,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_cnt('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
@@ -13504,7 +13524,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_cnt('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_cnt('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
@@ -13586,7 +13606,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
@@ -13674,7 +13694,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
@@ -13764,7 +13784,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_cnt('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
@@ -13873,7 +13893,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_int('svc-output-bandwidth'), svc_mtu=n.get_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_cnt('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_cnt('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_cnt('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
@@ -14160,7 +14180,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
@@ -14243,7 +14263,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_cnt('sham-links')))
         return None
 
@@ -14345,7 +14365,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_strs('address-family'))
         return None
 
@@ -14770,7 +14790,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
@@ -14854,7 +14874,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_cnt('cascaded-lan-prefixes')))
         return None
 
@@ -14924,7 +14944,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_strs('address-family'))
         return None
 
@@ -14990,7 +15010,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_strs('address-family'))
         return None
 
@@ -15293,7 +15313,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
@@ -15369,7 +15389,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
@@ -15464,7 +15484,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_Identityref('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
@@ -15833,7 +15853,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
@@ -16232,7 +16252,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
@@ -16313,7 +16333,7 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_cnt('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_cnt('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_cnt('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
 
@@ -16404,7 +16424,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_cnt('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_cnt('l3vpn-svc')))
         return root()
 

--- a/src/sorespo/layers/y_0_loose.act
+++ b/src/sorespo/layers/y_0_loose.act
@@ -25,6 +25,12 @@ mut def from_json_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
 mut def from_xml_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_json_netinfra__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -46,14 +52,16 @@ mut def from_xml_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?int
+    type: ?str
     role: ?str
     asn: ?int
     mock: ?str
 
-    mut def __init__(self, name: str, id: ?int, role: ?str, asn: ?int, mock: ?str):
+    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, asn: ?int, mock: ?str):
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
+        self.type = type
         self.role = role
         self.asn = asn
         self.mock = mock
@@ -66,6 +74,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('uint32', _id)
+        _type = self.type
+        if _type is not None:
+            children['type'] = yang.gdata.Leaf('string', _type)
         _role = self.role
         if _role is not None:
             children['role'] = yang.gdata.Leaf('string', _role)
@@ -79,7 +90,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'))
+        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -90,6 +101,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             leaves.append('{self_name}.id = {repr(_id)}')
+        _type = self.type
+        if _type is not None:
+            leaves.append('{self_name}.type = {repr(_type)}')
         _role = self.role
         if _role is not None:
             leaves.append('{self_name}.role = {repr(_role)}')
@@ -147,6 +161,8 @@ mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdat
     yang.gdata.maybe_add(children, 'name', from_xml_netinfra__netinfra__router__name, child_name)
     child_id = yang.gdata.from_xml_opt_int(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_netinfra__netinfra__router__id, child_id)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_netinfra__netinfra__router__type, child_type)
     child_role = yang.gdata.from_xml_opt_str(node, 'role')
     yang.gdata.maybe_add(children, 'role', from_xml_netinfra__netinfra__router__role, child_role)
     child_asn = yang.gdata.from_xml_opt_int(node, 'asn')
@@ -177,6 +193,8 @@ mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_netinfra__netinfra__router__name(keys[0])
         if point == 'id':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'type':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'role':
             raise ValueError("Invalid json path to non-inner node")
@@ -218,6 +236,8 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     yang.gdata.maybe_add(children, 'name', from_json_netinfra__netinfra__router__name, child_name)
     child_id = yang.gdata.take_json_opt_int(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_netinfra__netinfra__router__id, child_id)
+    child_type = yang.gdata.take_json_opt_str(jd, 'type')
+    yang.gdata.maybe_add(children, 'type', from_json_netinfra__netinfra__router__type, child_type)
     child_role = yang.gdata.take_json_opt_str(jd, 'role')
     yang.gdata.maybe_add(children, 'role', from_json_netinfra__netinfra__router__role, child_role)
     child_asn = yang.gdata.take_json_opt_int(jd, 'asn')
@@ -445,7 +465,7 @@ class netinfra__netinfra(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra:
-        if n != None:
+        if n is not None:
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
@@ -1092,7 +1112,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
@@ -1204,7 +1224,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_cnt('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
@@ -1331,7 +1351,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
@@ -1405,7 +1425,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_cnt('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
@@ -1654,7 +1674,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
@@ -1736,7 +1756,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_Identityrefs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
@@ -1835,7 +1855,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
@@ -2121,7 +2141,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
@@ -2364,7 +2384,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
@@ -2446,7 +2466,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
@@ -2516,7 +2536,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_Identityref('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_cnt('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
@@ -2596,7 +2616,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_cnt('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_cnt('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
@@ -2682,7 +2702,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_cnt('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_cnt('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
@@ -2932,7 +2952,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
@@ -3217,7 +3237,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
@@ -3542,7 +3562,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
@@ -3641,7 +3661,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_opt_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
@@ -3874,7 +3894,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
@@ -4081,7 +4101,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
@@ -4151,7 +4171,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_cnt('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
@@ -4225,7 +4245,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__management:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_opt_Identityref('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
@@ -4495,7 +4515,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
@@ -5036,7 +5056,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
@@ -5271,7 +5291,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
@@ -5337,7 +5357,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
@@ -5433,7 +5453,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
@@ -5526,7 +5546,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_cnt('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
@@ -5615,7 +5635,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_cnt('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_cnt('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
@@ -5762,7 +5782,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
@@ -5859,7 +5879,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
@@ -5992,7 +6012,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_cnt('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_cnt('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
@@ -6345,7 +6365,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
@@ -6458,7 +6478,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_empty('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
@@ -6549,7 +6569,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_empty('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
@@ -6640,7 +6660,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_empty('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
@@ -6915,7 +6935,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
@@ -6990,7 +7010,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_cnt('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
@@ -7070,7 +7090,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_cnt('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_cnt('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
@@ -7152,7 +7172,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
@@ -7240,7 +7260,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
@@ -7330,7 +7350,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_cnt('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
@@ -7424,7 +7444,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_cnt('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_cnt('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_cnt('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
@@ -7516,7 +7536,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
@@ -7764,7 +7784,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
@@ -7847,7 +7867,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_cnt('sham-links')))
         return None
 
@@ -7955,7 +7975,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -8386,7 +8406,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
@@ -8470,7 +8490,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_cnt('cascaded-lan-prefixes')))
         return None
 
@@ -8540,7 +8560,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -8609,7 +8629,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -8915,7 +8935,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
@@ -9148,7 +9168,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
@@ -9385,7 +9405,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_empty('all-other-accesses'), all_other_groups=n.get_opt_empty('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
@@ -9618,7 +9638,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
@@ -9693,7 +9713,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_cnt('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_cnt('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
@@ -9786,7 +9806,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
@@ -9882,7 +9902,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_cnt('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
@@ -10169,7 +10189,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
@@ -10254,7 +10274,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_cnt('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
@@ -10363,7 +10383,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
@@ -10438,7 +10458,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_cnt('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
@@ -10550,7 +10570,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
@@ -10648,7 +10668,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_Identityref('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_cnt('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_cnt('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_cnt('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
@@ -10946,7 +10966,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
@@ -11031,7 +11051,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_cnt('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
@@ -11140,7 +11160,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
@@ -11215,7 +11235,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_cnt('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
@@ -11327,7 +11347,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
@@ -11425,7 +11445,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_Identityref('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_cnt('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_cnt('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_cnt('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
@@ -11548,7 +11568,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
@@ -11631,7 +11651,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_cnt('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
@@ -11707,7 +11727,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_cnt('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_cnt('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_cnt('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
@@ -11789,7 +11809,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
@@ -11885,7 +11905,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
@@ -11978,7 +11998,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_cnt('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
@@ -12067,7 +12087,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_cnt('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_cnt('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
@@ -12232,7 +12252,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
@@ -12329,7 +12349,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
@@ -12462,7 +12482,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_cnt('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_cnt('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
@@ -12815,7 +12835,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
@@ -12928,7 +12948,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_empty('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
@@ -13019,7 +13039,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_empty('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
@@ -13110,7 +13130,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_empty('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
@@ -13385,7 +13405,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
@@ -13460,7 +13480,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_cnt('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
@@ -13540,7 +13560,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_cnt('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_cnt('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
@@ -13622,7 +13642,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
@@ -13710,7 +13730,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
@@ -13800,7 +13820,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_cnt('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
@@ -13909,7 +13929,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_opt_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_opt_int('svc-output-bandwidth'), svc_mtu=n.get_opt_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_cnt('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_cnt('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_cnt('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
@@ -14205,7 +14225,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
@@ -14288,7 +14308,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_cnt('sham-links')))
         return None
 
@@ -14396,7 +14416,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -14827,7 +14847,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
@@ -14911,7 +14931,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_cnt('cascaded-lan-prefixes')))
         return None
 
@@ -14981,7 +15001,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -15050,7 +15070,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
@@ -15356,7 +15376,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
@@ -15432,7 +15452,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
@@ -15527,7 +15547,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_Identityref('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
@@ -15895,7 +15915,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
@@ -16292,7 +16312,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
@@ -16372,7 +16392,7 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc:
-        if n != None:
+        if n is not None:
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_cnt('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_cnt('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_cnt('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
 
@@ -16463,7 +16483,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_cnt('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_cnt('l3vpn-svc')))
         return root()
 

--- a/src/sorespo/layers/y_1.act
+++ b/src/sorespo/layers/y_1.act
@@ -25,6 +25,12 @@ mut def from_json_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata
 mut def from_xml_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_json_netinfra_inter__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -81,7 +87,7 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra__router__base_config:
-        if n != None:
+        if n is not None:
             return netinfra_inter__netinfra__router__base_config(asn=n.get_int('asn'), ipv4_address=n.get_str('ipv4-address'), ipv6_address=n.get_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
@@ -297,15 +303,17 @@ mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf(jd: list[dict[str,
 class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: int
+    type: ?str
     role: ?str
     mock: ?str
     base_config: netinfra_inter__netinfra__router__base_config
     l3vpn_vrf: netinfra_inter__netinfra__router__l3vpn_vrf
 
-    mut def __init__(self, name: str, id: int, base_config: netinfra_inter__netinfra__router__base_config, role: ?str, mock: ?str, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
+    mut def __init__(self, name: str, id: int, base_config: netinfra_inter__netinfra__router__base_config, type: ?str, role: ?str, mock: ?str, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
         self._ns = 'http://example.com/netinfra-inter'
         self.name = name
         self.id = id
+        self.type = type
         self.role = role
         self.mock = mock
         self.base_config = base_config
@@ -319,6 +327,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('uint32', _id)
+        _type = self.type
+        if _type is not None:
+            children['type'] = yang.gdata.Leaf('string', _type)
         _role = self.role
         if _role is not None:
             children['role'] = yang.gdata.Leaf('string', _role)
@@ -335,7 +346,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -344,6 +355,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
             res.append('self_base_config = netinfra_inter__netinfra__router__base_config({repr(self.base_config.asn)}, {repr(self.base_config.ipv4_address)}, {repr(self.base_config.ipv6_address)})')
             res.append('{self_name} = netinfra_inter__netinfra__router({repr(self.name)}, {repr(self.id)}, self_base_config)')
         leaves = []
+        _type = self.type
+        if _type is not None:
+            leaves.append('{self_name}.type = {repr(_type)}')
         _role = self.role
         if _role is not None:
             leaves.append('{self_name}.role = {repr(_role)}')
@@ -408,6 +422,8 @@ mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yan
     yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__router__name, child_name)
     child_id = yang.gdata.from_xml_int(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_netinfra_inter__netinfra__router__id, child_id)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_netinfra_inter__netinfra__router__type, child_type)
     child_role = yang.gdata.from_xml_opt_str(node, 'role')
     yang.gdata.maybe_add(children, 'role', from_xml_netinfra_inter__netinfra__router__role, child_role)
     child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
@@ -440,6 +456,8 @@ mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path:
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_netinfra_inter__netinfra__router__name(keys[0])
         if point == 'id':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'type':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'role':
             raise ValueError("Invalid json path to non-inner node")
@@ -483,6 +501,8 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     yang.gdata.maybe_add(children, 'name', from_json_netinfra_inter__netinfra__router__name, child_name)
     child_id = yang.gdata.take_json_int(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_netinfra_inter__netinfra__router__id, child_id)
+    child_type = yang.gdata.take_json_opt_str(jd, 'type')
+    yang.gdata.maybe_add(children, 'type', from_json_netinfra_inter__netinfra__router__type, child_type)
     child_role = yang.gdata.take_json_opt_str(jd, 'role')
     yang.gdata.maybe_add(children, 'role', from_json_netinfra_inter__netinfra__router__role, child_role)
     child_mock = yang.gdata.take_json_opt_str(jd, 'mock')
@@ -1043,7 +1063,7 @@ class netinfra_inter__netinfra(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra:
-        if n != None:
+        if n is not None:
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
@@ -1202,7 +1222,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?l3vpn_inter__l3vpns__l3vpn__endpoint__bgp:
-        if n != None:
+        if n is not None:
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_int('as-number'))
         return None
 
@@ -1651,7 +1671,7 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> l3vpn_inter__l3vpns:
-        if n != None:
+        if n is not None:
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
@@ -1726,7 +1746,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_cnt('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_cnt('l3vpns')))
         return root()
 

--- a/src/sorespo/layers/y_1_loose.act
+++ b/src/sorespo/layers/y_1_loose.act
@@ -25,6 +25,12 @@ mut def from_json_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata
 mut def from_xml_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_json_netinfra_inter__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -81,7 +87,7 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra__router__base_config:
-        if n != None:
+        if n is not None:
             return netinfra_inter__netinfra__router__base_config(asn=n.get_opt_int('asn'), ipv4_address=n.get_opt_str('ipv4-address'), ipv6_address=n.get_opt_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
@@ -306,15 +312,17 @@ mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf(jd: list[dict[str,
 class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?int
+    type: ?str
     role: ?str
     mock: ?str
     base_config: netinfra_inter__netinfra__router__base_config
     l3vpn_vrf: netinfra_inter__netinfra__router__l3vpn_vrf
 
-    mut def __init__(self, name: str, id: ?int, role: ?str, mock: ?str, base_config: ?netinfra_inter__netinfra__router__base_config=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
+    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, mock: ?str, base_config: ?netinfra_inter__netinfra__router__base_config=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
         self._ns = 'http://example.com/netinfra-inter'
         self.name = name
         self.id = id
+        self.type = type
         self.role = role
         self.mock = mock
         self.base_config = base_config if base_config is not None else netinfra_inter__netinfra__router__base_config()
@@ -328,6 +336,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('uint32', _id)
+        _type = self.type
+        if _type is not None:
+            children['type'] = yang.gdata.Leaf('string', _type)
         _role = self.role
         if _role is not None:
             children['role'] = yang.gdata.Leaf('string', _role)
@@ -344,7 +355,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -355,6 +366,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             leaves.append('{self_name}.id = {repr(_id)}')
+        _type = self.type
+        if _type is not None:
+            leaves.append('{self_name}.type = {repr(_type)}')
         _role = self.role
         if _role is not None:
             leaves.append('{self_name}.role = {repr(_role)}')
@@ -419,6 +433,8 @@ mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yan
     yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__router__name, child_name)
     child_id = yang.gdata.from_xml_opt_int(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_netinfra_inter__netinfra__router__id, child_id)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_netinfra_inter__netinfra__router__type, child_type)
     child_role = yang.gdata.from_xml_opt_str(node, 'role')
     yang.gdata.maybe_add(children, 'role', from_xml_netinfra_inter__netinfra__router__role, child_role)
     child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
@@ -451,6 +467,8 @@ mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path:
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_netinfra_inter__netinfra__router__name(keys[0])
         if point == 'id':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'type':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'role':
             raise ValueError("Invalid json path to non-inner node")
@@ -494,6 +512,8 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     yang.gdata.maybe_add(children, 'name', from_json_netinfra_inter__netinfra__router__name, child_name)
     child_id = yang.gdata.take_json_opt_int(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_netinfra_inter__netinfra__router__id, child_id)
+    child_type = yang.gdata.take_json_opt_str(jd, 'type')
+    yang.gdata.maybe_add(children, 'type', from_json_netinfra_inter__netinfra__router__type, child_type)
     child_role = yang.gdata.take_json_opt_str(jd, 'role')
     yang.gdata.maybe_add(children, 'role', from_json_netinfra_inter__netinfra__router__role, child_role)
     child_mock = yang.gdata.take_json_opt_str(jd, 'mock')
@@ -1060,7 +1080,7 @@ class netinfra_inter__netinfra(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra:
-        if n != None:
+        if n is not None:
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
@@ -1218,7 +1238,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?l3vpn_inter__l3vpns__l3vpn__endpoint__bgp:
-        if n != None:
+        if n is not None:
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_opt_int('as-number'))
         return None
 
@@ -1682,7 +1702,7 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> l3vpn_inter__l3vpns:
-        if n != None:
+        if n is not None:
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
@@ -1757,7 +1777,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_cnt('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_cnt('l3vpns')))
         return root()
 

--- a/src/sorespo/layers/y_2.act
+++ b/src/sorespo/layers/y_2.act
@@ -593,7 +593,7 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__credentials:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__device__credentials(username=n.get_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
@@ -1054,7 +1054,7 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__mock:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
@@ -1615,7 +1615,7 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface__remote:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_str('device'), interface=n.get_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
@@ -1689,7 +1689,7 @@ class orchestron_rfs__rfs__backbone_interface__local(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface__local:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__rfs__backbone_interface__local(device=n.get_str('device'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__local')
 
@@ -3034,7 +3034,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
 

--- a/src/sorespo/layers/y_2_loose.act
+++ b/src/sorespo/layers/y_2_loose.act
@@ -596,7 +596,7 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__credentials:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__device__credentials(username=n.get_opt_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
@@ -1063,7 +1063,7 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__mock:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
@@ -1635,7 +1635,7 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface__remote:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_opt_str('device'), interface=n.get_opt_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
@@ -1715,7 +1715,7 @@ class orchestron_rfs__rfs__backbone_interface__local(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface__local:
-        if n != None:
+        if n is not None:
             return orchestron_rfs__rfs__backbone_interface__local(device=n.get_opt_str('device'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__local')
 
@@ -3086,7 +3086,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
 

--- a/src/sorespo/layers/y_3.act
+++ b/src/sorespo/layers/y_3.act
@@ -186,7 +186,7 @@ class orchestron_device__devices(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_device__devices:
-        if n != None:
+        if n is not None:
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
@@ -256,7 +256,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_cnt('devices')))
         return root()
 

--- a/src/sorespo/layers/y_3_loose.act
+++ b/src/sorespo/layers/y_3_loose.act
@@ -186,7 +186,7 @@ class orchestron_device__devices(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_device__devices:
-        if n != None:
+        if n is not None:
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
@@ -256,7 +256,7 @@ class root(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
-        if n != None:
+        if n is not None:
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_cnt('devices')))
         return root()
 

--- a/test/quicklab-crpd/netinfra.json
+++ b/test/quicklab-crpd/netinfra.json
@@ -4,24 +4,28 @@
             {
                 "name": "AMS-CORE-1",
                 "id": 1,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "FRA-CORE-1",
                 "id": 2,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "STO-CORE-1",
                 "id": 3,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "LJU-CORE-1",
                 "id": 4,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             }

--- a/test/quicklab-crpd/netinfra.xml
+++ b/test/quicklab-crpd/netinfra.xml
@@ -4,24 +4,28 @@
         <router>
             <name>AMS-CORE-1</name>
             <id>1</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>FRA-CORE-1</name>
             <id>2</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>STO-CORE-1</name>
             <id>3</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>LJU-CORE-1</name>
             <id>4</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>

--- a/test/quicklab-notconf/netinfra.json
+++ b/test/quicklab-notconf/netinfra.json
@@ -4,24 +4,28 @@
             {
                 "name": "AMS-CORE-1",
                 "id": 1,
+                "type": "CiscoIosXr_24_1_ncs55a1",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "FRA-CORE-1",
                 "id": 2,
+                "type": "CiscoIosXr_24_1_ncs55a1",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "STO-CORE-1",
                 "id": 3,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "LJU-CORE-1",
                 "id": 4,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             }

--- a/test/quicklab-notconf/netinfra.xml
+++ b/test/quicklab-notconf/netinfra.xml
@@ -4,24 +4,28 @@
         <router>
             <name>AMS-CORE-1</name>
             <id>1</id>
+            <type>CiscoIosXr_24_1_ncs55a1</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>FRA-CORE-1</name>
             <id>2</id>
+            <type>CiscoIosXr_24_1_ncs55a1</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>STO-CORE-1</name>
             <id>3</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>LJU-CORE-1</name>
             <id>4</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>

--- a/test/quicklab-srl/netinfra.json
+++ b/test/quicklab-srl/netinfra.json
@@ -4,24 +4,28 @@
             {
                 "name": "AMS-CORE-1",
                 "id": 1,
+                "type": "NokiaSRLinux_25_3_2",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "FRA-CORE-1",
                 "id": 2,
+                "type": "NokiaSRLinux_25_3_2",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "STO-CORE-1",
                 "id": 3,
+                "type": "NokiaSRLinux_25_3_2",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "LJU-CORE-1",
                 "id": 4,
+                "type": "NokiaSRLinux_25_3_2",
                 "role": "edge",
                 "asn": 65001
             }

--- a/test/quicklab-srl/netinfra.xml
+++ b/test/quicklab-srl/netinfra.xml
@@ -4,24 +4,28 @@
         <router>
             <name>AMS-CORE-1</name>
             <id>1</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>FRA-CORE-1</name>
             <id>2</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>STO-CORE-1</name>
             <id>3</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>LJU-CORE-1</name>
             <id>4</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>

--- a/test/quicklab-srl/tutorial-netinfra.xml
+++ b/test/quicklab-srl/tutorial-netinfra.xml
@@ -4,18 +4,21 @@
         <router>
             <name>AMS-CORE-1</name>
             <id>1</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>FRA-CORE-1</name>
             <id>2</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>STO-CORE-1</name>
             <id>3</id>
+            <type>NokiaSRLinux_25_3_2</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>

--- a/test/quicklab/netinfra.json
+++ b/test/quicklab/netinfra.json
@@ -4,24 +4,28 @@
             {
                 "name": "AMS-CORE-1",
                 "id": 1,
+                "type": "CiscoIosXr_24_1_ncs55a1",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "FRA-CORE-1",
                 "id": 2,
+                "type": "CiscoIosXr_24_1_ncs55a1",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "STO-CORE-1",
                 "id": 3,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             },
             {
                 "name": "LJU-CORE-1",
                 "id": 4,
+                "type": "JuniperCRPD_23_4R1_9",
                 "role": "edge",
                 "asn": 65001
             }

--- a/test/quicklab/netinfra.xml
+++ b/test/quicklab/netinfra.xml
@@ -4,24 +4,28 @@
         <router>
             <name>AMS-CORE-1</name>
             <id>1</id>
+            <type>CiscoIosXr_24_1_ncs55a1</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>FRA-CORE-1</name>
             <id>2</id>
+            <type>CiscoIosXr_24_1_ncs55a1</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>STO-CORE-1</name>
             <id>3</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>
         <router>
             <name>LJU-CORE-1</name>
             <id>4</id>
+            <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
         </router>


### PR DESCRIPTION
Upgrade deps to get new Orchestron version etc where the Device now carries DeviceSchema which we use to parse the config from a device and store it so it can later be retrieved.

Fixes #97.