### PR TITLE
In tests, increase retry wait in test-ping to 120s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
           make -C test/${{ matrix.TESTENV }} test-get-config
       - name: "Run quicklab tests"
         run: |
-          timeout 120 bash -c 'until make -C test/${{ matrix.TESTENV }} test-ping; do echo "Retrying..."; sleep 2; done'
+          make -C test/${{ matrix.TESTENV }} test-ping
       - run: |
           make -C test/${{ matrix.TESTENV }} save-logs
         if: ${{ always() }}

--- a/test/common/containers.mk
+++ b/test/common/containers.mk
@@ -30,9 +30,10 @@ $(addprefix platform-cli-,$(ROUTERS_FRR)):
 	docker exec -it $(TESTENV)-$(subst platform-cli-,,$@) vtysh
 
 
+$(addprefix test-ping-,$(ROUTERS_FRR)): WAIT ?= 120s
 $(addprefix test-ping-,$(ROUTERS_FRR)):
 # brew install coreutils on MacOS
-	timeout --foreground 10s bash -c "until docker exec -t $(TESTENV)-$(@:test-ping-%=%) ping -c 1 -W 1 -I $(SRC) $(IP); do sleep 1; done"
+	timeout --foreground $(WAIT) bash -c "until docker exec -t $(TESTENV)-$(@:test-ping-%=%) ping -c 1 -W 1 -I $(SRC) $(IP); do sleep 1; done"
 
 .PHONY: test-ping
 test-ping::


### PR DESCRIPTION
Allow "make test" now succeed.

Remove the extra layer to retry in github test cases.