### PR TITLE
Flip to await device completion etc by default

### DIFF
--- a/docs/tutorials/run-on-codespaces.md
+++ b/docs/tutorials/run-on-codespaces.md
@@ -658,8 +658,8 @@ make test-ping
 Throughout this tutorial you have used the `send-config-wait` target to apply
 intent configuration. This synchronous method waits for Orchestron to apply the
 configuration to the device(s) before it returns. Usually, asynchronous
-operations are preferred. Try using the `send-config` target instead and notice
-how your terminal returns as soon as the intent was accepted by SORESPO.
+operations are preferred. Try using the `send-config-async` target instead and
+notice how your terminal returns as soon as the intent was accepted by SORESPO.
 
 ## What's Next
 Now that you are familiar with running SORESPO and interacting with it,

--- a/docs/tutorials/run-on-linux.md
+++ b/docs/tutorials/run-on-linux.md
@@ -655,8 +655,8 @@ make test-ping
 Throughout this tutorial you have used the `send-config-wait` target to apply
 intent configuration. This synchronous method waits for Orchestron to apply the
 configuration to the device(s) before it returns. Usually, asynchronous
-operations are preferred. Try using the `send-config` target instead and notice
-how your terminal returns as soon as the intent was accepted by SORESPO.
+operations are preferred. Try using the `send-config-async` target instead and
+notice how your terminal returns as soon as the intent was accepted by SORESPO.
 
 ## What's Next
 Now that you are familiar with running SORESPO and interacting with it,

--- a/docs/tutorials/run-on-macos.md
+++ b/docs/tutorials/run-on-macos.md
@@ -661,8 +661,8 @@ make test-ping
 Throughout this tutorial you have used the `send-config-wait` target to apply
 intent configuration. This synchronous method waits for Orchestron to apply the
 configuration to the device(s) before it returns. Usually, asynchronous
-operations are preferred. Try using the `send-config` target instead and notice
-how your terminal returns as soon as the intent was accepted by SORESPO.
+operations are preferred. Try using the `send-config-async` target instead and
+notice how your terminal returns as soon as the intent was accepted by SORESPO.
 
 ## What's Next
 Now that you are familiar with running SORESPO and interacting with it,

--- a/docs/tutorials/run-on-windows.md
+++ b/docs/tutorials/run-on-windows.md
@@ -668,8 +668,8 @@ make test-ping
 Throughout this tutorial you have used the `send-config-wait` target to apply
 intent configuration. This synchronous method waits for Orchestron to apply the
 configuration to the device(s) before it returns. Usually, asynchronous
-operations are preferred. Try using the `send-config` target instead and notice
-how your terminal returns as soon as the intent was accepted by SORESPO.
+operations are preferred. Try using the `send-config-async` target instead and
+notice how your terminal returns as soon as the intent was accepted by SORESPO.
 
 ## What's Next
 Now that you are familiar with running SORESPO and interacting with it,

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -274,12 +274,11 @@ actor main(env):
 
                 if input_config is not None:
                     session = cfs.newsession()
-                    if request.headers.get_def("await-device", "") == "true":
-                        log.info("Client wants to await device config push")
-                        session.edit_config(input_config, None, config_done)
-                    else:
-                        log.info("Client does not want to await device config push")
+                    if request.headers.get_def("async", "") == "true":
+                        log.info("Client requests async behavior")
                         session.edit_config(input_config, config_done)
+                    else:
+                        session.edit_config(input_config, None, config_done)
                     return
 
             respond(404, {}, "")

--- a/test/common/quicklab.mk
+++ b/test/common/quicklab.mk
@@ -79,21 +79,21 @@ dev-tutorial:
 shell:
 	docker exec -it $(TESTENV)-otron bash -l
 
-.PHONY: send-config
-send-config:
-	curl -X PUT -H "Content-Type: application/yang-data+xml" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
+.PHONY: send-config-async
+send-config-async:
+	curl -X PUT -H "Content-Type: application/yang-data+xml" -H "Async: true" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
 
 .PHONY: send-config-wait
 send-config-wait:
-	curl -X PUT -H "Content-Type: application/yang-data+xml" -H "Await-Device: true" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
+	curl -X PUT -H "Content-Type: application/yang-data+xml" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
 
-.PHONY: send-config-json
-send-config-json:
-	curl -X PUT -H "Content-Type: application/yang-data+json" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
+.PHONY: send-config-json-async
+send-config-json-async:
+	curl -X PUT -H "Content-Type: application/yang-data+json" -H "Async: true" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
 
 .PHONY: send-config-json-wait
 send-config-json-wait:
-	curl -X PUT -H "Content-Type: application/yang-data+json" -H "Await-Device: true" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
+	curl -X PUT -H "Content-Type: application/yang-data+json" -d @$(FILE) http://localhost:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' $(TESTENV)-otron)/restconf
 
 .PHONY: send-config-tmf
 send-config-tmf:


### PR DESCRIPTION
Our default behavior has been to act asynchronously but have exposed the Await-Device header to optionally await that configuration has been pushed to the device before the HTTP API returns a response.

This flips the default so that we now await device completion per default. If a user wants async, they can request that by sending the header: Async: true

I think this better reflects naive users intuition. Most systems are synchronous and it's quite nice from a control flow perspective that when the Orchestron HTTP API returns, the configuration has been entirely applied, so if you are doing this from a simple script, the script can block on the HTTP API call and once it is done, it can proceed to the next thing. I think it will be even better when we integrate the concepts of transform health so that we can also ensure that a transform is healthy after a configuration change or at least didn't deteriorate (broken before = broken after is acceptable). For anyone that has a concurrent system or is used to dealing with async, it is trivial to enable.

The make targets have been renamed. We have -async or -wait explicitly in the name, which I think is OK, since even if you use the defauly synchronous, having -wait as the suffix hints that there are other options there.

Fixes https://github.com/orchestron-orchestrator/orchestron/issues/222