### PR TITLE
Add some redundant imports to avoid a familiar compiler bug.

### DIFF
--- a/src/sorespo/cfs.act
+++ b/src/sorespo/cfs.act
@@ -1,5 +1,6 @@
 import yang.adata
 import orchestron.ttt
+import logging
 
 from sorespo.conf import IGBP_AUTHENTICATION_KEY
 import sorespo.layers.base_0 as base

--- a/src/sorespo/inter.act
+++ b/src/sorespo/inter.act
@@ -1,5 +1,6 @@
 import yang.adata
 import orchestron.ttt
+import logging
 
 import sorespo.layers.base_1 as base
 import sorespo.layers.y_1   # TODO: remove https://github.com/actonlang/acton/issues/2390

--- a/src/sorespo/rfs.act
+++ b/src/sorespo/rfs.act
@@ -2,6 +2,7 @@ import yang.adata
 import orchestron.device as odev
 import orchestron.ttt
 from orchestron import UnsupportedDevice
+import logging
 
 from rtrsecrets.junos import *
 

--- a/src/sorespo/tmf.act
+++ b/src/sorespo/tmf.act
@@ -1,4 +1,5 @@
 import sorespo.layers.base_0 as base
+import logging
 
 class Tmf640Store(base.Tmf640Store):
     def transform(self, i):


### PR DESCRIPTION
Will become critical in an upcoming compiler fix (of another issue). The actual import inconsistency will be dealt with later.