### PR TITLE
Avoid undocumented config on cRPD

### DIFF
--- a/src/sorespo/rfs.act
+++ b/src/sorespo/rfs.act
@@ -414,8 +414,6 @@ class VrfInterface(base.VrfInterface):
             # Main interface config
             intf = dev.configuration.interfaces.interface.create(main_intf)
             intf.description = i.description
-            intf.flexible_vlan_tagging = True
-            intf.encapsulation = "flexible-ethernet-services"
 
             # Unit config
             unit = intf.unit.create(vlan_id)

--- a/test/golden/test_sorespo/l3vpn_svc
+++ b/test/golden/test_sorespo/l3vpn_svc
@@ -688,8 +688,6 @@ end-policy</rpl-route-policy>
                 </inet>
               </family>
             </unit>
-            <encapsulation>flexible-ethernet-services</encapsulation>
-            <flexible-vlan-tagging/>
           </interface>
           <interface>
             <name>lo0</name>
@@ -903,8 +901,6 @@ end-policy</rpl-route-policy>
                 </inet>
               </family>
             </unit>
-            <encapsulation>flexible-ethernet-services</encapsulation>
-            <flexible-vlan-tagging/>
           </interface>
           <interface>
             <name>lo0</name>

--- a/test/golden/test_sorespo/l3vpn_svc_adata
+++ b/test/golden/test_sorespo/l3vpn_svc_adata
@@ -517,8 +517,6 @@ def adata_LJU_CORE_1():
     # List /configuration/interfaces/interface element: eth3
     interface_element = ad.configuration.interfaces.interface.create('eth3')
     interface_element.description = 'Customer VPN access SITE-4 [SNA-4-1] in VPN acme-65501'
-    interface_element.encapsulation = 'flexible-ethernet-services'
-    interface_element.flexible_vlan_tagging = True
     
     # List /configuration/interfaces/interface/unit element: 100
     unit_element = interface_element.unit.create('100')
@@ -729,8 +727,6 @@ def adata_STO_CORE_1():
     # List /configuration/interfaces/interface element: eth4
     interface_element = ad.configuration.interfaces.interface.create('eth4')
     interface_element.description = 'Customer VPN access SITE-3 [SNA-3-1] in VPN acme-65501'
-    interface_element.encapsulation = 'flexible-ethernet-services'
-    interface_element.flexible_vlan_tagging = True
     
     # List /configuration/interfaces/interface/unit element: 100
     unit_element = interface_element.unit.create('100')

--- a/test/golden/test_sorespo/l3vpn_svc_json
+++ b/test/golden/test_sorespo/l3vpn_svc_json
@@ -1044,10 +1044,6 @@
                                                 }
                                             }
                                         }
-                                    ],
-                                    "encapsulation": "flexible-ethernet-services",
-                                    "flexible-vlan-tagging": [
-                                        null
                                     ]
                                 },
                                 {
@@ -1389,10 +1385,6 @@
                                                 }
                                             }
                                         }
-                                    ],
-                                    "encapsulation": "flexible-ethernet-services",
-                                    "flexible-vlan-tagging": [
-                                        null
                                     ]
                                 },
                                 {


### PR DESCRIPTION
These statements are not officially supported by the cRPD models, but
are still accepted and show up wrapped with `<undocumented>` in
get-config. The network still works without it though. These were likely
just copied from the vMX config templates without giving it a second
thought ...