### PR TITLE
Hacky cache update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,11 @@ jobs:
           path: |
             ~/.cache/acton
             out
-          key: acton-${{ hashFiles('**/build.act.json') }}-${{ steps.setup-acton.outputs.version }}
+          # Hacky cache update:
+          # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          key: acton-${{ github.run_id }}
+          restore-keys: |
+            acton
       - name: "Ensure generated code is up to date"
         run: |
           make gen


### PR DESCRIPTION
We always create a new cache (unique key), but restore from one of the existing ones. The documentation states that restore-keys is matched against an ordered list of caches, but what is the order?! I hope it is ascending by age :)