### PR TITLE
Update develop-on-linux.md

### DIFF
--- a/docs/tutorials/develop-on-linux.md
+++ b/docs/tutorials/develop-on-linux.md
@@ -276,7 +276,7 @@ list vrf-interface {
     }
 +   leaf mtu {
 +       type uint16 {
-+           range "..9000";
++           range "1..9000";
 +       }
 +   }
 }


### PR DESCRIPTION
to fix "Unhandled exception in actor: sorespo_gen.main[-12]:
  ValueError: Invalid range in type "uint16": integer type constructor: string "" cannot be interpreted as an int in base 10
" error when running "make -C ../../ build"