### PR TITLE
Add /reconfigure HTTP API

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/9829adeadc1a529dd84be1e0004542e7590252e4.zip",
-            "hash": "1220410697b3d6bd1cf9c6fa3d85bea271d99d1353c8013d4652d6e06ea5163ef4f9"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/7cbc7cb3957e0c7542406febf95e5a6aada1a8b3.zip",
+            "hash": "12208fe386043a9daa9e27dcc720a816c7787d4e427720c5c083420717916899fe0a"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/9829adeadc1a529dd84be1e0004542e7590252e4.zip",
-            "hash": "1220410697b3d6bd1cf9c6fa3d85bea271d99d1353c8013d4652d6e06ea5163ef4f9"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/7cbc7cb3957e0c7542406febf95e5a6aada1a8b3.zip",
+            "hash": "12208fe386043a9daa9e27dcc720a816c7787d4e427720c5c083420717916899fe0a"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -200,6 +200,14 @@ actor main(env):
                         config_gd = dev.get_config()
                         respond_with_data(config_gd, dev.get_schema(), request.headers.get("accept"))
                         return
+                    if path_elements[3] == 'reconfigure':
+                        def reconf_done(error: ?Exception):
+                            if error is None:
+                                respond(200, {}, "OK")
+                            else:
+                                respond(500, {}, str(error))
+                        dev.reconfigure(reconf_done)
+                        return
 
                     respond(404, {}, "Not found")
                     return

--- a/test/common/quicklab.mk
+++ b/test/common/quicklab.mk
@@ -143,6 +143,10 @@ $(addprefix get-running-adata-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
 $(addprefix get-running-diff-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
 	@curl $(HEADERS) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/device/$(subst get-running-diff-,,$@)/diff
 
+.PHONY: $(addprefix reconfigure-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL))
+$(addprefix reconfigure-,$(ROUTERS_XR) $(ROUTERS_CRPD) $(ROUTERS_SRL)):
+	@curl $(HEADERS) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/device/$(subst reconfigure-,,$@)/reconfigure
+
 .PHONY: delete-config
 delete-config:
 	curl -X DELETE http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf/netinfra:netinfra/routers=STO-CORE-1


### PR DESCRIPTION
This allows us to issue reconfiguration of a device, which ensures that the device configuration is aligned with the Orchestron / sorespo target configuration for the device. This is a synchronous action that returns once we have reconfigured the device.