### PR TITLE
HTTP API should listen on IPv6

### DIFF
--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -572,7 +572,7 @@ actor main(env):
     def _on_http_server_error(server, error):
         print("Error: {error}")
 
-    server = http.Listener(tcpl_cap, "0.0.0.0", 80, _on_http_accept, log_handler=logh_http)
+    server = http.Listener(tcpl_cap, "::", 80, _on_http_accept, log_handler=logh_http)
 
     configs = []
     env_exit_on_done = env.getenv("EXIT_ON_DONE")


### PR DESCRIPTION
Listen on ::, which, on Linux at least, seems to automatically result in us also receiving IPv4 connections.

Fixes https://github.com/orchestron-orchestrator/orchestron/issues/234 