### PR TITLE
Fetch conf and add /diff to HTTP API

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/77a35bfbf3b539fb2767fa8dc1d8416a18e6359f.zip",
-            "hash": "12203fb24afcd493538387e0bb0165fe38742dc6c8c020f98a2ba2e65f0bf75c7b2a"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/b38c887f7d67c079cd51386933f34f17f93279ce.zip",
+            "hash": "12201dffb1e3615f236be86bcdb7793c89dc4b885b2cf041a38e6cf64c5f27e30a19"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/77a35bfbf3b539fb2767fa8dc1d8416a18e6359f.zip",
-            "hash": "12203fb24afcd493538387e0bb0165fe38742dc6c8c020f98a2ba2e65f0bf75c7b2a"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/b38c887f7d67c079cd51386933f34f17f93279ce.zip",
+            "hash": "12201dffb1e3615f236be86bcdb7793c89dc4b885b2cf041a38e6cf64c5f27e30a19"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -178,6 +178,17 @@ actor main(env):
                         txt += r"}"
                         respond(200, {}, txt)
                         return
+                    if path_elements[3] == 'diff':
+                        running_config_gd = dev.get_config()
+                        session = cfs.newsession()
+                        device_layer = session.below().below().below().get()
+                        device_entry = device_layer.get_cnt("devices").get_list("device").get_list_entry(dev_name)
+                        target_config_gd = device_entry.get_cnt("config")
+                        config_diff = None
+                        if running_config_gd is not None and target_config_gd is not None:
+                            config_diff = yang.gdata.diff(running_config_gd, target_config_gd)
+                        respond_with_data(config_diff, dev.get_schema(), request.headers.get("accept"))
+                        return
                     if path_elements[3] == 'target':
                         session = cfs.newsession()
                         device_layer = session.below().below().below().get()

--- a/test/common/quicklab.mk
+++ b/test/common/quicklab.mk
@@ -139,6 +139,10 @@ $(addprefix get-running-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
 $(addprefix get-running-adata-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
 	@$(MAKE) HEADERS="-H \"Accept: application/adata+text\"" $(subst adata-,,$@)
 
+.PHONY: $(addprefix get-running-diff-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL))
+$(addprefix get-running-diff-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
+	@curl $(HEADERS) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/device/$(subst get-running-diff-,,$@)/diff
+
 .PHONY: delete-config
 delete-config:
 	curl -X DELETE http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf/netinfra:netinfra/routers=STO-CORE-1


### PR DESCRIPTION
It is now possible to get a diff of the running config on the device and our target config. This should make it easier to bring our transforms in line, for example adding configuration that is currently on the devices so that we later can turn on the diff reconciliation step.

Upgraded Orchestron to get the config-fetching during commit dance.