### PR TITLE
Upgrade dependencies: yang, netconf, orchestron, actmf

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,23 +2,23 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/77d3f79ba95c9ea5df94bb3ecc991a07903e4372.zip",
-            "hash": "1220f712026430d1097b49911d252bb096b96e0a0fe073b7ab18a02448ce97483f73"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/4a80ecc1dead281b9bbab802c5bc846498328c78.zip",
+            "hash": "1220f8609edc2abe4b3a1330378bc0c3a6f235ba044c1aea9cc95ce8e8a96681d37e"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/06db6c04ff8c55c41ccea17134c005943ae44e3b.zip",
-            "hash": "12201f52d293728263e7e9f320726702686de743509a39b1ffae0db55285daa59f42"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/6ebb23fd3c449fd65d69209acfbd00549f5d1248.zip",
+            "hash": "122096f0c9b63b7ae48cae74b108ecfd310f7c569db60e46ffa4ac703475314521cb"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/0449735923ebf7b7f5378a426cda06a534b002d5.zip",
-            "hash": "1220c71c2fd5719cc094a3ec3440c7ce069df8af1011d50ffaf8da1181c59d08786a"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/632ade93956e237adcdb3296771e18ab497f83af.zip",
+            "hash": "12200ceb8031076a3e4a39a2601cb82e32e816a1e450a56831ddc2b7cf273a00d610"
         },
         "actmf": {
             "repo_url": "https://github.com/orchestron-orchestrator/actmf.git",
-            "url": "https://github.com/orchestron-orchestrator/actmf/archive/abeed0f1a39f1368f2635cfe474949db3b5a8a12.zip",
-            "hash": "1220a434ae2d8c0fe96193b22f543566afef74baffdfa2825e7e8c94223e0fb53fb6"
+            "url": "https://github.com/orchestron-orchestrator/actmf/archive/714db19b35f7524c8cb549f11c267069f4b03bde.zip",
+            "hash": "12205218a723f3b776ed4808e071d03d05afcb004cbbce622656863f4ef2514b3497"
         }
     },
     "zig_dependencies": {}

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,18 +2,18 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/77d3f79ba95c9ea5df94bb3ecc991a07903e4372.zip",
-            "hash": "1220f712026430d1097b49911d252bb096b96e0a0fe073b7ab18a02448ce97483f73"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/4a80ecc1dead281b9bbab802c5bc846498328c78.zip",
+            "hash": "1220f8609edc2abe4b3a1330378bc0c3a6f235ba044c1aea9cc95ce8e8a96681d37e"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/06db6c04ff8c55c41ccea17134c005943ae44e3b.zip",
-            "hash": "12201f52d293728263e7e9f320726702686de743509a39b1ffae0db55285daa59f42"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/6ebb23fd3c449fd65d69209acfbd00549f5d1248.zip",
+            "hash": "122096f0c9b63b7ae48cae74b108ecfd310f7c569db60e46ffa4ac703475314521cb"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/0449735923ebf7b7f5378a426cda06a534b002d5.zip",
-            "hash": "1220c71c2fd5719cc094a3ec3440c7ce069df8af1011d50ffaf8da1181c59d08786a"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/632ade93956e237adcdb3296771e18ab497f83af.zip",
+            "hash": "12200ceb8031076a3e4a39a2601cb82e32e816a1e450a56831ddc2b7cf273a00d610"
         }
     },
     "zig_dependencies": {}


### PR DESCRIPTION
- yang: 06db6c0..6ebb23f
  * Support eq on different types
  * Support qualified node lookup DNode.get()
  * Fix diff of system-ordered lists
  * REUSE License compliance

- netconf: 0449735..632ade9
  * Add filter parameter to get-config method
  * Use correct namespace prefix for lock / unlock
  * REUSE License Compliance

- orchestron: 77d3f79..4a80ecc
  * Upgrade dependencies: netconf, yang (#188)

- actmf: abeed0f..714db19
  * REUSE License Compliance