### PR TITLE
Feature flag

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,18 +2,19 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/5c73c8b3e13650e7905b29505680ffa1aeed96e9.zip",
-            "hash": "1220e7dc2bc0e22856b8f559bf0b42499d341c42e0b941bddf50e7fd748566ad419a"
+            "repo_ref": "schema-registry",
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/198583fa65a1d165bec7c4f0e9a1725e757466cb.zip",
+            "hash": "1220d47a334ce442e03969e610759f18c1d684dfde04092e452de7de7e28ea948301"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2f228ebe0dbefc6c467aa190b6cab28a159a7f3d.zip",
-            "hash": "122060f6836d54d34b853f9747eaaaa1dfb4a295f2450c5098d9d39c4440dd87d9a5"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/01fe230292b99321fe30e0f3577a411bd60a7e8d.zip",
+            "hash": "1220b2a87312f3debdb36c693df623212f399a94f999d29bf5f34dbf7f2a2052d981"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/ec9358d5629e102dd3a9161713c0ab360d3df188.zip",
-            "hash": "122029ab2319806826dcfbb8d239866a40736739138ad0779b15573680225f749de4"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/40e4ac2d3772f82100ed80be3ede4570f9850813.zip",
+            "hash": "122083a088be74f823276c0a8975a81f82292178cc98c0ed71a37a4e88e550dc27c2"
         },
         "actmf": {
             "repo_url": "https://github.com/orchestron-orchestrator/actmf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,18 +2,19 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/53b9b918c0115f730e42c2d29f664ff2aa0c9580.zip",
-            "hash": "12200cc7919568e939d8ede688c6dbfae0b2e4040eaeb2f36d37b9340071d026be75"
+            "repo_ref": "schema-registry",
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/198583fa65a1d165bec7c4f0e9a1725e757466cb.zip",
+            "hash": "1220d47a334ce442e03969e610759f18c1d684dfde04092e452de7de7e28ea948301"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2f228ebe0dbefc6c467aa190b6cab28a159a7f3d.zip",
-            "hash": "122060f6836d54d34b853f9747eaaaa1dfb4a295f2450c5098d9d39c4440dd87d9a5"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/01fe230292b99321fe30e0f3577a411bd60a7e8d.zip",
+            "hash": "1220b2a87312f3debdb36c693df623212f399a94f999d29bf5f34dbf7f2a2052d981"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/ec9358d5629e102dd3a9161713c0ab360d3df188.zip",
-            "hash": "122029ab2319806826dcfbb8d239866a40736739138ad0779b15573680225f749de4"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/40e4ac2d3772f82100ed80be3ede4570f9850813.zip",
+            "hash": "122083a088be74f823276c0a8975a81f82292178cc98c0ed71a37a4e88e550dc27c2"
         }
     },
     "zig_dependencies": {}

--- a/gen/yang/cfs/netinfra.yang
+++ b/gen/yang/cfs/netinfra.yang
@@ -47,6 +47,12 @@ module netinfra {
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
     }
 
     list backbone-link {

--- a/gen/yang/inter/netinfra-inter.yang
+++ b/gen/yang/inter/netinfra-inter.yang
@@ -42,6 +42,12 @@ module netinfra-inter {
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
       container base-config {
         leaf asn {
           type inet:as-number;

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -11,6 +11,7 @@ import orchestron.ttt as ttt
 import orchestron.device_meta_config    # TODO: remove https://github.com/actonlang/acton/issues/2390
 import yang.adata
 import yang.gdata
+import yang.gen3
 
 import tmf.tmf641
 import sorespo.tmf
@@ -204,7 +205,8 @@ actor main(env):
                 return
 
             if len(path_elements) > 3 and path_elements[1] == "device":
-                def respond_with_data(data: ?yang.gdata.Node, schema: odev.DeviceSchema, accept_header: ?str):
+                # TODO; this is not used anywhere?!
+                def respond_with_data(data: ?yang.gdata.Node, dev: odev.DeviceMgr, accept_header: ?str):
                     aheader = accept_header if accept_header is not None else "application/yang-data+json"
                     if data is not None:
                         if aheader == "application/yang-data+json":
@@ -212,8 +214,12 @@ actor main(env):
                         elif aheader == "application/yang-data+xml":
                             out_data = data.to_xmlstr()
                         elif aheader == "application/yang-data+acton-adata":
-                            adata = schema.from_gdata(data)
-                            out_data = adata.prsrc()
+                            schema = dev.get_fetched_schema()
+                            if schema is not None:
+                                out_data = yang.gen3.pradata(schema, data, loose=True)
+                            else:
+                                respond(500, {}, "Schemas not compiled")
+                                return
                         else:
                             respond(404, {}, "Unsupported media type")
                             return
@@ -224,6 +230,7 @@ actor main(env):
                 try:
                     dev_name = path_elements[2]
                     dev = dev_registry.get(dev_name)
+                    schema = dev.get_fetched_schema()
                     if path_elements[3] == "capabilities":
                         respond(200, {}, str(dev.get_capabilities()))
                         return
@@ -259,8 +266,12 @@ actor main(env):
                                 elif format_type == "gdata":
                                     diff_str = config_diff.prsrc()
                                 elif format_type == "adata":
-                                    # adata conversion would need schema
-                                    diff_str = "# Adata format not available for diff"
+                                    # TODO: avoid "actonc: #### findAttr' fails for __builtin__.str . val"
+                                    # schema = dev.get_fetched_schema()
+                                    if schema is not None:
+                                        diff_str = yang.gen3.pradata(schema, config_diff, loose=True)
+                                    else:
+                                        diff_str = "# Adata format not available for diff (schemas not compiled)"
                                 else:
                                     diff_str = config_diff.to_json()  # default to json
                                 respond(200, {"Content-Type": "text/plain"}, diff_str)
@@ -317,8 +328,12 @@ actor main(env):
                             elif format_type == "gdata":
                                 conf_str = running_conf.prsrc()
                             elif format_type == "adata":
-                                # adata conversion would need schema
-                                conf_str = "# Adata format not available"
+                                # TODO: avoid "actonc: #### findAttr' fails for __builtin__.str . val"
+                                # schema = dev.get_fetched_schema()
+                                if schema is not None:
+                                    conf_str = yang.gen3.pradata(schema, running_conf, loose=True)
+                                else:
+                                    conf_str = "# Adata format not available (schemas not compiled)"
                             else:
                                 conf_str = running_conf.to_json()  # default to json
                             respond(200, {"Content-Type": "text/plain"}, conf_str)

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -377,7 +377,13 @@ actor main(env):
                         # Add credentials info (just username, not password)
                         if dmc.credentials is not None:
                             info["username"] = dmc.credentials.username if dmc.credentials.username is not None else ""
-                        
+
+                        # Add feature flags
+                        feature_flags = {}
+                        if dmc.feature_flags is not None:
+                            feature_flags["runtime_schema_fetch"] = dmc.feature_flags.runtime_schema_fetch
+                        info["feature_flags"] = feature_flags
+
                         # Add YANG modules information (available for all devices)
                         modset, modset_id = dev.get_modules()
                         modules = []
@@ -476,7 +482,7 @@ actor main(env):
                                             config_diff_str = config_diff.prsrc()
                                         else:  # xml is default
                                             config_diff_str = config_diff.to_xmlstr()
-                                    
+
                                     return {
                                         "tid": di.ci.tid,
                                         "config_diff": config_diff_str,

--- a/src/sorespo.act
+++ b/src/sorespo.act
@@ -432,13 +432,13 @@ actor main(env):
                             respond(200, {}, format_listq(dev.list_confq()))
                             return
                         elif len(path_elements) >= 5:
-                            pe = path_elements[4].split('?', 1)
-                            id: str = pe[0]
+                            id: str = path_elements[4]
                             if len(path_elements) == 5:
                                 format_type = "xml"  # default
                                 query_params = {}
-                                if len(pe) > 1:
-                                    for param in pe[1].split("&"):
+                                if "?" in request.path:
+                                    query_string = request.path.split('?', 1)[1]
+                                    for param in query_string.split("&"):
                                         if "=" in param:
                                             kv = param.split("=", 1)
                                             query_params[kv[0]] = kv[1]

--- a/src/sorespo/cfs.act
+++ b/src/sorespo/cfs.act
@@ -19,6 +19,7 @@ class Router(base.Router):
         o_router.role = i.role
         o_router.mock = i.mock
         o_router.approval_required = i.approval_required
+        o_router.feature_flags.runtime_schema_fetch = i.feature_flags.runtime_schema_fetch
 
         # Assign the loopback interface addresses
         bc = o_router.base_config

--- a/src/sorespo/inter.act
+++ b/src/sorespo/inter.act
@@ -31,6 +31,7 @@ class Router(base.Router):
         mock = i.mock
         if mock is not None:
             dev.mock.preset.append(mock)
+        dev.feature_flags.runtime_schema_fetch = i.feature_flags.runtime_schema_fetch
 
         sid = i.id
         rfs = o.rfs.create(i.name)

--- a/src/sorespo/layers/y_0.act
+++ b/src/sorespo/layers/y_0.act
@@ -3521,6 +3521,12 @@ identity urllc {
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
     }
 
     list backbone-link {
@@ -4052,6 +4058,86 @@ mut def from_json_netinfra__netinfra__router__approval_required(val: value) -> y
 mut def from_xml_netinfra__netinfra__router__approval_required(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_json_netinfra__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_netinfra__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool=None):
+        self._ns = 'http://example.com/netinfra'
+        self.runtime_schema_fetch = runtime_schema_fetch if runtime_schema_fetch is not None else False
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra__router__feature_flags:
+        if n is not None:
+            return netinfra__netinfra__router__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return netinfra__netinfra__router__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra__netinfra__router__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /netinfra/router/feature-flags')
+            res.append('{self_name} = netinfra__netinfra__router__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['netinfra:netinfra', 'router', 'feature-flags'])
+
+
+mut def from_xml_netinfra__netinfra__router__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_netinfra__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_netinfra__netinfra__router__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_netinfra__netinfra__router__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_netinfra__netinfra__router__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_netinfra__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: int
@@ -4060,8 +4146,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     asn: int
     mock: ?str
     approval_required: bool
+    feature_flags: netinfra__netinfra__router__feature_flags
 
-    mut def __init__(self, name: str, id: int, type: str, asn: int, role: ?str, mock: ?str, approval_required: ?bool=None):
+    mut def __init__(self, name: str, id: int, type: str, asn: int, role: ?str, mock: ?str, approval_required: ?bool=None, feature_flags: ?netinfra__netinfra__router__feature_flags=None):
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
@@ -4070,6 +4157,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         self.asn = asn
         self.mock = mock
         self.approval_required = approval_required if approval_required is not None else False
+        self.feature_flags = feature_flags if feature_flags is not None else netinfra__netinfra__router__feature_flags()
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -4094,11 +4182,14 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             children['approval-required'] = yang.gdata.Leaf('boolean', _approval_required)
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_str('type'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'))
+        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_str('type'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), feature_flags=netinfra__netinfra__router__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -4119,6 +4210,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             leaves.append('{self_name}.approval_required = {repr(_approval_required)}')
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /netinfra/router'] + leaves + res
@@ -4195,6 +4289,8 @@ mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdat
     yang.gdata.maybe_add(children, 'mock', from_xml_netinfra__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.from_xml_opt_bool(node, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_xml_netinfra__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_netinfra__netinfra__router__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_xml_netinfra__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
@@ -4230,6 +4326,8 @@ mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[
             raise ValueError("Invalid json path to non-inner node")
         if point == 'approval-required':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_netinfra__netinfra__router__feature_flags(jd, rest_path, op)
         return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
@@ -4274,6 +4372,8 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     yang.gdata.maybe_add(children, 'mock', from_json_netinfra__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.take_json_opt_bool(jd, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_json_netinfra__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_netinfra__netinfra__router__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/src/sorespo/layers/y_0_loose.act
+++ b/src/sorespo/layers/y_0_loose.act
@@ -3521,6 +3521,12 @@ identity urllc {
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
     }
 
     list backbone-link {
@@ -4052,6 +4058,86 @@ mut def from_json_netinfra__netinfra__router__approval_required(val: value) -> y
 mut def from_xml_netinfra__netinfra__router__approval_required(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_json_netinfra__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_netinfra__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: ?bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool):
+        self._ns = 'http://example.com/netinfra'
+        self.runtime_schema_fetch = runtime_schema_fetch
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra__router__feature_flags:
+        if n is not None:
+            return netinfra__netinfra__router__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return netinfra__netinfra__router__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra__netinfra__router__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /netinfra/router/feature-flags')
+            res.append('{self_name} = netinfra__netinfra__router__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['netinfra:netinfra', 'router', 'feature-flags'])
+
+
+mut def from_xml_netinfra__netinfra__router__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_netinfra__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_netinfra__netinfra__router__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_netinfra__netinfra__router__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_netinfra__netinfra__router__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_netinfra__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?int
@@ -4060,8 +4146,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     asn: ?int
     mock: ?str
     approval_required: ?bool
+    feature_flags: netinfra__netinfra__router__feature_flags
 
-    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, asn: ?int, mock: ?str, approval_required: ?bool):
+    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, asn: ?int, mock: ?str, approval_required: ?bool, feature_flags: ?netinfra__netinfra__router__feature_flags=None):
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
@@ -4070,6 +4157,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         self.asn = asn
         self.mock = mock
         self.approval_required = approval_required
+        self.feature_flags = feature_flags if feature_flags is not None else netinfra__netinfra__router__feature_flags()
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -4094,11 +4182,14 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             children['approval-required'] = yang.gdata.Leaf('boolean', _approval_required)
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'))
+        return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), feature_flags=netinfra__netinfra__router__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -4128,6 +4219,9 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             leaves.append('{self_name}.approval_required = {repr(_approval_required)}')
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /netinfra/router'] + leaves + res
@@ -4204,6 +4298,8 @@ mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdat
     yang.gdata.maybe_add(children, 'mock', from_xml_netinfra__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.from_xml_opt_bool(node, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_xml_netinfra__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_netinfra__netinfra__router__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_xml_netinfra__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
@@ -4239,6 +4335,8 @@ mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[
             raise ValueError("Invalid json path to non-inner node")
         if point == 'approval-required':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_netinfra__netinfra__router__feature_flags(jd, rest_path, op)
         return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
@@ -4283,6 +4381,8 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     yang.gdata.maybe_add(children, 'mock', from_json_netinfra__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.take_json_opt_bool(jd, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_json_netinfra__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_netinfra__netinfra__router__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/src/sorespo/layers/y_1.act
+++ b/src/sorespo/layers/y_1.act
@@ -123,6 +123,12 @@ def src_yang():
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
       container base-config {
         leaf asn {
           type inet:as-number;
@@ -706,6 +712,86 @@ mut def from_json_netinfra_inter__netinfra__router__approval_required(val: value
 mut def from_xml_netinfra_inter__netinfra__router__approval_required(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_json_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool=None):
+        self._ns = 'http://example.com/netinfra-inter'
+        self.runtime_schema_fetch = runtime_schema_fetch if runtime_schema_fetch is not None else False
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra__router__feature_flags:
+        if n is not None:
+            return netinfra_inter__netinfra__router__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return netinfra_inter__netinfra__router__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra_inter__netinfra__router__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /netinfra/router/feature-flags')
+            res.append('{self_name} = netinfra_inter__netinfra__router__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['netinfra-inter:netinfra', 'router', 'feature-flags'])
+
+
+mut def from_xml_netinfra_inter__netinfra__router__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_netinfra_inter__netinfra__router__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_netinfra_inter__netinfra__router__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_netinfra_inter__netinfra__router__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
@@ -1003,10 +1089,11 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     role: ?str
     mock: ?str
     approval_required: bool
+    feature_flags: netinfra_inter__netinfra__router__feature_flags
     base_config: netinfra_inter__netinfra__router__base_config
     l3vpn_vrf: netinfra_inter__netinfra__router__l3vpn_vrf
 
-    mut def __init__(self, name: str, id: int, base_config: netinfra_inter__netinfra__router__base_config, type: ?str, role: ?str, mock: ?str, approval_required: ?bool=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
+    mut def __init__(self, name: str, id: int, base_config: netinfra_inter__netinfra__router__base_config, type: ?str, role: ?str, mock: ?str, approval_required: ?bool=None, feature_flags: ?netinfra_inter__netinfra__router__feature_flags=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
         self._ns = 'http://example.com/netinfra-inter'
         self.name = name
         self.id = id
@@ -1014,6 +1101,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         self.role = role
         self.mock = mock
         self.approval_required = approval_required if approval_required is not None else False
+        self.feature_flags = feature_flags if feature_flags is not None else netinfra_inter__netinfra__router__feature_flags()
         self.base_config = base_config
         self.l3vpn_vrf = netinfra_inter__netinfra__router__l3vpn_vrf(elements=l3vpn_vrf)
 
@@ -1037,6 +1125,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             children['approval-required'] = yang.gdata.Leaf('boolean', _approval_required)
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         _base_config = self.base_config
         if _base_config is not None:
             children['base-config'] = _base_config.to_gdata()
@@ -1047,7 +1138,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), feature_flags=netinfra_inter__netinfra__router__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -1072,6 +1163,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             leaves.append('{self_name}.approval_required = {repr(_approval_required)}')
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         _base_config = self.base_config
         if _base_config is not None:
             res.extend(_base_config.prsrc('{self_name}.base_config', False).splitlines())
@@ -1156,6 +1250,8 @@ mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yan
     yang.gdata.maybe_add(children, 'mock', from_xml_netinfra_inter__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.from_xml_opt_bool(node, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_xml_netinfra_inter__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_netinfra_inter__netinfra__router__feature_flags, child_feature_flags)
     child_base_config = yang.gdata.from_xml_cnt(node, 'base-config')
     yang.gdata.maybe_add(children, 'base-config', from_xml_netinfra_inter__netinfra__router__base_config, child_base_config)
     child_l3vpn_vrf = yang.gdata.from_xml_opt_list(node, 'l3vpn-vrf')
@@ -1193,6 +1289,8 @@ mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path:
             raise ValueError("Invalid json path to non-inner node")
         if point == 'approval-required':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_netinfra_inter__netinfra__router__feature_flags(jd, rest_path, op)
         if point == 'base-config':
             children['base-config'] = from_json_path_netinfra_inter__netinfra__router__base_config(jd, rest_path, op)
         if point == 'l3vpn-vrf':
@@ -1239,6 +1337,8 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     yang.gdata.maybe_add(children, 'mock', from_json_netinfra_inter__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.take_json_opt_bool(jd, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_json_netinfra_inter__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_netinfra_inter__netinfra__router__feature_flags, child_feature_flags)
     child_base_config = yang.gdata.take_json_cnt(jd, 'base-config')
     yang.gdata.maybe_add(children, 'base-config', from_json_netinfra_inter__netinfra__router__base_config, child_base_config)
     child_l3vpn_vrf = yang.gdata.take_json_opt_list(jd, 'l3vpn-vrf')

--- a/src/sorespo/layers/y_1_loose.act
+++ b/src/sorespo/layers/y_1_loose.act
@@ -123,6 +123,12 @@ def src_yang():
         type boolean;
         default false;
       }
+      container feature-flags {
+        leaf runtime-schema-fetch {
+          type boolean;
+          default false;
+        }
+      }
       container base-config {
         leaf asn {
           type inet:as-number;
@@ -706,6 +712,86 @@ mut def from_json_netinfra_inter__netinfra__router__approval_required(val: value
 mut def from_xml_netinfra_inter__netinfra__router__approval_required(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_json_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: ?bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool):
+        self._ns = 'http://example.com/netinfra-inter'
+        self.runtime_schema_fetch = runtime_schema_fetch
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra_inter__netinfra__router__feature_flags:
+        if n is not None:
+            return netinfra_inter__netinfra__router__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return netinfra_inter__netinfra__router__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra_inter__netinfra__router__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /netinfra/router/feature-flags')
+            res.append('{self_name} = netinfra_inter__netinfra__router__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /netinfra/router/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['netinfra-inter:netinfra', 'router', 'feature-flags'])
+
+
+mut def from_xml_netinfra_inter__netinfra__router__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_netinfra_inter__netinfra__router__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_netinfra_inter__netinfra__router__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_netinfra_inter__netinfra__router__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_netinfra_inter__netinfra__router__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
@@ -1012,10 +1098,11 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     role: ?str
     mock: ?str
     approval_required: ?bool
+    feature_flags: netinfra_inter__netinfra__router__feature_flags
     base_config: netinfra_inter__netinfra__router__base_config
     l3vpn_vrf: netinfra_inter__netinfra__router__l3vpn_vrf
 
-    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, mock: ?str, approval_required: ?bool, base_config: ?netinfra_inter__netinfra__router__base_config=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
+    mut def __init__(self, name: str, id: ?int, type: ?str, role: ?str, mock: ?str, approval_required: ?bool, feature_flags: ?netinfra_inter__netinfra__router__feature_flags=None, base_config: ?netinfra_inter__netinfra__router__base_config=None, l3vpn_vrf: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]=[]):
         self._ns = 'http://example.com/netinfra-inter'
         self.name = name
         self.id = id
@@ -1023,6 +1110,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         self.role = role
         self.mock = mock
         self.approval_required = approval_required
+        self.feature_flags = feature_flags if feature_flags is not None else netinfra_inter__netinfra__router__feature_flags()
         self.base_config = base_config if base_config is not None else netinfra_inter__netinfra__router__base_config()
         self.l3vpn_vrf = netinfra_inter__netinfra__router__l3vpn_vrf(elements=l3vpn_vrf)
 
@@ -1046,6 +1134,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             children['approval-required'] = yang.gdata.Leaf('boolean', _approval_required)
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         _base_config = self.base_config
         if _base_config is not None:
             children['base-config'] = _base_config.to_gdata()
@@ -1056,7 +1147,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
+        return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), type=n.get_opt_str('type'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), approval_required=n.get_opt_bool('approval-required'), feature_flags=netinfra_inter__netinfra__router__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_cnt('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -1083,6 +1174,9 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         _approval_required = self.approval_required
         if _approval_required is not None:
             leaves.append('{self_name}.approval_required = {repr(_approval_required)}')
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         _base_config = self.base_config
         if _base_config is not None:
             res.extend(_base_config.prsrc('{self_name}.base_config', False).splitlines())
@@ -1167,6 +1261,8 @@ mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yan
     yang.gdata.maybe_add(children, 'mock', from_xml_netinfra_inter__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.from_xml_opt_bool(node, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_xml_netinfra_inter__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_netinfra_inter__netinfra__router__feature_flags, child_feature_flags)
     child_base_config = yang.gdata.from_xml_opt_cnt(node, 'base-config')
     yang.gdata.maybe_add(children, 'base-config', from_xml_netinfra_inter__netinfra__router__base_config, child_base_config)
     child_l3vpn_vrf = yang.gdata.from_xml_opt_list(node, 'l3vpn-vrf')
@@ -1204,6 +1300,8 @@ mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path:
             raise ValueError("Invalid json path to non-inner node")
         if point == 'approval-required':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_netinfra_inter__netinfra__router__feature_flags(jd, rest_path, op)
         if point == 'base-config':
             children['base-config'] = from_json_path_netinfra_inter__netinfra__router__base_config(jd, rest_path, op)
         if point == 'l3vpn-vrf':
@@ -1250,6 +1348,8 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     yang.gdata.maybe_add(children, 'mock', from_json_netinfra_inter__netinfra__router__mock, child_mock)
     child_approval_required = yang.gdata.take_json_opt_bool(jd, 'approval-required')
     yang.gdata.maybe_add(children, 'approval-required', from_json_netinfra_inter__netinfra__router__approval_required, child_approval_required)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_netinfra_inter__netinfra__router__feature_flags, child_feature_flags)
     child_base_config = yang.gdata.take_json_opt_cnt(jd, 'base-config')
     yang.gdata.maybe_add(children, 'base-config', from_json_netinfra_inter__netinfra__router__base_config, child_base_config)
     child_l3vpn_vrf = yang.gdata.take_json_opt_list(jd, 'l3vpn-vrf')

--- a/src/sorespo/layers/y_2.act
+++ b/src/sorespo/layers/y_2.act
@@ -348,6 +348,13 @@ def src_yang():
       }
     }
 
+    container feature-flags {
+      leaf runtime-schema-fetch {
+        type boolean;
+        default false;
+      }
+    }
+
     container state {
       config false;
     }
@@ -2149,6 +2156,86 @@ mut def from_json_orchestron_rfs__device__debug(jd: dict[str, ?value]) -> yang.g
     yang.gdata.maybe_add(children, 'connection', from_json_orchestron_rfs__device__debug__connection, child_connection)
     return yang.gdata.Container(children)
 
+mut def from_json_orchestron_rfs__device__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_orchestron_rfs__device__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class orchestron_rfs__device__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool=None):
+        self._ns = 'http://orchestron.org/yang/orchestron-rfs.yang'
+        self.runtime_schema_fetch = runtime_schema_fetch if runtime_schema_fetch is not None else False
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__feature_flags:
+        if n is not None:
+            return orchestron_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return orchestron_rfs__device__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return orchestron_rfs__device__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /device/feature-flags')
+            res.append('{self_name} = orchestron_rfs__device__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['orchestron-rfs:device', 'feature-flags'])
+
+
+mut def from_xml_orchestron_rfs__device__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_orchestron_rfs__device__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_orchestron_rfs__device__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_orchestron_rfs__device__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_orchestron_rfs__device__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_orchestron_rfs__device__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 class orchestron_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -2159,8 +2246,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     approval_required: bool
     mock: orchestron_rfs__device__mock
     debug: orchestron_rfs__device__debug
+    feature_flags: orchestron_rfs__device__feature_flags
 
-    mut def __init__(self, name: str, credentials: orchestron_rfs__device__credentials, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None):
+    mut def __init__(self, name: str, credentials: orchestron_rfs__device__credentials, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None, feature_flags: ?orchestron_rfs__device__feature_flags=None):
         self._ns = 'http://orchestron.org/yang/orchestron-rfs.yang'
         self.name = name
         self.description = description
@@ -2171,6 +2259,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         self.approval_required = approval_required if approval_required is not None else False
         self.mock = mock if mock is not None else orchestron_rfs__device__mock()
         self.debug = debug if debug is not None else orchestron_rfs__device__debug()
+        self.feature_flags = feature_flags if feature_flags is not None else orchestron_rfs__device__feature_flags()
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -2201,11 +2290,14 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _debug = self.debug
         if _debug is not None:
             children['debug'] = _debug.to_gdata()
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
-        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), approval_required=n.get_opt_bool('approval-required'), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')))
+        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), approval_required=n.get_opt_bool('approval-required'), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')), feature_flags=orchestron_rfs__device__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -2250,6 +2342,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _debug = self.debug
         if _debug is not None:
             res.extend(_debug.prsrc('{self_name}.debug', False).splitlines())
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /device'] + leaves + res
@@ -2330,6 +2425,8 @@ mut def from_xml_orchestron_rfs__device_element(node: xml.Node) -> yang.gdata.No
     yang.gdata.maybe_add(children, 'mock', from_xml_orchestron_rfs__device__mock, child_mock)
     child_debug = yang.gdata.from_xml_opt_cnt(node, 'debug')
     yang.gdata.maybe_add(children, 'debug', from_xml_orchestron_rfs__device__debug, child_debug)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_orchestron_rfs__device__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_xml_orchestron_rfs__device(nodes: list[xml.Node]) -> yang.gdata.List:
@@ -2369,6 +2466,8 @@ mut def from_json_path_orchestron_rfs__device_element(jd: value, path: list[str]
             children['mock'] = from_json_path_orchestron_rfs__device__mock(jd, rest_path, op)
         if point == 'debug':
             children['debug'] = from_json_path_orchestron_rfs__device__debug(jd, rest_path, op)
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_orchestron_rfs__device__feature_flags(jd, rest_path, op)
         return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
@@ -2417,6 +2516,8 @@ mut def from_json_orchestron_rfs__device_element(jd: dict[str, ?value]) -> yang.
     yang.gdata.maybe_add(children, 'mock', from_json_orchestron_rfs__device__mock, child_mock)
     child_debug = yang.gdata.take_json_opt_cnt(jd, 'debug')
     yang.gdata.maybe_add(children, 'debug', from_json_orchestron_rfs__device__debug, child_debug)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_orchestron_rfs__device__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/src/sorespo/layers/y_2_loose.act
+++ b/src/sorespo/layers/y_2_loose.act
@@ -348,6 +348,13 @@ def src_yang():
       }
     }
 
+    container feature-flags {
+      leaf runtime-schema-fetch {
+        type boolean;
+        default false;
+      }
+    }
+
     container state {
       config false;
     }
@@ -2158,6 +2165,86 @@ mut def from_json_orchestron_rfs__device__debug(jd: dict[str, ?value]) -> yang.g
     yang.gdata.maybe_add(children, 'connection', from_json_orchestron_rfs__device__debug__connection, child_connection)
     return yang.gdata.Container(children)
 
+mut def from_json_orchestron_rfs__device__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_orchestron_rfs__device__feature_flags__runtime_schema_fetch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+class orchestron_rfs__device__feature_flags(yang.adata.MNode):
+    runtime_schema_fetch: ?bool
+
+    mut def __init__(self, runtime_schema_fetch: ?bool):
+        self._ns = 'http://orchestron.org/yang/orchestron-rfs.yang'
+        self.runtime_schema_fetch = runtime_schema_fetch
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            children['runtime-schema-fetch'] = yang.gdata.Leaf('boolean', _runtime_schema_fetch)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__feature_flags:
+        if n is not None:
+            return orchestron_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool('runtime-schema-fetch'))
+        return orchestron_rfs__device__feature_flags()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return orchestron_rfs__device__feature_flags.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /device/feature-flags')
+            res.append('{self_name} = orchestron_rfs__device__feature_flags()')
+        leaves = []
+        _runtime_schema_fetch = self.runtime_schema_fetch
+        if _runtime_schema_fetch is not None:
+            leaves.append('{self_name}.runtime_schema_fetch = {repr(_runtime_schema_fetch)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /device/feature-flags'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['orchestron-rfs:device', 'feature-flags'])
+
+
+mut def from_xml_orchestron_rfs__device__feature_flags(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.from_xml_opt_bool(node, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_xml_orchestron_rfs__device__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_orchestron_rfs__device__feature_flags(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'runtime-schema-fetch':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_orchestron_rfs__device__feature_flags(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_orchestron_rfs__device__feature_flags(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_runtime_schema_fetch = yang.gdata.take_json_opt_bool(jd, 'runtime-schema-fetch')
+    yang.gdata.maybe_add(children, 'runtime-schema-fetch', from_json_orchestron_rfs__device__feature_flags__runtime_schema_fetch, child_runtime_schema_fetch)
+    return yang.gdata.Container(children)
+
 class orchestron_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -2168,8 +2255,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     approval_required: ?bool
     mock: orchestron_rfs__device__mock
     debug: orchestron_rfs__device__debug
+    feature_flags: orchestron_rfs__device__feature_flags
 
-    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], credentials: ?orchestron_rfs__device__credentials=None, initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None):
+    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], credentials: ?orchestron_rfs__device__credentials=None, initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None, feature_flags: ?orchestron_rfs__device__feature_flags=None):
         self._ns = 'http://orchestron.org/yang/orchestron-rfs.yang'
         self.name = name
         self.description = description
@@ -2180,6 +2268,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         self.approval_required = approval_required
         self.mock = mock if mock is not None else orchestron_rfs__device__mock()
         self.debug = debug if debug is not None else orchestron_rfs__device__debug()
+        self.feature_flags = feature_flags if feature_flags is not None else orchestron_rfs__device__feature_flags()
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -2210,11 +2299,14 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _debug = self.debug
         if _debug is not None:
             children['debug'] = _debug.to_gdata()
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            children['feature-flags'] = _feature_flags.to_gdata()
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
-        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_opt_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), approval_required=n.get_opt_bool('approval-required'), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')))
+        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_opt_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), approval_required=n.get_opt_bool('approval-required'), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')), feature_flags=orchestron_rfs__device__feature_flags.from_gdata(n.get_opt_cnt('feature-flags')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -2258,6 +2350,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _debug = self.debug
         if _debug is not None:
             res.extend(_debug.prsrc('{self_name}.debug', False).splitlines())
+        _feature_flags = self.feature_flags
+        if _feature_flags is not None:
+            res.extend(_feature_flags.prsrc('{self_name}.feature_flags', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /device'] + leaves + res
@@ -2338,6 +2433,8 @@ mut def from_xml_orchestron_rfs__device_element(node: xml.Node) -> yang.gdata.No
     yang.gdata.maybe_add(children, 'mock', from_xml_orchestron_rfs__device__mock, child_mock)
     child_debug = yang.gdata.from_xml_opt_cnt(node, 'debug')
     yang.gdata.maybe_add(children, 'debug', from_xml_orchestron_rfs__device__debug, child_debug)
+    child_feature_flags = yang.gdata.from_xml_opt_cnt(node, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_xml_orchestron_rfs__device__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_xml_orchestron_rfs__device(nodes: list[xml.Node]) -> yang.gdata.List:
@@ -2377,6 +2474,8 @@ mut def from_json_path_orchestron_rfs__device_element(jd: value, path: list[str]
             children['mock'] = from_json_path_orchestron_rfs__device__mock(jd, rest_path, op)
         if point == 'debug':
             children['debug'] = from_json_path_orchestron_rfs__device__debug(jd, rest_path, op)
+        if point == 'feature-flags':
+            children['feature-flags'] = from_json_path_orchestron_rfs__device__feature_flags(jd, rest_path, op)
         return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
@@ -2425,6 +2524,8 @@ mut def from_json_orchestron_rfs__device_element(jd: dict[str, ?value]) -> yang.
     yang.gdata.maybe_add(children, 'mock', from_json_orchestron_rfs__device__mock, child_mock)
     child_debug = yang.gdata.take_json_opt_cnt(jd, 'debug')
     yang.gdata.maybe_add(children, 'debug', from_json_orchestron_rfs__device__debug, child_debug)
+    child_feature_flags = yang.gdata.take_json_opt_cnt(jd, 'feature-flags')
+    yang.gdata.maybe_add(children, 'feature-flags', from_json_orchestron_rfs__device__feature_flags, child_feature_flags)
     return yang.gdata.Container(children)
 
 mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/test/quicklab-crpd/netinfra.xml
+++ b/test/quicklab-crpd/netinfra.xml
@@ -7,6 +7,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <router>
             <name>FRA-CORE-1</name>
@@ -14,6 +17,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <router>
             <name>STO-CORE-1</name>
@@ -21,6 +27,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <router>
             <name>LJU-CORE-1</name>
@@ -28,6 +37,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <backbone-link>
             <left-router>AMS-CORE-1</left-router>

--- a/test/quicklab/netinfra.xml
+++ b/test/quicklab/netinfra.xml
@@ -21,6 +21,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <router>
             <name>LJU-CORE-1</name>
@@ -28,6 +31,9 @@
             <type>JuniperCRPD_23_4R1_9</type>
             <role>edge</role>
             <asn>65001</asn>
+            <feature-flags>
+                <runtime-schema-fetch>true</runtime-schema-fetch>
+            </feature-flags>
         </router>
         <backbone-link>
             <left-router>AMS-CORE-1</left-router>

--- a/webui/src/components/DeviceConfig.svelte
+++ b/webui/src/components/DeviceConfig.svelte
@@ -12,7 +12,7 @@
 
   let device = null;
   let configViewMode = 'running'; // Start with running config by default
-  let configFormat = 'xml';  // XML is the only working format currently
+  let configFormat = 'xml';
   let configData = null;
   let loadingConfig = false;
   let loading = true;
@@ -114,30 +114,27 @@
         <div class="control-group">
           <span class="control-label">Format:</span>
           <div class="button-group">
-            <button 
-              class="control-btn disabled"
-              disabled
-              title="JSON format not yet available"
+            <button
+              class="control-btn {configFormat === 'json' ? 'active' : ''}"
+              on:click|preventDefault={() => changeFormat('json')}
             >
               JSON
             </button>
-            <button 
+            <button
               class="control-btn {configFormat === 'xml' ? 'active' : ''}"
               on:click|preventDefault={() => changeFormat('xml')}
             >
               XML
             </button>
-            <button 
-              class="control-btn disabled"
-              disabled
-              title="GData format not yet available"
+            <button
+              class="control-btn {configFormat === 'gdata' ? 'active' : ''}"
+              on:click|preventDefault={() => changeFormat('gdata')}
             >
               GData
             </button>
-            <button 
-              class="control-btn disabled"
-              disabled
-              title="AData format not yet available"
+            <button
+              class="control-btn {configFormat === 'adata' ? 'active' : ''}"
+              on:click|preventDefault={() => changeFormat('adata')}
             >
               AData
             </button>
@@ -267,17 +264,6 @@
   .control-btn.active {
     background: #3498db;
     color: white;
-  }
-
-  .control-btn.disabled,
-  .control-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-    color: #adb5bd;
-  }
-
-  .control-btn.disabled:hover {
-    background: transparent;
   }
 
   .config-content {

--- a/webui/src/components/DeviceDetail.svelte
+++ b/webui/src/components/DeviceDetail.svelte
@@ -221,6 +221,22 @@
             {/if}
           </dl>
         </div>
+
+        <div class="info-section">
+          <h3>Feature Flags</h3>
+          <dl>
+            {#if device.featureFlags && Object.keys(device.featureFlags).length > 0}
+              {#each Object.entries(device.featureFlags) as [flag, enabled]}
+                <dt>{flag.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</dt>
+                <dd class:feature-enabled={enabled} class:feature-disabled={!enabled}>
+                  {enabled ? 'Enabled' : 'Disabled'}
+                </dd>
+              {/each}
+            {:else}
+              <dd class="no-features">No feature flags configured</dd>
+            {/if}
+          </dl>
+        </div>
       </div>
 
       <div class="config-queue-section">
@@ -633,6 +649,21 @@
     max-height: 400px;
     overflow-y: auto;
   }
+
+  .feature-enabled {
+    color: #27ae60;
+    font-weight: 500;
+  }
+
+  .feature-disabled {
+    color: #95a5a6;
+  }
+
+  .no-features {
+    font-style: italic;
+    color: #95a5a6;
+  }
+
   .modules-section {
     margin-top: 2rem;
     padding: 1.5rem;

--- a/webui/src/components/QueueDashboard.svelte
+++ b/webui/src/components/QueueDashboard.svelte
@@ -17,7 +17,7 @@
   let itemDetail = null;
   let approvingItem = null;
   let refreshInterval = null;
-  let diffFormat = 'xml'; // 'xml', 'json', or 'adata'
+  let diffFormat = 'xml'; // 'xml', 'json', 'gdata', or 'adata'
 
   onMount(async () => {
     await loadAllQueues();

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -53,6 +53,7 @@ export async function fetchDevice(deviceId) {
       hasTargetConfig: info.has_target_config,
       queueLength: info.queue_length,
       pendingApprovals: info.pending_approvals,
+      featureFlags: info.feature_flags,
       modules: info.modules
     };
   } catch (err) {
@@ -132,7 +133,7 @@ export async function fetchAllDeviceQueues() {
         });
       });
     }
-    
+
     // Don't sort - maintain the order from the backend which is the actual queue order
     return allQueues;
   } catch (err) {


### PR DESCRIPTION
Exposes the new feature-flag [`/orfs:devices/feature-flags/runtime-schema-fetch`](https://github.com/orchestron-orchestrator/orchestron/pull/244) in CFS.

The flag is enabled for Juniper cRPD devices because the impact is low - schema download is a couple of seconds, and compilation (once) is about 15s. This is still acceptable and we get to exercise that code path on every run.

We also show the feature flag state in the Web UI and use the runtime fetched schemas for adata printing when enabled. 