### PR TITLE
Update deps

### DIFF
--- a/spec/Build.act
+++ b/spec/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0xcb43a968b1316986
 dependencies = {
     "orchestron": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/067a4586042682b3e0cefc7c54c4f1a4eb2d35bb.zip",
-        hash="N-V-__8AAA7aHgCXaQhn6dTmracloZLGI61FIvR4gTXXFQBm"
+        url="https://github.com/stratoweave/stratoweave/archive/e25ef80c6dc9c99d20e87cb69bb5e5222ae97cc4.zip",
+        hash="N-V-__8AAGm3HgBOvFU5wnoGxY_bhld4g-tBEcVusAyF8lAI"
     )
 }
 zig_dependencies = {}

--- a/src/sorespo/devices/JuniperCRPD_24_4R1_9.act
+++ b/src/sorespo/devices/JuniperCRPD_24_4R1_9.act
@@ -74697,7 +74697,7 @@ NS_junos_common_types = 'http://yang.juniper.net/junos/common/types'
 NS_junos_conf_root = 'http://yang.juniper.net/junos/conf/root'
 
 
-_breaker = 1
+_breaker1 = None
 class junos_conf_root__configuration__system__services__netconf(yang.adata.MNode):
     rfc_compliant: ?bool
     yang_compliant: ?bool
@@ -74712,7 +74712,6 @@ class junos_conf_root__configuration__system__services__netconf(yang.adata.MNode
             return self.rfc_compliant
         if name == 'yang_compliant':
             return self.yang_compliant
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__system__services__netconf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'system', 'services', 'netconf'])
@@ -74728,7 +74727,7 @@ class junos_conf_root__configuration__system__services__netconf(yang.adata.MNode
         return junos_conf_root__configuration__system__services__netconf.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class junos_conf_root__configuration__system__services(yang.adata.MNode):
     netconf: junos_conf_root__configuration__system__services__netconf
 
@@ -74739,7 +74738,6 @@ class junos_conf_root__configuration__system__services(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'netconf':
             return self.netconf
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__system__services')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'system', 'services'])
@@ -74758,7 +74756,7 @@ class junos_conf_root__configuration__system__services(yang.adata.MNode):
         raise Exception('Unreachable in junos_conf_root__configuration__system__services.copy()')
 
 
-_breaker = 1
+_breaker3 = None
 class junos_conf_root__configuration__system(yang.adata.MNode):
     host_name: ?str
     services: ?junos_conf_root__configuration__system__services
@@ -74781,7 +74779,6 @@ class junos_conf_root__configuration__system(yang.adata.MNode):
             return self.host_name
         if name == 'services':
             return self.services
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__system')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'system'])
@@ -74797,7 +74794,7 @@ class junos_conf_root__configuration__system(yang.adata.MNode):
         return junos_conf_root__configuration__system.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry(yang.adata.MNode):
     name: str
 
@@ -74808,7 +74805,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet_
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__inet__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'inet', 'address'])
@@ -74821,7 +74817,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet_
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker5 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry]
     mut def __init__(self, elements=[]):
@@ -74862,7 +74858,7 @@ extension junos_conf_root__configuration__interfaces__interface__unit__family__i
     def __iter__(self) -> Iterator[junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker6 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__inet__address
 
@@ -74873,7 +74869,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet(
     def _get_attr(self, name: str) -> ?value:
         if name == 'address':
             return iter(self.address)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__inet')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'inet'])
@@ -74892,7 +74887,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet(
         raise Exception('Unreachable in junos_conf_root__configuration__interfaces__interface__unit__family__inet.copy()')
 
 
-_breaker = 1
+_breaker7 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry(yang.adata.MNode):
     name: str
 
@@ -74903,7 +74898,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'inet6', 'address'])
@@ -74916,7 +74910,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker8 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry]
     mut def __init__(self, elements=[]):
@@ -74957,7 +74951,7 @@ extension junos_conf_root__configuration__interfaces__interface__unit__family__i
     def __iter__(self) -> Iterator[junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker9 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address
 
@@ -74968,7 +74962,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
     def _get_attr(self, name: str) -> ?value:
         if name == 'address':
             return iter(self.address)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__inet6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'inet6'])
@@ -74987,7 +74980,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
         raise Exception('Unreachable in junos_conf_root__configuration__interfaces__interface__unit__family__inet6.copy()')
 
 
-_breaker = 1
+_breaker10 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry(yang.adata.MNode):
     name: str
 
@@ -74998,7 +74991,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso__
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__iso__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'iso', 'address'])
@@ -75011,7 +75003,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso__
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry]
     mut def __init__(self, elements=[]):
@@ -75052,7 +75044,7 @@ extension junos_conf_root__configuration__interfaces__interface__unit__family__i
     def __iter__(self) -> Iterator[junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__iso__address
 
@@ -75063,7 +75055,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso(y
     def _get_attr(self, name: str) -> ?value:
         if name == 'address':
             return iter(self.address)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family__iso')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family', 'iso'])
@@ -75082,7 +75073,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso(y
         raise Exception('Unreachable in junos_conf_root__configuration__interfaces__interface__unit__family__iso.copy()')
 
 
-_breaker = 1
+_breaker13 = None
 class junos_conf_root__configuration__interfaces__interface__unit__family(yang.adata.MNode):
     inet: ?junos_conf_root__configuration__interfaces__interface__unit__family__inet
     inet6: ?junos_conf_root__configuration__interfaces__interface__unit__family__inet6
@@ -75125,7 +75116,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family(yang.a
             return self.inet6
         if name == 'iso':
             return self.iso
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit__family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit', 'family'])
@@ -75141,7 +75131,7 @@ class junos_conf_root__configuration__interfaces__interface__unit__family(yang.a
         return junos_conf_root__configuration__interfaces__interface__unit__family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.adata.MNode):
     name: str
     alias: ?str
@@ -75180,7 +75170,6 @@ class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.ada
             return self.mtu
         if name == 'mac':
             return self.mac
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface__unit')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface', 'unit'])
@@ -75193,7 +75182,7 @@ class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.ada
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__interfaces__interface__unit_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker15 = None
 class junos_conf_root__configuration__interfaces__interface__unit(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit_entry]
     mut def __init__(self, elements=[]):
@@ -75246,7 +75235,7 @@ extension junos_conf_root__configuration__interfaces__interface__unit(Iterable[j
     def __iter__(self) -> Iterator[junos_conf_root__configuration__interfaces__interface__unit_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker16 = None
 class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -75277,7 +75266,6 @@ class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNo
             return self.native_vlan_id
         if name == 'unit':
             return iter(self.unit)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces', 'interface'])
@@ -75290,7 +75278,7 @@ class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__interfaces__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker17 = None
 class junos_conf_root__configuration__interfaces__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -75339,7 +75327,7 @@ extension junos_conf_root__configuration__interfaces__interface(Iterable[junos_c
     def __iter__(self) -> Iterator[junos_conf_root__configuration__interfaces__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker18 = None
 class junos_conf_root__configuration__interfaces(yang.adata.MNode):
     interface: junos_conf_root__configuration__interfaces__interface
 
@@ -75350,7 +75338,6 @@ class junos_conf_root__configuration__interfaces(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__interfaces')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'interfaces'])
@@ -75366,7 +75353,7 @@ class junos_conf_root__configuration__interfaces(yang.adata.MNode):
         return junos_conf_root__configuration__interfaces.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(yang.adata.MNode):
     ttl: ?value
     no_nexthop_change: ?bool
@@ -75381,7 +75368,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return self.ttl
         if name == 'no_nexthop_change':
             return self.no_nexthop_change
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'protocols', 'bgp', 'group', 'neighbor', 'multihop'])
@@ -75400,7 +75386,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
         raise Exception('Unreachable in junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop.copy()')
 
 
-_breaker = 1
+_breaker20 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -75447,7 +75433,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return self.peer_as
         if name == 'as_override':
             return self.as_override
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'protocols', 'bgp', 'group', 'neighbor'])
@@ -75460,7 +75445,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -75511,7 +75496,7 @@ extension junos_conf_root__configuration__routing_instances__instance__protocols
     def __iter__(self) -> Iterator[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry(yang.adata.MNode):
     name: str
     passive: ?bool
@@ -75538,7 +75523,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return self.export
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'protocols', 'bgp', 'group'])
@@ -75551,7 +75535,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker23 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -75594,7 +75578,7 @@ extension junos_conf_root__configuration__routing_instances__instance__protocols
     def __iter__(self) -> Iterator[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker24 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp(yang.adata.MNode):
     group: junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group
 
@@ -75605,7 +75589,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__protocols__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'protocols', 'bgp'])
@@ -75621,7 +75604,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker25 = None
 class junos_conf_root__configuration__routing_instances__instance__protocols(yang.adata.MNode):
     bgp: junos_conf_root__configuration__routing_instances__instance__protocols__bgp
 
@@ -75632,7 +75615,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols(yan
     def _get_attr(self, name: str) -> ?value:
         if name == 'bgp':
             return self.bgp
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'protocols'])
@@ -75648,7 +75630,7 @@ class junos_conf_root__configuration__routing_instances__instance__protocols(yan
         return junos_conf_root__configuration__routing_instances__instance__protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker26 = None
 class junos_conf_root__configuration__routing_instances__instance__interface_entry(yang.adata.MNode):
     name: str
     any: ?bool
@@ -75675,7 +75657,6 @@ class junos_conf_root__configuration__routing_instances__instance__interface_ent
             return self.multicast
         if name == 'primary':
             return self.primary
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'interface'])
@@ -75688,7 +75669,7 @@ class junos_conf_root__configuration__routing_instances__instance__interface_ent
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__routing_instances__instance__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class junos_conf_root__configuration__routing_instances__instance__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__interface_entry]
     mut def __init__(self, elements=[]):
@@ -75737,7 +75718,7 @@ extension junos_conf_root__configuration__routing_instances__instance__interface
     def __iter__(self) -> Iterator[junos_conf_root__configuration__routing_instances__instance__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class junos_conf_root__configuration__routing_instances__instance__route_distinguisher(yang.adata.MNode):
     rd_type: ?str
 
@@ -75748,7 +75729,6 @@ class junos_conf_root__configuration__routing_instances__instance__route_disting
     def _get_attr(self, name: str) -> ?value:
         if name == 'rd_type':
             return self.rd_type
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__route_distinguisher')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'route-distinguisher'])
@@ -75764,7 +75744,7 @@ class junos_conf_root__configuration__routing_instances__instance__route_disting
         return junos_conf_root__configuration__routing_instances__instance__route_distinguisher.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker29 = None
 class junos_conf_root__configuration__routing_instances__instance__vrf_target(yang.adata.MNode):
     community: ?str
     import_: ?str
@@ -75787,7 +75767,6 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_target(ya
             return self.export
         if name == 'auto':
             return self.auto
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance__vrf_target')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance', 'vrf-target'])
@@ -75803,7 +75782,7 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_target(ya
         return junos_conf_root__configuration__routing_instances__instance__vrf_target.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker30 = None
 class junos_conf_root__configuration__routing_instances__instance__vrf_table_label(yang.adata.MNode):
 
     mut def __init__(self):
@@ -75827,7 +75806,7 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_table_lab
         raise Exception('Unreachable in junos_conf_root__configuration__routing_instances__instance__vrf_table_label.copy()')
 
 
-_breaker = 1
+_breaker31 = None
 class junos_conf_root__configuration__routing_instances__instance_entry(yang.adata.MNode):
     name: str
     instance_type: ?str
@@ -75870,7 +75849,6 @@ class junos_conf_root__configuration__routing_instances__instance_entry(yang.ada
             return self.vrf_target
         if name == 'vrf_table_label':
             return self.vrf_table_label
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances__instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances', 'instance'])
@@ -75883,7 +75861,7 @@ class junos_conf_root__configuration__routing_instances__instance_entry(yang.ada
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__routing_instances__instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker32 = None
 class junos_conf_root__configuration__routing_instances__instance(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance_entry]
     mut def __init__(self, elements=[]):
@@ -75926,7 +75904,7 @@ extension junos_conf_root__configuration__routing_instances__instance(Iterable[j
     def __iter__(self) -> Iterator[junos_conf_root__configuration__routing_instances__instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker33 = None
 class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
     instance: junos_conf_root__configuration__routing_instances__instance
 
@@ -75937,7 +75915,6 @@ class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'instance':
             return iter(self.instance)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_instances')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-instances'])
@@ -75953,7 +75930,7 @@ class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
         return junos_conf_root__configuration__routing_instances.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker34 = None
 class junos_conf_root__configuration__routing_options__autonomous_system(yang.adata.MNode):
     as_number: ?str
 
@@ -75964,7 +75941,6 @@ class junos_conf_root__configuration__routing_options__autonomous_system(yang.ad
     def _get_attr(self, name: str) -> ?value:
         if name == 'as_number':
             return self.as_number
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_options__autonomous_system')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-options', 'autonomous-system'])
@@ -75980,7 +75956,7 @@ class junos_conf_root__configuration__routing_options__autonomous_system(yang.ad
         return junos_conf_root__configuration__routing_options__autonomous_system.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker35 = None
 class junos_conf_root__configuration__routing_options(yang.adata.MNode):
     autonomous_system: junos_conf_root__configuration__routing_options__autonomous_system
 
@@ -75991,7 +75967,6 @@ class junos_conf_root__configuration__routing_options(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'autonomous_system':
             return self.autonomous_system
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__routing_options')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'routing-options'])
@@ -76007,7 +75982,7 @@ class junos_conf_root__configuration__routing_options(yang.adata.MNode):
         return junos_conf_root__configuration__routing_options.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker36 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(yang.adata.MNode):
 
     mut def __init__(self):
@@ -76031,7 +76006,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast.copy()')
 
 
-_breaker = 1
+_breaker37 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(yang.adata.MNode):
     unicast: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast
 
@@ -76050,7 +76025,6 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
     def _get_attr(self, name: str) -> ?value:
         if name == 'unicast':
             return self.unicast
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group', 'family', 'inet-vpn'])
@@ -76066,7 +76040,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker38 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(yang.adata.MNode):
 
     mut def __init__(self):
@@ -76090,7 +76064,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast.copy()')
 
 
-_breaker = 1
+_breaker39 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(yang.adata.MNode):
     unicast: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast
 
@@ -76109,7 +76083,6 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(y
     def _get_attr(self, name: str) -> ?value:
         if name == 'unicast':
             return self.unicast
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group', 'family', 'inet6-vpn'])
@@ -76125,7 +76098,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(y
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker40 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling(yang.adata.MNode):
 
     mut def __init__(self):
@@ -76149,7 +76122,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signa
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling.copy()')
 
 
-_breaker = 1
+_breaker41 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.adata.MNode):
     signaling: ?junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling
 
@@ -76168,7 +76141,6 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.a
     def _get_attr(self, name: str) -> ?value:
         if name == 'signaling':
             return self.signaling
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group__family__evpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group', 'family', 'evpn'])
@@ -76184,7 +76156,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.a
         return junos_conf_root__configuration__protocols__bgp__group__family__evpn.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker42 = None
 class junos_conf_root__configuration__protocols__bgp__group__family__route_target(yang.adata.MNode):
 
     mut def __init__(self):
@@ -76208,7 +76180,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__route_targe
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__bgp__group__family__route_target.copy()')
 
 
-_breaker = 1
+_breaker43 = None
 class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.MNode):
     inet_vpn: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn
     inet6_vpn: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn
@@ -76239,7 +76211,6 @@ class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.M
             return self.evpn
         if name == 'route_target':
             return self.route_target
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group__family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group', 'family'])
@@ -76255,7 +76226,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.M
         return junos_conf_root__configuration__protocols__bgp__group__family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker44 = None
 class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -76274,7 +76245,6 @@ class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang
             return self.description
         if name == 'passive':
             return self.passive
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group', 'neighbor'])
@@ -76287,7 +76257,7 @@ class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__bgp__group__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker45 = None
 class junos_conf_root__configuration__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -76332,7 +76302,7 @@ extension junos_conf_root__configuration__protocols__bgp__group__neighbor(Iterab
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker46 = None
 class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNode):
     name: str
     type: ?str
@@ -76391,7 +76361,6 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
             return self.tcp_mss
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp', 'group'])
@@ -76404,7 +76373,7 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__bgp__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker47 = None
 class junos_conf_root__configuration__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -76463,7 +76432,7 @@ extension junos_conf_root__configuration__protocols__bgp__group(Iterable[junos_c
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__bgp__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker48 = None
 class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
     group: junos_conf_root__configuration__protocols__bgp__group
     log_updown: ?bool
@@ -76478,7 +76447,6 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
             return iter(self.group)
         if name == 'log_updown':
             return self.log_updown
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'bgp'])
@@ -76494,7 +76462,7 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
         return junos_conf_root__configuration__protocols__bgp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker49 = None
 class junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(yang.adata.MNode):
     disable: ?bool
     hold_time: ?value
@@ -76509,7 +76477,6 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
             return self.disable
         if name == 'hold_time':
             return self.hold_time
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'interface', 'ldp-synchronization'])
@@ -76528,7 +76495,7 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.copy()')
 
 
-_breaker = 1
+_breaker50 = None
 class junos_conf_root__configuration__protocols__isis__interface__level_entry(yang.adata.MNode):
     name: value
     disable: ?bool
@@ -76547,7 +76514,6 @@ class junos_conf_root__configuration__protocols__isis__interface__level_entry(ya
             return self.disable
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__interface__level')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'interface', 'level'])
@@ -76560,7 +76526,7 @@ class junos_conf_root__configuration__protocols__isis__interface__level_entry(ya
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__isis__interface__level_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker51 = None
 class junos_conf_root__configuration__protocols__isis__interface__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]
     mut def __init__(self, elements=[]):
@@ -76612,7 +76578,7 @@ extension junos_conf_root__configuration__protocols__isis__interface__level(Iter
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__isis__interface__level_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker52 = None
 class junos_conf_root__configuration__protocols__isis__interface__passive(yang.adata.MNode):
     remote_node_iso: ?str
     remote_node_id: ?str
@@ -76627,7 +76593,6 @@ class junos_conf_root__configuration__protocols__isis__interface__passive(yang.a
             return self.remote_node_iso
         if name == 'remote_node_id':
             return self.remote_node_id
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__interface__passive')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'interface', 'passive'])
@@ -76646,7 +76611,7 @@ class junos_conf_root__configuration__protocols__isis__interface__passive(yang.a
         raise Exception('Unreachable in junos_conf_root__configuration__protocols__isis__interface__passive.copy()')
 
 
-_breaker = 1
+_breaker53 = None
 class junos_conf_root__configuration__protocols__isis__interface__family_entry(yang.adata.MNode):
     name: str
 
@@ -76657,7 +76622,6 @@ class junos_conf_root__configuration__protocols__isis__interface__family_entry(y
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__interface__family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'interface', 'family'])
@@ -76670,7 +76634,7 @@ class junos_conf_root__configuration__protocols__isis__interface__family_entry(y
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__isis__interface__family_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker54 = None
 class junos_conf_root__configuration__protocols__isis__interface__family(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]
     mut def __init__(self, elements=[]):
@@ -76711,7 +76675,7 @@ extension junos_conf_root__configuration__protocols__isis__interface__family(Ite
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__isis__interface__family_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker55 = None
 class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adata.MNode):
     name: str
     ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization
@@ -76770,7 +76734,6 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
             return self.passive
         if name == 'family':
             return iter(self.family)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'interface'])
@@ -76783,7 +76746,7 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__isis__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker56 = None
 class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface_entry]
     mut def __init__(self, elements=[]):
@@ -76828,7 +76791,7 @@ extension junos_conf_root__configuration__protocols__isis__interface(Iterable[ju
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__isis__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker57 = None
 class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MNode):
     name: value
     disable: ?bool
@@ -76867,7 +76830,6 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
             return self.no_psnp_authentication
         if name == 'wide_metrics_only':
             return self.wide_metrics_only
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis__level')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis', 'level'])
@@ -76880,7 +76842,7 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__isis__level_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker58 = None
 class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__level_entry]
     mut def __init__(self, elements=[]):
@@ -76942,7 +76904,7 @@ extension junos_conf_root__configuration__protocols__isis__level(Iterable[junos_
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__isis__level_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker59 = None
 class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
     interface: junos_conf_root__configuration__protocols__isis__interface
     level: junos_conf_root__configuration__protocols__isis__level
@@ -76961,7 +76923,6 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
             return iter(self.level)
         if name == 'lsp_lifetime':
             return self.lsp_lifetime
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__isis')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'isis'])
@@ -76977,7 +76938,7 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
         return junos_conf_root__configuration__protocols__isis.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker60 = None
 class junos_conf_root__configuration__protocols__ldp__transport_address(yang.adata.MNode):
     router_id: ?bool
     interface: ?bool
@@ -76996,7 +76957,6 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
             return self.interface
         if name == 'address':
             return self.address
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__ldp__transport_address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'ldp', 'transport-address'])
@@ -77012,7 +76972,7 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
         return junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker61 = None
 class junos_conf_root__configuration__protocols__ldp__interface__transport_address(yang.adata.MNode):
     router_id: ?bool
     interface: ?bool
@@ -77031,7 +76991,6 @@ class junos_conf_root__configuration__protocols__ldp__interface__transport_addre
             return self.interface
         if name == 'address':
             return self.address
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__ldp__interface__transport_address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'ldp', 'interface', 'transport-address'])
@@ -77047,7 +77006,7 @@ class junos_conf_root__configuration__protocols__ldp__interface__transport_addre
         return junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker62 = None
 class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata.MNode):
     name: str
     disable: ?bool
@@ -77074,7 +77033,6 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
             return self.hold_time
         if name == 'transport_address':
             return self.transport_address
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__ldp__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'ldp', 'interface'])
@@ -77087,7 +77045,7 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__ldp__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker63 = None
 class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__ldp__interface_entry]
     mut def __init__(self, elements=[]):
@@ -77134,7 +77092,7 @@ extension junos_conf_root__configuration__protocols__ldp__interface(Iterable[jun
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__ldp__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker64 = None
 class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
     preference: ?value
     transport_address: junos_conf_root__configuration__protocols__ldp__transport_address
@@ -77153,7 +77111,6 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
             return self.transport_address
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__ldp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'ldp'])
@@ -77169,7 +77126,7 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
         return junos_conf_root__configuration__protocols__ldp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker65 = None
 class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adata.MNode):
     name: str
     disable: ?bool
@@ -77184,7 +77141,6 @@ class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adat
             return self.name
         if name == 'disable':
             return self.disable
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__mpls__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'mpls', 'interface'])
@@ -77197,7 +77153,7 @@ class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adat
         """Create a deep copy of this adata object"""
         return junos_conf_root__configuration__protocols__mpls__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker66 = None
 class junos_conf_root__configuration__protocols__mpls__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__mpls__interface_entry]
     mut def __init__(self, elements=[]):
@@ -77240,7 +77196,7 @@ extension junos_conf_root__configuration__protocols__mpls__interface(Iterable[ju
     def __iter__(self) -> Iterator[junos_conf_root__configuration__protocols__mpls__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker67 = None
 class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
     no_propagate_ttl: ?bool
     interface: junos_conf_root__configuration__protocols__mpls__interface
@@ -77255,7 +77211,6 @@ class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
             return self.no_propagate_ttl
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols__mpls')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols', 'mpls'])
@@ -77271,7 +77226,7 @@ class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
         return junos_conf_root__configuration__protocols__mpls.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker68 = None
 class junos_conf_root__configuration__protocols(yang.adata.MNode):
     bgp: junos_conf_root__configuration__protocols__bgp
     isis: junos_conf_root__configuration__protocols__isis
@@ -77294,7 +77249,6 @@ class junos_conf_root__configuration__protocols(yang.adata.MNode):
             return self.ldp
         if name == 'mpls':
             return self.mpls
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration__protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration', 'protocols'])
@@ -77310,7 +77264,7 @@ class junos_conf_root__configuration__protocols(yang.adata.MNode):
         return junos_conf_root__configuration__protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker69 = None
 class junos_conf_root__configuration(yang.adata.MNode):
     rcsid: ?str
     version: ?str
@@ -77345,7 +77299,6 @@ class junos_conf_root__configuration(yang.adata.MNode):
             return self.routing_options
         if name == 'protocols':
             return self.protocols
-        raise ValueError('Attribute {name} not found in junos_conf_root__configuration')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['junos-conf-root:configuration'])
@@ -77361,7 +77314,7 @@ class junos_conf_root__configuration(yang.adata.MNode):
         return junos_conf_root__configuration.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker70 = None
 class root(yang.adata.MNode):
     configuration: junos_conf_root__configuration
 
@@ -77372,7 +77325,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'configuration':
             return self.configuration
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/sorespo/devices/NokiaSRLinux_25_3_2.act
+++ b/src/sorespo/devices/NokiaSRLinux_25_3_2.act
@@ -33891,7 +33891,7 @@ NS_srl_nokia_tunnel = 'urn:nokia.com:srlinux:vxlan:tunnel'
 NS_srl_nokia_tunnel_interfaces = 'urn:nokia.com:srlinux:vxlan:tunnel-interfaces'
 
 
-_breaker = 1
+_breaker1 = None
 class srl_nokia_system__system__name(yang.adata.MNode):
     host_name: ?str
 
@@ -33902,7 +33902,6 @@ class srl_nokia_system__system__name(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'host_name':
             return self.host_name
-        raise ValueError('Attribute {name} not found in srl_nokia_system__system__name')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-system:system', 'srl_nokia-system-name:name'])
@@ -33918,7 +33917,7 @@ class srl_nokia_system__system__name(yang.adata.MNode):
         return srl_nokia_system__system__name.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class srl_nokia_system__system(yang.adata.MNode):
     name: srl_nokia_system__system__name
 
@@ -33929,7 +33928,6 @@ class srl_nokia_system__system(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in srl_nokia_system__system')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-system:system'])
@@ -33945,7 +33943,7 @@ class srl_nokia_system__system(yang.adata.MNode):
         return srl_nokia_system__system.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class srl_nokia_interfaces__interface__statistics(yang.adata.MNode):
     in_unicast_packets: ?u64
 
@@ -33956,7 +33954,6 @@ class srl_nokia_interfaces__interface__statistics(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'in_unicast_packets':
             return self.in_unicast_packets
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__statistics')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'statistics'])
@@ -33972,7 +33969,7 @@ class srl_nokia_interfaces__interface__statistics(yang.adata.MNode):
         return srl_nokia_interfaces__interface__statistics.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class srl_nokia_interfaces__interface__subinterface__ipv4__address_entry(yang.adata.MNode):
     ip_prefix: str
 
@@ -33983,7 +33980,6 @@ class srl_nokia_interfaces__interface__subinterface__ipv4__address_entry(yang.ad
     def _get_attr(self, name: str) -> ?value:
         if name == 'ip_prefix':
             return self.ip_prefix
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__ipv4__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'ipv4', 'address'])
@@ -33996,7 +33992,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv4__address_entry(yang.ad
         """Create a deep copy of this adata object"""
         return srl_nokia_interfaces__interface__subinterface__ipv4__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker5 = None
 class srl_nokia_interfaces__interface__subinterface__ipv4__address(yang.adata.MNode):
     elements: list[srl_nokia_interfaces__interface__subinterface__ipv4__address_entry]
     mut def __init__(self, elements=[]):
@@ -34037,7 +34033,7 @@ extension srl_nokia_interfaces__interface__subinterface__ipv4__address(Iterable[
     def __iter__(self) -> Iterator[srl_nokia_interfaces__interface__subinterface__ipv4__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker6 = None
 class srl_nokia_interfaces__interface__subinterface__ipv4(yang.adata.MNode):
     admin_state: ?str
     address: srl_nokia_interfaces__interface__subinterface__ipv4__address
@@ -34052,7 +34048,6 @@ class srl_nokia_interfaces__interface__subinterface__ipv4(yang.adata.MNode):
             return self.admin_state
         if name == 'address':
             return iter(self.address)
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__ipv4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'ipv4'])
@@ -34068,7 +34063,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv4(yang.adata.MNode):
         return srl_nokia_interfaces__interface__subinterface__ipv4.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker7 = None
 class srl_nokia_interfaces__interface__subinterface__ipv6(yang.adata.MNode):
     admin_state: ?str
 
@@ -34079,7 +34074,6 @@ class srl_nokia_interfaces__interface__subinterface__ipv6(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'admin_state':
             return self.admin_state
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__ipv6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'ipv6'])
@@ -34095,7 +34089,7 @@ class srl_nokia_interfaces__interface__subinterface__ipv6(yang.adata.MNode):
         return srl_nokia_interfaces__interface__subinterface__ipv6.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged(yang.adata.MNode):
     vlan_id: ?value
 
@@ -34106,7 +34100,6 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged(
     def _get_attr(self, name: str) -> ?value:
         if name == 'vlan_id':
             return self.vlan_id
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'srl_nokia-interfaces-vlans:vlan', 'encap', 'single-tagged'])
@@ -34125,7 +34118,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged(
         raise Exception('Unreachable in srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged.copy()')
 
 
-_breaker = 1
+_breaker9 = None
 class srl_nokia_interfaces__interface__subinterface__vlan__encap(yang.adata.MNode):
     single_tagged: ?srl_nokia_interfaces__interface__subinterface__vlan__encap__single_tagged
 
@@ -34146,7 +34139,6 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap(yang.adata.MNod
     def _get_attr(self, name: str) -> ?value:
         if name == 'single_tagged':
             return self.single_tagged
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__vlan__encap')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'srl_nokia-interfaces-vlans:vlan', 'encap'])
@@ -34162,7 +34154,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan__encap(yang.adata.MNod
         return srl_nokia_interfaces__interface__subinterface__vlan__encap.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker10 = None
 class srl_nokia_interfaces__interface__subinterface__vlan(yang.adata.MNode):
     encap: srl_nokia_interfaces__interface__subinterface__vlan__encap
 
@@ -34173,7 +34165,6 @@ class srl_nokia_interfaces__interface__subinterface__vlan(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'encap':
             return self.encap
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface__vlan')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface', 'srl_nokia-interfaces-vlans:vlan'])
@@ -34189,7 +34180,7 @@ class srl_nokia_interfaces__interface__subinterface__vlan(yang.adata.MNode):
         return srl_nokia_interfaces__interface__subinterface__vlan.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker11 = None
 class srl_nokia_interfaces__interface__subinterface_entry(yang.adata.MNode):
     index: u64
     description: ?str
@@ -34220,7 +34211,6 @@ class srl_nokia_interfaces__interface__subinterface_entry(yang.adata.MNode):
             return self.ipv6
         if name == 'vlan':
             return self.vlan
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface__subinterface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface', 'subinterface'])
@@ -34233,7 +34223,7 @@ class srl_nokia_interfaces__interface__subinterface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return srl_nokia_interfaces__interface__subinterface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker12 = None
 class srl_nokia_interfaces__interface__subinterface(yang.adata.MNode):
     elements: list[srl_nokia_interfaces__interface__subinterface_entry]
     mut def __init__(self, elements=[]):
@@ -34278,7 +34268,7 @@ extension srl_nokia_interfaces__interface__subinterface(Iterable[srl_nokia_inter
     def __iter__(self) -> Iterator[srl_nokia_interfaces__interface__subinterface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker13 = None
 class srl_nokia_interfaces__interface_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -34309,7 +34299,6 @@ class srl_nokia_interfaces__interface_entry(yang.adata.MNode):
             return iter(self.subinterface)
         if name == 'vlan_tagging':
             return self.vlan_tagging
-        raise ValueError('Attribute {name} not found in srl_nokia_interfaces__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-interfaces:interface'])
@@ -34322,7 +34311,7 @@ class srl_nokia_interfaces__interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return srl_nokia_interfaces__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker14 = None
 class srl_nokia_interfaces__interface(yang.adata.MNode):
     elements: list[srl_nokia_interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -34369,7 +34358,7 @@ extension srl_nokia_interfaces__interface(Iterable[srl_nokia_interfaces__interfa
     def __iter__(self) -> Iterator[srl_nokia_interfaces__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker15 = None
 class srl_nokia_network_instance__network_instance__interface_entry(yang.adata.MNode):
     name: str
 
@@ -34380,7 +34369,6 @@ class srl_nokia_network_instance__network_instance__interface_entry(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'interface'])
@@ -34393,7 +34381,7 @@ class srl_nokia_network_instance__network_instance__interface_entry(yang.adata.M
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class srl_nokia_network_instance__network_instance__interface(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__interface_entry]
     mut def __init__(self, elements=[]):
@@ -34434,7 +34422,7 @@ extension srl_nokia_network_instance__network_instance__interface(Iterable[srl_n
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class srl_nokia_network_instance__network_instance__vxlan_interface_entry(yang.adata.MNode):
     name: str
 
@@ -34445,7 +34433,6 @@ class srl_nokia_network_instance__network_instance__vxlan_interface_entry(yang.a
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__vxlan_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'vxlan-interface'])
@@ -34458,7 +34445,7 @@ class srl_nokia_network_instance__network_instance__vxlan_interface_entry(yang.a
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__vxlan_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker18 = None
 class srl_nokia_network_instance__network_instance__vxlan_interface(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__vxlan_interface_entry]
     mut def __init__(self, elements=[]):
@@ -34499,7 +34486,7 @@ extension srl_nokia_network_instance__network_instance__vxlan_interface(Iterable
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__vxlan_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker19 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance_entry(yang.adata.MNode):
     id: u64
     admin_state: ?str
@@ -34522,7 +34509,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_ins
             return self.vxlan_interface
         if name == 'evi':
             return self.evi
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'bgp-evpn', 'srl_nokia-bgp-evpn:bgp-instance'])
@@ -34535,7 +34521,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_ins
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker20 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance_entry]
     mut def __init__(self, elements=[]):
@@ -34582,7 +34568,7 @@ extension srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker21 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_evpn(yang.adata.MNode):
     bgp_instance: srl_nokia_network_instance__network_instance__protocols__bgp_evpn__bgp_instance
 
@@ -34593,7 +34579,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_evpn(yang.ada
     def _get_attr(self, name: str) -> ?value:
         if name == 'bgp_instance':
             return iter(self.bgp_instance)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp_evpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'bgp-evpn'])
@@ -34612,7 +34597,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_evpn(yang.ada
         raise Exception('Unreachable in srl_nokia_network_instance__network_instance__protocols__bgp_evpn.copy()')
 
 
-_breaker = 1
+_breaker22 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast(yang.adata.MNode):
     admin_state: ?str
 
@@ -34623,7 +34608,6 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
     def _get_attr(self, name: str) -> ?value:
         if name == 'admin_state':
             return self.admin_state
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-isis:isis', 'instance', 'ipv4-unicast'])
@@ -34639,7 +34623,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__ipv4_unicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker23 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level_entry(yang.adata.MNode):
     level_number: u64
     metric: ?u64
@@ -34654,7 +34638,6 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
             return self.level_number
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-isis:isis', 'instance', 'interface', 'level'])
@@ -34667,7 +34650,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker24 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level_entry]
     mut def __init__(self, elements=[]):
@@ -34710,7 +34693,7 @@ extension srl_nokia_network_instance__network_instance__protocols__isis__instanc
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__isis__instance__interface__level_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker25 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance__interface_entry(yang.adata.MNode):
     interface_name: str
     admin_state: ?str
@@ -34737,7 +34720,6 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
             return self.passive
         if name == 'level':
             return iter(self.level)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__isis__instance__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-isis:isis', 'instance', 'interface'])
@@ -34750,7 +34732,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance__i
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__isis__instance__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker26 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance__interface(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__isis__instance__interface_entry]
     mut def __init__(self, elements=[]):
@@ -34797,7 +34779,7 @@ extension srl_nokia_network_instance__network_instance__protocols__isis__instanc
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__isis__instance__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker27 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance_entry(yang.adata.MNode):
     name: str
     admin_state: ?str
@@ -34828,7 +34810,6 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance_en
             return self.ipv4_unicast
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__isis__instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-isis:isis', 'instance'])
@@ -34841,7 +34822,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis__instance_en
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__isis__instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker28 = None
 class srl_nokia_network_instance__network_instance__protocols__isis__instance(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__isis__instance_entry]
     mut def __init__(self, elements=[]):
@@ -34886,7 +34867,7 @@ extension srl_nokia_network_instance__network_instance__protocols__isis__instanc
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__isis__instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker29 = None
 class srl_nokia_network_instance__network_instance__protocols__isis(yang.adata.MNode):
     instance: srl_nokia_network_instance__network_instance__protocols__isis__instance
 
@@ -34897,7 +34878,6 @@ class srl_nokia_network_instance__network_instance__protocols__isis(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'instance':
             return iter(self.instance)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__isis')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-isis:isis'])
@@ -34916,7 +34896,7 @@ class srl_nokia_network_instance__network_instance__protocols__isis(yang.adata.M
         raise Exception('Unreachable in srl_nokia_network_instance__network_instance__protocols__isis.copy()')
 
 
-_breaker = 1
+_breaker30 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy(yang.adata.MNode):
     import_reject_all: ?bool
     export_reject_all: ?bool
@@ -34931,7 +34911,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default
             return self.import_reject_all
         if name == 'export_reject_all':
             return self.export_reject_all
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'ebgp-default-policy'])
@@ -34947,7 +34926,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default
         return srl_nokia_network_instance__network_instance__protocols__bgp__ebgp_default_policy.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker31 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_entry(yang.adata.MNode):
     afi_safi_name: Identityref
     admin_state: ?str
@@ -34962,7 +34941,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_ent
             return self.afi_safi_name
         if name == 'admin_state':
             return self.admin_state
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'afi-safi'])
@@ -34975,7 +34953,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_ent
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker32 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_entry]
     mut def __init__(self, elements=[]):
@@ -35018,7 +34996,7 @@ extension srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__bgp__afi_safi_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker33 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route(yang.adata.MNode):
     ipv4_unicast: ?bool
 
@@ -35029,7 +35007,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__send_
     def _get_attr(self, name: str) -> ?value:
         if name == 'ipv4_unicast':
             return self.ipv4_unicast
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'group', 'send-default-route'])
@@ -35045,7 +35022,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group__send_
         return srl_nokia_network_instance__network_instance__protocols__bgp__group__send_default_route.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker34 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__group_entry(yang.adata.MNode):
     group_name: str
     peer_as: ?u64
@@ -35064,7 +35041,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group_entry(
             return self.peer_as
         if name == 'send_default_route':
             return self.send_default_route
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'group'])
@@ -35077,7 +35053,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__group_entry(
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__bgp__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker35 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -35120,7 +35096,7 @@ extension srl_nokia_network_instance__network_instance__protocols__bgp__group(It
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__bgp__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker36 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication(yang.adata.MNode):
     password: ?str
 
@@ -35131,7 +35107,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__au
     def _get_attr(self, name: str) -> ?value:
         if name == 'password':
             return self.password
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'neighbor', 'authentication'])
@@ -35147,7 +35122,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__au
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker37 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_entry(yang.adata.MNode):
     peer_address: str
     admin_state: ?str
@@ -35178,7 +35153,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_ent
             return self.peer_group
         if name == 'authentication':
             return self.authentication
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp', 'neighbor'])
@@ -35191,7 +35165,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_ent
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker38 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp__neighbor(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -35240,7 +35214,7 @@ extension srl_nokia_network_instance__network_instance__protocols__bgp__neighbor
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__bgp__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker39 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp(yang.adata.MNode):
     autonomous_system: ?u64
     router_id: ?str
@@ -35271,7 +35245,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp(yang.adata.MN
             return iter(self.group)
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp:bgp'])
@@ -35290,7 +35263,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp(yang.adata.MN
         raise Exception('Unreachable in srl_nokia_network_instance__network_instance__protocols__bgp.copy()')
 
 
-_breaker = 1
+_breaker40 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target(yang.adata.MNode):
     export_rt: ?str
     import_rt: ?str
@@ -35305,7 +35278,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
             return self.export_rt
         if name == 'import_rt':
             return self.import_rt
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp-vpn:bgp-vpn', 'bgp-instance', 'route-target'])
@@ -35321,7 +35293,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
         return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker41 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance_entry(yang.adata.MNode):
     id: u64
     route_target: srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance__route_target
@@ -35336,7 +35308,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
             return self.id
         if name == 'route_target':
             return self.route_target
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp-vpn:bgp-vpn', 'bgp-instance'])
@@ -35349,7 +35320,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_inst
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker42 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance_entry]
     mut def __init__(self, elements=[]):
@@ -35390,7 +35361,7 @@ extension srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker43 = None
 class srl_nokia_network_instance__network_instance__protocols__bgp_vpn(yang.adata.MNode):
     bgp_instance: srl_nokia_network_instance__network_instance__protocols__bgp_vpn__bgp_instance
 
@@ -35401,7 +35372,6 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn(yang.adat
     def _get_attr(self, name: str) -> ?value:
         if name == 'bgp_instance':
             return iter(self.bgp_instance)
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols__bgp_vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols', 'srl_nokia-bgp-vpn:bgp-vpn'])
@@ -35420,7 +35390,7 @@ class srl_nokia_network_instance__network_instance__protocols__bgp_vpn(yang.adat
         raise Exception('Unreachable in srl_nokia_network_instance__network_instance__protocols__bgp_vpn.copy()')
 
 
-_breaker = 1
+_breaker44 = None
 class srl_nokia_network_instance__network_instance__protocols(yang.adata.MNode):
     bgp_evpn: ?srl_nokia_network_instance__network_instance__protocols__bgp_evpn
     isis: ?srl_nokia_network_instance__network_instance__protocols__isis
@@ -35479,7 +35449,6 @@ class srl_nokia_network_instance__network_instance__protocols(yang.adata.MNode):
             return self.bgp
         if name == 'bgp_vpn':
             return self.bgp_vpn
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance__protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance', 'protocols'])
@@ -35495,7 +35464,7 @@ class srl_nokia_network_instance__network_instance__protocols(yang.adata.MNode):
         return srl_nokia_network_instance__network_instance__protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker45 = None
 class srl_nokia_network_instance__network_instance_entry(yang.adata.MNode):
     name: str
     type: ?Identityref
@@ -35530,7 +35499,6 @@ class srl_nokia_network_instance__network_instance_entry(yang.adata.MNode):
             return iter(self.vxlan_interface)
         if name == 'protocols':
             return self.protocols
-        raise ValueError('Attribute {name} not found in srl_nokia_network_instance__network_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-network-instance:network-instance'])
@@ -35543,7 +35511,7 @@ class srl_nokia_network_instance__network_instance_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return srl_nokia_network_instance__network_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker46 = None
 class srl_nokia_network_instance__network_instance(yang.adata.MNode):
     elements: list[srl_nokia_network_instance__network_instance_entry]
     mut def __init__(self, elements=[]):
@@ -35590,7 +35558,7 @@ extension srl_nokia_network_instance__network_instance(Iterable[srl_nokia_networ
     def __iter__(self) -> Iterator[srl_nokia_network_instance__network_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker47 = None
 class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress(yang.adata.MNode):
     vni: ?u64
 
@@ -35601,7 +35569,6 @@ class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress(ya
     def _get_attr(self, name: str) -> ?value:
         if name == 'vni':
             return self.vni
-        raise ValueError('Attribute {name} not found in srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-tunnel-interfaces:tunnel-interface', 'vxlan-interface', 'ingress'])
@@ -35617,7 +35584,7 @@ class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress(ya
         return srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface__ingress.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker48 = None
 class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry(yang.adata.MNode):
     index: u64
     type: ?Identityref
@@ -35636,7 +35603,6 @@ class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry(yang.
             return self.type
         if name == 'ingress':
             return self.ingress
-        raise ValueError('Attribute {name} not found in srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-tunnel-interfaces:tunnel-interface', 'vxlan-interface'])
@@ -35649,7 +35615,7 @@ class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry(yang.
         """Create a deep copy of this adata object"""
         return srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker49 = None
 class srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface(yang.adata.MNode):
     elements: list[srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry]
     mut def __init__(self, elements=[]):
@@ -35692,7 +35658,7 @@ extension srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface(Iterabl
     def __iter__(self) -> Iterator[srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker50 = None
 class srl_nokia_tunnel_interfaces__tunnel_interface_entry(yang.adata.MNode):
     name: str
     vxlan_interface: srl_nokia_tunnel_interfaces__tunnel_interface__vxlan_interface
@@ -35707,7 +35673,6 @@ class srl_nokia_tunnel_interfaces__tunnel_interface_entry(yang.adata.MNode):
             return self.name
         if name == 'vxlan_interface':
             return iter(self.vxlan_interface)
-        raise ValueError('Attribute {name} not found in srl_nokia_tunnel_interfaces__tunnel_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['srl_nokia-tunnel-interfaces:tunnel-interface'])
@@ -35720,7 +35685,7 @@ class srl_nokia_tunnel_interfaces__tunnel_interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return srl_nokia_tunnel_interfaces__tunnel_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker51 = None
 class srl_nokia_tunnel_interfaces__tunnel_interface(yang.adata.MNode):
     elements: list[srl_nokia_tunnel_interfaces__tunnel_interface_entry]
     mut def __init__(self, elements=[]):
@@ -35761,7 +35726,7 @@ extension srl_nokia_tunnel_interfaces__tunnel_interface(Iterable[srl_nokia_tunne
     def __iter__(self) -> Iterator[srl_nokia_tunnel_interfaces__tunnel_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker52 = None
 class root(yang.adata.MNode):
     system: srl_nokia_system__system
     interface: srl_nokia_interfaces__interface
@@ -35784,7 +35749,6 @@ class root(yang.adata.MNode):
             return iter(self.network_instance)
         if name == 'tunnel_interface':
             return iter(self.tunnel_interface)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/sorespo/layers/y_0.act
+++ b/src/sorespo/layers/y_0.act
@@ -7160,7 +7160,7 @@ NS_ietf_yang_tmf_map = 'urn:ietf:params:xml:ns:yang:ietf-yang-tmf-map'
 NS_ietf_yang_types = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7199,7 +7199,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yan
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__constraint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'constraint'])
@@ -7212,7 +7211,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yan
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -7267,7 +7266,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__constraint(Itera
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -7294,7 +7293,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureCharacteristic', 'characteristicRelationship'])
@@ -7307,7 +7305,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -7356,7 +7354,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacter
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry(yang.adata.MNode):
     id: str
     name: str
@@ -7387,7 +7385,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureCharacteristic'])
@@ -7400,7 +7397,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -7448,7 +7445,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacter
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor(yang.adata.MNode):
     endDateTime: ?str
     startDateTime: ?str
@@ -7475,7 +7472,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureRelationship', 'validFor'])
@@ -7491,7 +7487,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry(yang.adata.MNode):
     id: str
     name: str
@@ -7526,7 +7522,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureRelationship'])
@@ -7539,7 +7534,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -7588,7 +7583,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelations
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNode):
     id: str
     isBundle: ?bool
@@ -7635,7 +7630,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNod
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature'])
@@ -7648,7 +7642,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNod
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature_entry]
     mut def __init__(self, elements=[]):
@@ -7700,7 +7694,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature(Iterable[stratowe
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
     id: str
     author: ?str
@@ -7735,7 +7729,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__note')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'note'])
@@ -7748,7 +7741,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__note_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_tmf__tmf_store__tmf640__service__note(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__note_entry]
     mut def __init__(self, elements=[]):
@@ -7801,7 +7794,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__note(Iterable[stratoweave
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__note_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7840,7 +7833,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode)
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__place')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'place'])
@@ -7853,7 +7845,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode)
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__place_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_tmf__tmf_store__tmf640__service__place(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__place_entry]
     mut def __init__(self, elements=[]):
@@ -7907,7 +7899,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__place(Iterable[stratoweav
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__place_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7946,7 +7938,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adat
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__relatedEntity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'relatedEntity'])
@@ -7959,7 +7950,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adat
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry]
     mut def __init__(self, elements=[]):
@@ -8013,7 +8004,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__relatedEntity(Iterable[st
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8052,7 +8043,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__relatedParty')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'relatedParty'])
@@ -8065,7 +8055,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedParty(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry]
     mut def __init__(self, elements=[]):
@@ -8119,7 +8109,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__relatedParty(Iterable[str
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -8146,7 +8136,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__charac
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceCharacteristic', 'characteristicRelationship'])
@@ -8159,7 +8148,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__charac
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8208,7 +8197,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__ch
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(yang.adata.MNode):
     id: str
     name: str
@@ -8239,7 +8228,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(y
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceCharacteristic'])
@@ -8252,7 +8240,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(y
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker23 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -8300,7 +8288,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic(Ite
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker24 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.adata.MNode):
     itemId: str
     role: ?str
@@ -8343,7 +8331,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.a
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceOrderItem'])
@@ -8356,7 +8343,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.a
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker25 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry]
     mut def __init__(self, elements=[]):
@@ -8412,7 +8399,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem(Iterable
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker26 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -8439,7 +8426,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship', 'ServiceRelationshipCharacteristic', 'characteristicRelationship'])
@@ -8452,7 +8438,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8501,7 +8487,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__Serv
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry(yang.adata.MNode):
     id: str
     name: str
@@ -8532,7 +8518,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship', 'ServiceRelationshipCharacteristic'])
@@ -8545,7 +8530,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker29 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -8593,7 +8578,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__Serv
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker30 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yang.adata.MNode):
     service: str
     relationshipType: str
@@ -8624,7 +8609,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yan
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship'])
@@ -8637,7 +8621,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yan
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8685,7 +8669,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship(Itera
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.adata.MNode):
     id: str
     href: ?str
@@ -8724,7 +8708,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.ada
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceSpecification'])
@@ -8740,7 +8723,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.ada
         return stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker33 = None
 class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8775,7 +8758,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__supportingResource')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'supportingResource'])
@@ -8788,7 +8770,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker34 = None
 class stratoweave_tmf__tmf_store__tmf640__service__supportingResource(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry]
     mut def __init__(self, elements=[]):
@@ -8841,7 +8823,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__supportingResource(Iterab
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker35 = None
 class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8964,7 +8946,6 @@ class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service'])
@@ -8977,7 +8958,7 @@ class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker36 = None
 class stratoweave_tmf__tmf_store__tmf640__service(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service_entry]
     mut def __init__(self, elements=[]):
@@ -9053,7 +9034,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service(Iterable[stratoweave_tmf__
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker37 = None
 class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
     service: stratoweave_tmf__tmf_store__tmf640__service
 
@@ -9064,7 +9045,6 @@ class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'service':
             return iter(self.service)
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store', 'tmf640'])
@@ -9080,7 +9060,7 @@ class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
         return stratoweave_tmf__tmf_store__tmf640.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker38 = None
 class stratoweave_tmf__tmf_store(yang.adata.MNode):
     tmf640: stratoweave_tmf__tmf_store__tmf640
 
@@ -9091,7 +9071,6 @@ class stratoweave_tmf__tmf_store(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'tmf640':
             return self.tmf640
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-tmf:tmf-store'])
@@ -9107,7 +9086,7 @@ class stratoweave_tmf__tmf_store(yang.adata.MNode):
         return stratoweave_tmf__tmf_store.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker39 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9118,7 +9097,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'cloud-identifier'])
@@ -9131,7 +9109,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker40 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9172,7 +9150,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__c
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker41 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9183,7 +9161,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'encryption-profile-identifier'])
@@ -9196,7 +9173,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker42 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9237,7 +9214,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__e
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker43 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9248,7 +9225,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'qos-profile-identifier'])
@@ -9261,7 +9237,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker44 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9302,7 +9278,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__q
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker45 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9313,7 +9289,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'bfd-profile-identifier'])
@@ -9326,7 +9301,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker46 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9367,7 +9342,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__b
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker47 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.adata.MNode):
     cloud_identifier: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier
     encryption_profile_identifier: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier
@@ -9390,7 +9365,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return iter(self.qos_profile_identifier)
         if name == 'bfd_profile_identifier':
             return iter(self.bfd_profile_identifier)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers'])
@@ -9406,7 +9380,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker48 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
     valid_provider_identifiers: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers
 
@@ -9417,7 +9391,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'valid_provider_identifiers':
             return self.valid_provider_identifiers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles'])
@@ -9433,7 +9406,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker49 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(yang.adata.MNode):
     enabled: bool
     nat44_customer_address: ?str
@@ -9448,7 +9421,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return self.enabled
         if name == 'nat44_customer_address':
             return self.nat44_customer_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access', 'address-translation', 'nat44'])
@@ -9464,7 +9436,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker50 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(yang.adata.MNode):
     nat44: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44
 
@@ -9475,7 +9447,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     def _get_attr(self, name: str) -> ?value:
         if name == 'nat44':
             return self.nat44
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access', 'address-translation'])
@@ -9491,7 +9462,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker51 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(yang.adata.MNode):
     cloud_identifier: str
     permit_any: ?bool
@@ -9518,7 +9489,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return self.deny_site
         if name == 'address_translation':
             return self.address_translation
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access'])
@@ -9531,7 +9501,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker52 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
     mut def __init__(self, elements=[]):
@@ -9574,7 +9544,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker53 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.adata.MNode):
     cloud_access: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access
 
@@ -9585,7 +9555,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
     def _get_attr(self, name: str) -> ?value:
         if name == 'cloud_access':
             return iter(self.cloud_access)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses'])
@@ -9601,7 +9570,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker54 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(yang.adata.MNode):
     tree_flavor: list[Identityref]
 
@@ -9612,7 +9581,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
     def _get_attr(self, name: str) -> ?value:
         if name == 'tree_flavor':
             return self.tree_flavor
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'customer-tree-flavors'])
@@ -9628,7 +9596,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker55 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(yang.adata.MNode):
     enabled: bool
     rp_redundancy: bool
@@ -9647,7 +9615,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.rp_redundancy
         if name == 'optimal_traffic_delivery':
             return self.optimal_traffic_delivery
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'provider-managed'])
@@ -9663,7 +9630,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker56 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(yang.adata.MNode):
     id: u64
     group_address: ?str
@@ -9686,7 +9653,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.group_start
         if name == 'group_end':
             return self.group_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'groups', 'group'])
@@ -9699,7 +9665,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker57 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -9746,7 +9712,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__r
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker58 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group
 
@@ -9757,7 +9723,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'groups'])
@@ -9773,7 +9738,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker59 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(yang.adata.MNode):
     id: u64
     provider_managed: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed
@@ -9796,7 +9761,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.rp_address
         if name == 'groups':
             return self.groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping'])
@@ -9809,7 +9773,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker60 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
     mut def __init__(self, elements=[]):
@@ -9851,7 +9815,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__r
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker61 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(yang.adata.MNode):
     rp_group_mapping: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping
 
@@ -9862,7 +9826,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     def _get_attr(self, name: str) -> ?value:
         if name == 'rp_group_mapping':
             return iter(self.rp_group_mapping)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings'])
@@ -9878,7 +9841,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker62 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(yang.adata.MNode):
     bsr_candidate_address: list[str]
 
@@ -9889,7 +9852,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
     def _get_attr(self, name: str) -> ?value:
         if name == 'bsr_candidate_address':
             return self.bsr_candidate_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-discovery', 'bsr-candidates'])
@@ -9905,7 +9867,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker63 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(yang.adata.MNode):
     rp_discovery_type: Identityref
     bsr_candidates: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates
@@ -9924,7 +9886,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return self.rp_discovery_type
         if name == 'bsr_candidates':
             return self.bsr_candidates
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-discovery'])
@@ -9940,7 +9901,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker64 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.adata.MNode):
     rp_group_mappings: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings
     rp_discovery: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery
@@ -9955,7 +9916,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
             return self.rp_group_mappings
         if name == 'rp_discovery':
             return self.rp_discovery
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp'])
@@ -9971,7 +9931,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker65 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata.MNode):
     enabled: bool
     customer_tree_flavors: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors
@@ -9990,7 +9950,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
             return self.customer_tree_flavors
         if name == 'rp':
             return self.rp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast'])
@@ -10006,7 +9965,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker66 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(yang.adata.MNode):
     vpn_id: str
     local_sites_role: Identityref
@@ -10025,7 +9984,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
             return self.vpn_id
         if name == 'local_sites_role':
             return self.local_sites_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'extranet-vpns', 'extranet-vpn'])
@@ -10038,7 +9996,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker67 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
     mut def __init__(self, elements=[]):
@@ -10081,7 +10039,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__e
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker68 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.adata.MNode):
     extranet_vpn: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn
 
@@ -10092,7 +10050,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
     def _get_attr(self, name: str) -> ?value:
         if name == 'extranet_vpn':
             return iter(self.extranet_vpn)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'extranet-vpns'])
@@ -10108,7 +10065,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker69 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNode):
     vpn_id: str
     customer_name: ?str
@@ -10147,7 +10104,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
             return self.carrierscarrier
         if name == 'extranet_vpns':
             return self.extranet_vpns
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service'])
@@ -10160,7 +10116,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker70 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
     mut def __init__(self, elements=[]):
@@ -10207,7 +10163,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(Iterable[ietf_l3v
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker71 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
     vpn_service: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service
 
@@ -10218,7 +10174,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'vpn_service':
             return iter(self.vpn_service)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services'])
@@ -10234,7 +10189,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker72 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.adata.MNode):
     location_id: str
     address: ?str
@@ -10265,7 +10220,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
             return self.city
         if name == 'country_code':
             return self.country_code
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'locations', 'location'])
@@ -10278,7 +10232,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker73 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
     mut def __init__(self, elements=[]):
@@ -10329,7 +10283,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(Iterable[i
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker74 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
     location: ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location
 
@@ -10340,7 +10294,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'location':
             return iter(self.location)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__locations')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'locations'])
@@ -10356,7 +10309,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker75 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.adata.MNode):
     address_family: ?str
     address: str
@@ -10371,7 +10324,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return self.address_family
         if name == 'address':
             return self.address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices', 'device', 'management'])
@@ -10387,7 +10339,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker76 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.MNode):
     device_id: str
     location: str
@@ -10406,7 +10358,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
             return self.location
         if name == 'management':
             return self.management
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices', 'device'])
@@ -10419,7 +10370,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker77 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -10462,7 +10413,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(Iterable[ietf_
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker78 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
     device: ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device
 
@@ -10473,7 +10424,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices'])
@@ -10489,7 +10439,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker79 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -10500,7 +10450,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity', 'groups', 'group'])
@@ -10513,7 +10462,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker80 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -10554,7 +10503,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker81 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group
 
@@ -10565,7 +10514,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity', 'groups'])
@@ -10581,7 +10529,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker82 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
     groups: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups
 
@@ -10592,7 +10540,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'groups':
             return self.groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity'])
@@ -10608,7 +10555,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker83 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     type: Identityref
 
@@ -10619,7 +10566,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'management'])
@@ -10635,7 +10581,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker84 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(yang.adata.MNode):
     type: Identityref
     lan_tag: list[str]
@@ -10658,7 +10604,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.ipv4_lan_prefix
         if name == 'ipv6_lan_prefix':
             return self.ipv6_lan_prefix
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'filters', 'filter'])
@@ -10671,7 +10616,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker85 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
     mut def __init__(self, elements=[]):
@@ -10712,7 +10657,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker86 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(yang.adata.MNode):
     filter: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter
 
@@ -10723,7 +10668,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     def _get_attr(self, name: str) -> ?value:
         if name == 'filter':
             return iter(self.filter)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'filters'])
@@ -10739,7 +10683,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker87 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(yang.adata.MNode):
     vpn_id: str
     site_role: Identityref
@@ -10758,7 +10702,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.vpn_id
         if name == 'site_role':
             return self.site_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'vpn'])
@@ -10771,7 +10714,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker88 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
     mut def __init__(self, elements=[]):
@@ -10814,7 +10757,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker89 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(yang.adata.MNode):
     id: str
     filters: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters
@@ -10833,7 +10776,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.filters
         if name == 'vpn':
             return iter(self.vpn)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries'])
@@ -10846,7 +10788,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker90 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
     mut def __init__(self, elements=[]):
@@ -10887,7 +10829,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker91 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yang.adata.MNode):
     vpn_policy_id: str
     entries: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries
@@ -10902,7 +10844,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
             return self.vpn_policy_id
         if name == 'entries':
             return iter(self.entries)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy'])
@@ -10915,7 +10856,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker92 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -10956,7 +10897,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(Itera
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker93 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
     vpn_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy
 
@@ -10967,7 +10908,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'vpn_policy':
             return iter(self.vpn_policy)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies'])
@@ -10983,7 +10923,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker94 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(yang.adata.MNode):
     af: str
     maximum_routes: ?u64
@@ -10998,7 +10938,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
             return self.af
         if name == 'maximum_routes':
             return self.maximum_routes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'maximum-routes', 'address-family'])
@@ -11011,7 +10950,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker95 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
     mut def __init__(self, elements=[]):
@@ -11054,7 +10993,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker96 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
     address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family
 
@@ -11065,7 +11004,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return iter(self.address_family)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'maximum-routes'])
@@ -11081,7 +11019,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker97 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adata.MNode):
 
     mut def __init__(self):
@@ -11102,7 +11040,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker98 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(yang.adata.MNode):
     profile_name: ?str
     algorithm: ?str
@@ -11121,7 +11059,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return self.algorithm
         if name == 'preshared_key':
             return self.preshared_key
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security', 'encryption', 'encryption-profile'])
@@ -11137,7 +11074,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker99 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MNode):
     enabled: bool
     layer: ?str
@@ -11156,7 +11093,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return self.layer
         if name == 'encryption_profile':
             return self.encryption_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security', 'encryption'])
@@ -11172,7 +11108,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker100 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
     authentication: ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication
     encryption: ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption
@@ -11187,7 +11123,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
             return self.authentication
         if name == 'encryption':
             return self.encryption
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security'])
@@ -11203,7 +11138,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker101 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -11218,7 +11153,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-src-port-range'])
@@ -11234,7 +11168,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker102 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -11249,7 +11183,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-dst-port-range'])
@@ -11265,7 +11198,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker103 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
     dscp: ?u64
     dot1p: ?u64
@@ -11320,7 +11253,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.l4_dst_port_range
         if name == 'protocol_field':
             return self.protocol_field
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow'])
@@ -11336,7 +11268,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker104 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
     id: str
     match_flow: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow
@@ -11359,7 +11291,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.match_application
         if name == 'target_class_id':
             return self.target_class_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule'])
@@ -11372,7 +11303,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker105 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
     mut def __init__(self, elements=[]):
@@ -11417,7 +11348,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classificati
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker106 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(yang.adata.MNode):
     rule: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule
 
@@ -11428,7 +11359,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'rule':
             return iter(self.rule)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy'])
@@ -11444,7 +11374,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker107 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
     use_lowest_latency: ?bool
     latency_boundary: u64
@@ -11459,7 +11389,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.use_lowest_latency
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'latency'])
@@ -11475,7 +11404,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker108 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
     use_lowest_jitter: ?bool
     latency_boundary: u64
@@ -11490,7 +11419,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.use_lowest_jitter
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'jitter'])
@@ -11506,7 +11434,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker109 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
     guaranteed_bw_percent: Decimal
     end_to_end: ?bool
@@ -11521,7 +11449,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.guaranteed_bw_percent
         if name == 'end_to_end':
             return self.end_to_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'bandwidth'])
@@ -11537,7 +11464,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker110 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(yang.adata.MNode):
     class_id: str
     direction: Identityref
@@ -11572,7 +11499,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.jitter
         if name == 'bandwidth':
             return self.bandwidth
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class'])
@@ -11585,7 +11511,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker111 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -11631,7 +11557,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__cla
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker112 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(yang.adata.MNode):
     class_: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class
 
@@ -11642,7 +11568,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     def _get_attr(self, name: str) -> ?value:
         if name == 'class_':
             return iter(self.class_)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes'])
@@ -11658,7 +11583,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker113 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.adata.MNode):
     profile: ?str
     classes: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
@@ -11673,7 +11598,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
             return self.profile
         if name == 'classes':
             return self.classes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile'])
@@ -11689,7 +11613,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker114 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
     qos_classification_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy
     qos_profile: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile
@@ -11704,7 +11628,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
             return self.qos_classification_policy
         if name == 'qos_profile':
             return self.qos_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos'])
@@ -11720,7 +11643,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker115 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adata.MNode):
     signalling_type: str
 
@@ -11731,7 +11654,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
     def _get_attr(self, name: str) -> ?value:
         if name == 'signalling_type':
             return self.signalling_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'carrierscarrier'])
@@ -11747,7 +11669,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker116 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(yang.adata.MNode):
     ipv4: bool
     ipv6: bool
@@ -11762,7 +11684,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'multicast', 'multicast-address-family'])
@@ -11778,7 +11699,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker117 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNode):
     multicast_site_type: str
     multicast_address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family
@@ -11797,7 +11718,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
             return self.multicast_address_family
         if name == 'protocol_type':
             return self.protocol_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'multicast'])
@@ -11813,7 +11733,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker118 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
     qos: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos
     carrierscarrier: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier
@@ -11832,7 +11752,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return self.carrierscarrier
         if name == 'multicast':
             return self.multicast
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service'])
@@ -11848,7 +11767,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker119 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNode):
     enabled: bool
 
@@ -11859,7 +11778,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
     def _get_attr(self, name: str) -> ?value:
         if name == 'enabled':
             return self.enabled
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'traffic-protection'])
@@ -11875,7 +11793,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker120 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
     target_site: str
     metric: u64
@@ -11890,7 +11808,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.target_site
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links', 'sham-link'])
@@ -11903,7 +11820,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker121 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
     mut def __init__(self, elements=[]):
@@ -11946,7 +11863,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker122 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(yang.adata.MNode):
     sham_link: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link
 
@@ -11957,7 +11874,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'sham_link':
             return iter(self.sham_link)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links'])
@@ -11973,7 +11889,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker123 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(yang.adata.MNode):
     address_family: list[str]
     area_address: str
@@ -11996,7 +11912,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.metric
         if name == 'sham_links':
             return self.sham_links
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf'])
@@ -12015,7 +11930,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.copy()')
 
 
-_breaker = 1
+_breaker124 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
     autonomous_system: u64
     address_family: list[str]
@@ -12030,7 +11945,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.autonomous_system
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'bgp'])
@@ -12049,7 +11963,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.copy()')
 
 
-_breaker = 1
+_breaker125 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -12068,7 +11982,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv4-lan-prefixes'])
@@ -12081,7 +11994,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker126 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12127,7 +12040,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker127 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -12146,7 +12059,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv6-lan-prefixes'])
@@ -12159,7 +12071,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker128 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12205,7 +12117,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker129 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(yang.adata.MNode):
     ipv4_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes
     ipv6_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes
@@ -12220,7 +12132,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return iter(self.ipv4_lan_prefixes)
         if name == 'ipv6_lan_prefixes':
             return iter(self.ipv6_lan_prefixes)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes'])
@@ -12236,7 +12147,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker130 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(yang.adata.MNode):
     cascaded_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes
 
@@ -12247,7 +12158,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'cascaded_lan_prefixes':
             return self.cascaded_lan_prefixes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static'])
@@ -12266,7 +12176,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.copy()')
 
 
-_breaker = 1
+_breaker131 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(yang.adata.MNode):
     address_family: list[str]
 
@@ -12277,7 +12187,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'rip'])
@@ -12296,7 +12205,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.copy()')
 
 
-_breaker = 1
+_breaker132 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
     address_family: list[str]
 
@@ -12307,7 +12216,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'vrrp'])
@@ -12326,7 +12234,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.copy()')
 
 
-_breaker = 1
+_breaker133 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: Identityref
     ospf: ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf
@@ -12401,7 +12309,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.rip
         if name == 'vrrp':
             return self.vrrp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol'])
@@ -12414,7 +12321,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker134 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -12455,7 +12362,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker135 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode):
     routing_protocol: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol
 
@@ -12466,7 +12373,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
     def _get_attr(self, name: str) -> ?value:
         if name == 'routing_protocol':
             return iter(self.routing_protocol)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols'])
@@ -12482,7 +12388,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker136 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -12493,7 +12399,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'groups', 'group'])
@@ -12506,7 +12411,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker137 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -12547,7 +12452,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker138 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group
 
@@ -12558,7 +12463,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'groups'])
@@ -12574,7 +12478,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker139 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -12585,7 +12489,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint', 'target', 'group'])
@@ -12598,7 +12501,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker140 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
     mut def __init__(self, elements=[]):
@@ -12639,7 +12542,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker141 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group
     all_other_accesses: ?bool
@@ -12658,7 +12561,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.all_other_accesses
         if name == 'all_other_groups':
             return self.all_other_groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint', 'target'])
@@ -12674,7 +12576,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker142 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(yang.adata.MNode):
     constraint_type: Identityref
     target: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target
@@ -12689,7 +12591,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.constraint_type
         if name == 'target':
             return self.target
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint'])
@@ -12702,7 +12603,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker143 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -12743,7 +12644,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker144 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(yang.adata.MNode):
     constraint: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint
 
@@ -12754,7 +12655,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'constraint':
             return iter(self.constraint)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints'])
@@ -12770,7 +12670,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker145 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(yang.adata.MNode):
     groups: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups
     constraints: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints
@@ -12785,7 +12685,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.groups
         if name == 'constraints':
             return self.constraints
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity'])
@@ -12801,7 +12700,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker146 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(yang.adata.MNode):
     requested_type: ?str
     strict: bool
@@ -12816,7 +12715,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.requested_type
         if name == 'strict':
             return self.strict
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'bearer', 'requested-type'])
@@ -12832,7 +12730,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker147 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(yang.adata.MNode):
     requested_type: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type
     always_on: bool
@@ -12851,7 +12749,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.always_on
         if name == 'bearer_reference':
             return self.bearer_reference
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'bearer'])
@@ -12867,7 +12764,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker148 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
     group_id: str
     start_address: ?str
@@ -12886,7 +12783,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.start_address
         if name == 'end_address':
             return self.end_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp', 'customer-addresses', 'address-group'])
@@ -12899,7 +12795,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker149 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
     mut def __init__(self, elements=[]):
@@ -12944,7 +12840,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker150 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(yang.adata.MNode):
     address_group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group
 
@@ -12955,7 +12851,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_group':
             return iter(self.address_group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp', 'customer-addresses'])
@@ -12971,7 +12866,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker151 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -12994,7 +12889,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.number_of_dynamic_address
         if name == 'customer_addresses':
             return self.customer_addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp'])
@@ -13010,7 +12904,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker152 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
     server_ip_address: list[str]
 
@@ -13021,7 +12915,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'server_ip_address':
             return self.server_ip_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'dhcp-relay', 'customer-dhcp-servers'])
@@ -13037,7 +12930,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker153 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13056,7 +12949,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.prefix_length
         if name == 'customer_dhcp_servers':
             return self.customer_dhcp_servers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'dhcp-relay'])
@@ -13072,7 +12964,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker154 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(yang.adata.MNode):
     provider_address: ?str
     customer_address: ?str
@@ -13091,7 +12983,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.customer_address
         if name == 'prefix_length':
             return self.prefix_length
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'addresses'])
@@ -13107,7 +12998,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker155 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(yang.adata.MNode):
     address_allocation_type: ?Identityref
     provider_dhcp: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp
@@ -13130,7 +13021,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.dhcp_relay
         if name == 'addresses':
             return self.addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4'])
@@ -13146,7 +13036,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker156 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
     group_id: str
     start_address: ?str
@@ -13165,7 +13055,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.start_address
         if name == 'end_address':
             return self.end_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp', 'customer-addresses', 'address-group'])
@@ -13178,7 +13067,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker157 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
     mut def __init__(self, elements=[]):
@@ -13223,7 +13112,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker158 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(yang.adata.MNode):
     address_group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group
 
@@ -13234,7 +13123,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_group':
             return iter(self.address_group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp', 'customer-addresses'])
@@ -13250,7 +13138,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker159 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13273,7 +13161,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.number_of_dynamic_address
         if name == 'customer_addresses':
             return self.customer_addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp'])
@@ -13289,7 +13176,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker160 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
     server_ip_address: list[str]
 
@@ -13300,7 +13187,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'server_ip_address':
             return self.server_ip_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'dhcp-relay', 'customer-dhcp-servers'])
@@ -13316,7 +13202,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker161 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13335,7 +13221,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.prefix_length
         if name == 'customer_dhcp_servers':
             return self.customer_dhcp_servers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'dhcp-relay'])
@@ -13351,7 +13236,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker162 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(yang.adata.MNode):
     provider_address: ?str
     customer_address: ?str
@@ -13370,7 +13255,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.customer_address
         if name == 'prefix_length':
             return self.prefix_length
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'addresses'])
@@ -13386,7 +13270,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker163 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(yang.adata.MNode):
     address_allocation_type: ?Identityref
     provider_dhcp: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp
@@ -13409,7 +13293,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.dhcp_relay
         if name == 'addresses':
             return self.addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6'])
@@ -13425,7 +13308,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker164 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(yang.adata.MNode):
     enabled: bool
     fixed_value: ?u64
@@ -13444,7 +13327,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.fixed_value
         if name == 'profile_name':
             return self.profile_name
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'oam', 'bfd'])
@@ -13460,7 +13342,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker165 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(yang.adata.MNode):
     bfd: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd
 
@@ -13471,7 +13353,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'bfd':
             return self.bfd
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'oam'])
@@ -13487,7 +13368,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker166 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(yang.adata.MNode):
     ipv4: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4
     ipv6: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6
@@ -13506,7 +13387,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.ipv6
         if name == 'oam':
             return self.oam
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection'])
@@ -13522,7 +13402,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker167 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(yang.adata.MNode):
 
     mut def __init__(self):
@@ -13543,7 +13423,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker168 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(yang.adata.MNode):
     profile_name: ?str
     algorithm: ?str
@@ -13562,7 +13442,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.algorithm
         if name == 'preshared_key':
             return self.preshared_key
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security', 'encryption', 'encryption-profile'])
@@ -13578,7 +13457,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker169 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(yang.adata.MNode):
     enabled: bool
     layer: ?str
@@ -13597,7 +13476,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.layer
         if name == 'encryption_profile':
             return self.encryption_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security', 'encryption'])
@@ -13613,7 +13491,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker170 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(yang.adata.MNode):
     authentication: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication
     encryption: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption
@@ -13628,7 +13506,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.authentication
         if name == 'encryption':
             return self.encryption
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security'])
@@ -13644,7 +13521,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker171 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -13659,7 +13536,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-src-port-range'])
@@ -13675,7 +13551,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker172 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -13690,7 +13566,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-dst-port-range'])
@@ -13706,7 +13581,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker173 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
     dscp: ?u64
     dot1p: ?u64
@@ -13761,7 +13636,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.l4_dst_port_range
         if name == 'protocol_field':
             return self.protocol_field
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow'])
@@ -13777,7 +13651,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker174 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
     id: str
     match_flow: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow
@@ -13800,7 +13674,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.match_application
         if name == 'target_class_id':
             return self.target_class_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule'])
@@ -13813,7 +13686,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker175 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
     mut def __init__(self, elements=[]):
@@ -13858,7 +13731,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker176 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(yang.adata.MNode):
     rule: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule
 
@@ -13869,7 +13742,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'rule':
             return iter(self.rule)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy'])
@@ -13885,7 +13757,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker177 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
     use_lowest_latency: ?bool
     latency_boundary: u64
@@ -13900,7 +13772,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.use_lowest_latency
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'latency'])
@@ -13916,7 +13787,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker178 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
     use_lowest_jitter: ?bool
     latency_boundary: u64
@@ -13931,7 +13802,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.use_lowest_jitter
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'jitter'])
@@ -13947,7 +13817,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker179 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
     guaranteed_bw_percent: Decimal
     end_to_end: ?bool
@@ -13962,7 +13832,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.guaranteed_bw_percent
         if name == 'end_to_end':
             return self.end_to_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'bandwidth'])
@@ -13978,7 +13847,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker180 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(yang.adata.MNode):
     class_id: str
     direction: Identityref
@@ -14013,7 +13882,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.jitter
         if name == 'bandwidth':
             return self.bandwidth
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class'])
@@ -14026,7 +13894,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker181 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -14072,7 +13940,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker182 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(yang.adata.MNode):
     class_: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class
 
@@ -14083,7 +13951,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'class_':
             return iter(self.class_)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes'])
@@ -14099,7 +13966,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker183 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(yang.adata.MNode):
     profile: ?str
     classes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes
@@ -14114,7 +13981,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.profile
         if name == 'classes':
             return self.classes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile'])
@@ -14130,7 +13996,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker184 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(yang.adata.MNode):
     qos_classification_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy
     qos_profile: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile
@@ -14145,7 +14011,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.qos_classification_policy
         if name == 'qos_profile':
             return self.qos_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos'])
@@ -14161,7 +14026,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker185 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(yang.adata.MNode):
     signalling_type: str
 
@@ -14172,7 +14037,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'signalling_type':
             return self.signalling_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'carrierscarrier'])
@@ -14188,7 +14052,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker186 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(yang.adata.MNode):
     ipv4: bool
     ipv6: bool
@@ -14203,7 +14067,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'multicast', 'multicast-address-family'])
@@ -14219,7 +14082,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker187 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(yang.adata.MNode):
     multicast_site_type: str
     multicast_address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family
@@ -14238,7 +14101,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.multicast_address_family
         if name == 'protocol_type':
             return self.protocol_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'multicast'])
@@ -14254,7 +14116,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker188 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(yang.adata.MNode):
     svc_input_bandwidth: u64
     svc_output_bandwidth: u64
@@ -14285,7 +14147,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.carrierscarrier
         if name == 'multicast':
             return self.multicast
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service'])
@@ -14301,7 +14162,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker189 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
     target_site: str
     metric: u64
@@ -14316,7 +14177,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.target_site
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links', 'sham-link'])
@@ -14329,7 +14189,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker190 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
     mut def __init__(self, elements=[]):
@@ -14372,7 +14232,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker191 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(yang.adata.MNode):
     sham_link: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link
 
@@ -14383,7 +14243,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'sham_link':
             return iter(self.sham_link)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links'])
@@ -14399,7 +14258,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker192 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(yang.adata.MNode):
     address_family: list[str]
     area_address: str
@@ -14422,7 +14281,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.metric
         if name == 'sham_links':
             return self.sham_links
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf'])
@@ -14441,7 +14299,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.copy()')
 
 
-_breaker = 1
+_breaker193 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
     autonomous_system: u64
     address_family: list[str]
@@ -14456,7 +14314,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.autonomous_system
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'bgp'])
@@ -14475,7 +14332,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.copy()')
 
 
-_breaker = 1
+_breaker194 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -14494,7 +14351,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv4-lan-prefixes'])
@@ -14507,7 +14363,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker195 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -14553,7 +14409,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker196 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -14572,7 +14428,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv6-lan-prefixes'])
@@ -14585,7 +14440,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker197 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -14631,7 +14486,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker198 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(yang.adata.MNode):
     ipv4_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes
     ipv6_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes
@@ -14646,7 +14501,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return iter(self.ipv4_lan_prefixes)
         if name == 'ipv6_lan_prefixes':
             return iter(self.ipv6_lan_prefixes)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes'])
@@ -14662,7 +14516,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker199 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(yang.adata.MNode):
     cascaded_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes
 
@@ -14673,7 +14527,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'cascaded_lan_prefixes':
             return self.cascaded_lan_prefixes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static'])
@@ -14692,7 +14545,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.copy()')
 
 
-_breaker = 1
+_breaker200 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(yang.adata.MNode):
     address_family: list[str]
 
@@ -14703,7 +14556,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'rip'])
@@ -14722,7 +14574,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.copy()')
 
 
-_breaker = 1
+_breaker201 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
     address_family: list[str]
 
@@ -14733,7 +14585,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'vrrp'])
@@ -14752,7 +14603,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.copy()')
 
 
-_breaker = 1
+_breaker202 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: Identityref
     ospf: ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf
@@ -14827,7 +14678,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.rip
         if name == 'vrrp':
             return self.vrrp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol'])
@@ -14840,7 +14690,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker203 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -14881,7 +14731,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker204 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(yang.adata.MNode):
     routing_protocol: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol
 
@@ -14892,7 +14742,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'routing_protocol':
             return iter(self.routing_protocol)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols'])
@@ -14908,7 +14757,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker205 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(yang.adata.MNode):
     access_priority: u64
 
@@ -14919,7 +14768,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'access_priority':
             return self.access_priority
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'availability'])
@@ -14935,7 +14783,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker206 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(yang.adata.MNode):
     vpn_policy_id: ?str
     vpn_id: ?str
@@ -14958,7 +14806,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.vpn_id
         if name == 'site_role':
             return self.site_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'vpn-attachment'])
@@ -14974,7 +14821,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker207 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(yang.adata.MNode):
     site_network_access_id: str
     site_network_access_type: Identityref
@@ -15033,7 +14880,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.availability
         if name == 'vpn_attachment':
             return self.vpn_attachment
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access'])
@@ -15046,7 +14892,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker208 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
     mut def __init__(self, elements=[]):
@@ -15094,7 +14940,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker209 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.MNode):
     site_network_access: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access
 
@@ -15105,7 +14951,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'site_network_access':
             return iter(self.site_network_access)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses'])
@@ -15121,7 +14966,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker210 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     site_id: str
     requested_site_start: ?str
@@ -15192,7 +15037,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
             return self.routing_protocols
         if name == 'site_network_accesses':
             return self.site_network_accesses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site'])
@@ -15205,7 +15049,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker211 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
     mut def __init__(self, elements=[]):
@@ -15253,7 +15097,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site(Iterable[ietf_l3vpn_svc__l3vpn_
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker212 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
     site: ietf_l3vpn_svc__l3vpn_svc__sites__site
 
@@ -15264,7 +15108,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'site':
             return iter(self.site)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites'])
@@ -15280,7 +15123,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker213 = None
 class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
     vpn_profiles: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles
     vpn_services: ietf_l3vpn_svc__l3vpn_svc__vpn_services
@@ -15299,7 +15142,6 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
             return self.vpn_services
         if name == 'sites':
             return self.sites
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc'])
@@ -15315,7 +15157,7 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker214 = None
 class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
@@ -15326,7 +15168,6 @@ class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra', 'router', 'feature-flags'])
@@ -15342,7 +15183,7 @@ class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
         return netinfra__netinfra__router__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker215 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: u64
@@ -15381,7 +15222,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
             return self.approval_required
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra', 'router'])
@@ -15394,7 +15234,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker216 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -15444,7 +15284,7 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker217 = None
 class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     left_router: str
     left_interface: str
@@ -15471,7 +15311,6 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
             return self.right_interface
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__backbone_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra', 'backbone-link'])
@@ -15484,7 +15323,7 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__backbone_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker218 = None
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -15536,7 +15375,7 @@ extension netinfra__netinfra__backbone_link(Iterable[netinfra__netinfra__backbon
     def __iter__(self) -> Iterator[netinfra__netinfra__backbone_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker219 = None
 class netinfra__netinfra(yang.adata.MNode):
     router: netinfra__netinfra__router
     backbone_link: netinfra__netinfra__backbone_link
@@ -15551,7 +15390,6 @@ class netinfra__netinfra(yang.adata.MNode):
             return iter(self.router)
         if name == 'backbone_link':
             return iter(self.backbone_link)
-        raise ValueError('Attribute {name} not found in netinfra__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra'])
@@ -15567,7 +15405,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker220 = None
 class root(yang.adata.MNode):
     tmf_store: stratoweave_tmf__tmf_store
     l3vpn_svc: ietf_l3vpn_svc__l3vpn_svc
@@ -15586,7 +15424,6 @@ class root(yang.adata.MNode):
             return self.l3vpn_svc
         if name == 'netinfra':
             return self.netinfra
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/src/sorespo/layers/y_0_loose.act
+++ b/src/sorespo/layers/y_0_loose.act
@@ -7160,7 +7160,7 @@ NS_ietf_yang_tmf_map = 'urn:ietf:params:xml:ns:yang:ietf-yang-tmf-map'
 NS_ietf_yang_types = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7199,7 +7199,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yan
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__constraint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'constraint'])
@@ -7212,7 +7211,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry(yan
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__constraint(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -7267,7 +7266,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__constraint(Itera
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__constraint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -7294,7 +7293,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureCharacteristic', 'characteristicRelationship'])
@@ -7307,7 +7305,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -7356,7 +7354,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacter
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry(yang.adata.MNode):
     id: str
     name: ?str
@@ -7387,7 +7385,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureCharacteristic'])
@@ -7400,7 +7397,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristi
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -7449,7 +7446,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacter
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor(yang.adata.MNode):
     endDateTime: ?str
     startDateTime: ?str
@@ -7476,7 +7473,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureRelationship', 'validFor'])
@@ -7492,7 +7488,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship__validFor.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry(yang.adata.MNode):
     id: str
     name: ?str
@@ -7527,7 +7523,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature', 'featureRelationship'])
@@ -7540,7 +7535,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -7591,7 +7586,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelations
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature__featureRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNode):
     id: str
     isBundle: ?bool
@@ -7638,7 +7633,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNod
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__feature')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'feature'])
@@ -7651,7 +7645,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__feature_entry(yang.adata.MNod
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__feature_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_tmf__tmf_store__tmf640__service__feature(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__feature_entry]
     mut def __init__(self, elements=[]):
@@ -7704,7 +7698,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__feature(Iterable[stratowe
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__feature_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
     id: str
     author: ?str
@@ -7739,7 +7733,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__note')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'note'])
@@ -7752,7 +7745,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__note_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__note_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_tmf__tmf_store__tmf640__service__note(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__note_entry]
     mut def __init__(self, elements=[]):
@@ -7805,7 +7798,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__note(Iterable[stratoweave
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__note_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7844,7 +7837,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode)
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__place')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'place'])
@@ -7857,7 +7849,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__place_entry(yang.adata.MNode)
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__place_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_tmf__tmf_store__tmf640__service__place(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__place_entry]
     mut def __init__(self, elements=[]):
@@ -7912,7 +7904,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__place(Iterable[stratoweav
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__place_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -7951,7 +7943,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adat
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__relatedEntity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'relatedEntity'])
@@ -7964,7 +7955,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry(yang.adat
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedEntity(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry]
     mut def __init__(self, elements=[]):
@@ -8019,7 +8010,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__relatedEntity(Iterable[st
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__relatedEntity_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8058,7 +8049,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__relatedParty')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'relatedParty'])
@@ -8071,7 +8061,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry(yang.adata
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_tmf__tmf_store__tmf640__service__relatedParty(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry]
     mut def __init__(self, elements=[]):
@@ -8126,7 +8116,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__relatedParty(Iterable[str
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__relatedParty_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -8153,7 +8143,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__charac
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceCharacteristic', 'characteristicRelationship'])
@@ -8166,7 +8155,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__charac
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8215,7 +8204,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__ch
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(yang.adata.MNode):
     id: str
     name: ?str
@@ -8246,7 +8235,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(y
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceCharacteristic'])
@@ -8259,7 +8247,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry(y
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker23 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -8308,7 +8296,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic(Ite
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker24 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.adata.MNode):
     itemId: str
     role: ?str
@@ -8351,7 +8339,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.a
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceOrderItem'])
@@ -8364,7 +8351,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry(yang.a
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker25 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry]
     mut def __init__(self, elements=[]):
@@ -8421,7 +8408,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem(Iterable
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceOrderItem_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker26 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry(yang.adata.MNode):
     id: str
     relationshipType: ?str
@@ -8448,7 +8435,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship', 'ServiceRelationshipCharacteristic', 'characteristicRelationship'])
@@ -8461,7 +8447,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8510,7 +8496,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__Serv
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic__characteristicRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry(yang.adata.MNode):
     id: str
     name: ?str
@@ -8541,7 +8527,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship', 'ServiceRelationshipCharacteristic'])
@@ -8554,7 +8539,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceR
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker29 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry]
     mut def __init__(self, elements=[]):
@@ -8603,7 +8588,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__Serv
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship__ServiceRelationshipCharacteristic_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker30 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yang.adata.MNode):
     service: str
     relationshipType: ?str
@@ -8634,7 +8619,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yan
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceRelationship'])
@@ -8647,7 +8631,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry(yan
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry]
     mut def __init__(self, elements=[]):
@@ -8696,7 +8680,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship(Itera
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__serviceRelationship_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.adata.MNode):
     id: ?str
     href: ?str
@@ -8735,7 +8719,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.ada
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'serviceSpecification'])
@@ -8751,7 +8734,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification(yang.ada
         return stratoweave_tmf__tmf_store__tmf640__service__serviceSpecification.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker33 = None
 class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8786,7 +8769,6 @@ class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang
             return self.type
         if name == 'referredType':
             return self.referredType
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service__supportingResource')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service', 'supportingResource'])
@@ -8799,7 +8781,7 @@ class stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry(yang
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker34 = None
 class stratoweave_tmf__tmf_store__tmf640__service__supportingResource(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry]
     mut def __init__(self, elements=[]):
@@ -8852,7 +8834,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service__supportingResource(Iterab
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service__supportingResource_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker35 = None
 class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
     id: str
     href: ?str
@@ -8975,7 +8957,6 @@ class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
             return self.schemaLocation
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640', 'service'])
@@ -8988,7 +8969,7 @@ class stratoweave_tmf__tmf_store__tmf640__service_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_tmf__tmf_store__tmf640__service_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker36 = None
 class stratoweave_tmf__tmf_store__tmf640__service(yang.adata.MNode):
     elements: list[stratoweave_tmf__tmf_store__tmf640__service_entry]
     mut def __init__(self, elements=[]):
@@ -9063,7 +9044,7 @@ extension stratoweave_tmf__tmf_store__tmf640__service(Iterable[stratoweave_tmf__
     def __iter__(self) -> Iterator[stratoweave_tmf__tmf_store__tmf640__service_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker37 = None
 class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
     service: stratoweave_tmf__tmf_store__tmf640__service
 
@@ -9074,7 +9055,6 @@ class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'service':
             return iter(self.service)
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store__tmf640')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store', 'tmf640'])
@@ -9090,7 +9070,7 @@ class stratoweave_tmf__tmf_store__tmf640(yang.adata.MNode):
         return stratoweave_tmf__tmf_store__tmf640.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker38 = None
 class stratoweave_tmf__tmf_store(yang.adata.MNode):
     tmf640: stratoweave_tmf__tmf_store__tmf640
 
@@ -9101,7 +9081,6 @@ class stratoweave_tmf__tmf_store(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'tmf640':
             return self.tmf640
-        raise ValueError('Attribute {name} not found in stratoweave_tmf__tmf_store')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-tmf:tmf-store'])
@@ -9117,7 +9096,7 @@ class stratoweave_tmf__tmf_store(yang.adata.MNode):
         return stratoweave_tmf__tmf_store.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker39 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9128,7 +9107,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'cloud-identifier'])
@@ -9141,7 +9119,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker40 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9182,7 +9160,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__c
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker41 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9193,7 +9171,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'encryption-profile-identifier'])
@@ -9206,7 +9183,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker42 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9247,7 +9224,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__e
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker43 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9258,7 +9235,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'qos-profile-identifier'])
@@ -9271,7 +9247,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker44 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9312,7 +9288,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__q
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker45 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -9323,7 +9299,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers', 'bfd-profile-identifier'])
@@ -9336,7 +9311,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker46 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
     mut def __init__(self, elements=[]):
@@ -9377,7 +9352,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__b
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker47 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.adata.MNode):
     cloud_identifier: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier
     encryption_profile_identifier: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier
@@ -9400,7 +9375,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return iter(self.qos_profile_identifier)
         if name == 'bfd_profile_identifier':
             return iter(self.bfd_profile_identifier)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles', 'valid-provider-identifiers'])
@@ -9416,7 +9390,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker48 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
     valid_provider_identifiers: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers
 
@@ -9427,7 +9401,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'valid_provider_identifiers':
             return self.valid_provider_identifiers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_profiles')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-profiles'])
@@ -9443,7 +9416,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker49 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(yang.adata.MNode):
     enabled: ?bool
     nat44_customer_address: ?str
@@ -9458,7 +9431,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return self.enabled
         if name == 'nat44_customer_address':
             return self.nat44_customer_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access', 'address-translation', 'nat44'])
@@ -9474,7 +9446,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker50 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(yang.adata.MNode):
     nat44: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44
 
@@ -9485,7 +9457,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     def _get_attr(self, name: str) -> ?value:
         if name == 'nat44':
             return self.nat44
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access', 'address-translation'])
@@ -9501,7 +9472,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker51 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(yang.adata.MNode):
     cloud_identifier: str
     permit_any: ?bool
@@ -9528,7 +9499,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return self.deny_site
         if name == 'address_translation':
             return self.address_translation
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses', 'cloud-access'])
@@ -9541,7 +9511,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker52 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
     mut def __init__(self, elements=[]):
@@ -9584,7 +9554,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker53 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.adata.MNode):
     cloud_access: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access
 
@@ -9595,7 +9565,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
     def _get_attr(self, name: str) -> ?value:
         if name == 'cloud_access':
             return iter(self.cloud_access)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'cloud-accesses'])
@@ -9611,7 +9580,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker54 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(yang.adata.MNode):
     tree_flavor: list[Identityref]
 
@@ -9622,7 +9591,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
     def _get_attr(self, name: str) -> ?value:
         if name == 'tree_flavor':
             return self.tree_flavor
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'customer-tree-flavors'])
@@ -9638,7 +9606,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker55 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(yang.adata.MNode):
     enabled: ?bool
     rp_redundancy: ?bool
@@ -9657,7 +9625,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.rp_redundancy
         if name == 'optimal_traffic_delivery':
             return self.optimal_traffic_delivery
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'provider-managed'])
@@ -9673,7 +9640,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker56 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(yang.adata.MNode):
     id: u64
     group_address: ?str
@@ -9696,7 +9663,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.group_start
         if name == 'group_end':
             return self.group_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'groups', 'group'])
@@ -9709,7 +9675,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker57 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -9756,7 +9722,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__r
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker58 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group
 
@@ -9767,7 +9733,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping', 'groups'])
@@ -9783,7 +9748,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker59 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(yang.adata.MNode):
     id: u64
     provider_managed: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed
@@ -9806,7 +9771,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return self.rp_address
         if name == 'groups':
             return self.groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings', 'rp-group-mapping'])
@@ -9819,7 +9783,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker60 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
     mut def __init__(self, elements=[]):
@@ -9862,7 +9826,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__r
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker61 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(yang.adata.MNode):
     rp_group_mapping: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping
 
@@ -9873,7 +9837,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     def _get_attr(self, name: str) -> ?value:
         if name == 'rp_group_mapping':
             return iter(self.rp_group_mapping)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-group-mappings'])
@@ -9889,7 +9852,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker62 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(yang.adata.MNode):
     bsr_candidate_address: list[str]
 
@@ -9900,7 +9863,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
     def _get_attr(self, name: str) -> ?value:
         if name == 'bsr_candidate_address':
             return self.bsr_candidate_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-discovery', 'bsr-candidates'])
@@ -9916,7 +9878,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker63 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(yang.adata.MNode):
     rp_discovery_type: ?Identityref
     bsr_candidates: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates
@@ -9931,7 +9893,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return self.rp_discovery_type
         if name == 'bsr_candidates':
             return self.bsr_candidates
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp', 'rp-discovery'])
@@ -9947,7 +9908,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker64 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.adata.MNode):
     rp_group_mappings: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings
     rp_discovery: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery
@@ -9962,7 +9923,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
             return self.rp_group_mappings
         if name == 'rp_discovery':
             return self.rp_discovery
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast', 'rp'])
@@ -9978,7 +9938,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker65 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata.MNode):
     enabled: ?bool
     customer_tree_flavors: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors
@@ -9997,7 +9957,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
             return self.customer_tree_flavors
         if name == 'rp':
             return self.rp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'multicast'])
@@ -10013,7 +9972,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker66 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(yang.adata.MNode):
     vpn_id: str
     local_sites_role: ?Identityref
@@ -10028,7 +9987,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
             return self.vpn_id
         if name == 'local_sites_role':
             return self.local_sites_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'extranet-vpns', 'extranet-vpn'])
@@ -10041,7 +9999,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker67 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
     mut def __init__(self, elements=[]):
@@ -10084,7 +10042,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__e
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker68 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.adata.MNode):
     extranet_vpn: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn
 
@@ -10095,7 +10053,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
     def _get_attr(self, name: str) -> ?value:
         if name == 'extranet_vpn':
             return iter(self.extranet_vpn)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service', 'extranet-vpns'])
@@ -10111,7 +10068,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker69 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNode):
     vpn_id: str
     customer_name: ?str
@@ -10146,7 +10103,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
             return self.carrierscarrier
         if name == 'extranet_vpns':
             return self.extranet_vpns
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service'])
@@ -10159,7 +10115,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker70 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
     mut def __init__(self, elements=[]):
@@ -10206,7 +10162,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(Iterable[ietf_l3v
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker71 = None
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
     vpn_service: ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service
 
@@ -10217,7 +10173,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'vpn_service':
             return iter(self.vpn_service)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__vpn_services')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services'])
@@ -10233,7 +10188,7 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker72 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.adata.MNode):
     location_id: str
     address: ?str
@@ -10264,7 +10219,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
             return self.city
         if name == 'country_code':
             return self.country_code
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'locations', 'location'])
@@ -10277,7 +10231,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker73 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
     mut def __init__(self, elements=[]):
@@ -10328,7 +10282,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(Iterable[i
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker74 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
     location: ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location
 
@@ -10339,7 +10293,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'location':
             return iter(self.location)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__locations')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'locations'])
@@ -10355,7 +10308,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker75 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.adata.MNode):
     address_family: ?str
     address: ?str
@@ -10370,7 +10323,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return self.address_family
         if name == 'address':
             return self.address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices', 'device', 'management'])
@@ -10386,7 +10338,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker76 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.MNode):
     device_id: str
     location: ?str
@@ -10405,7 +10357,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
             return self.location
         if name == 'management':
             return self.management
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices', 'device'])
@@ -10418,7 +10369,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker77 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -10461,7 +10412,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(Iterable[ietf_
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker78 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
     device: ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device
 
@@ -10472,7 +10423,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'devices'])
@@ -10488,7 +10438,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker79 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -10499,7 +10449,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity', 'groups', 'group'])
@@ -10512,7 +10461,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker80 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -10553,7 +10502,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker81 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group
 
@@ -10564,7 +10513,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity', 'groups'])
@@ -10580,7 +10528,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker82 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
     groups: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups
 
@@ -10591,7 +10539,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'groups':
             return self.groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-diversity'])
@@ -10607,7 +10554,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker83 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     type: ?Identityref
 
@@ -10618,7 +10565,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'type':
             return self.type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'management'])
@@ -10634,7 +10580,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker84 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(yang.adata.MNode):
     type: Identityref
     lan_tag: list[str]
@@ -10657,7 +10603,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.ipv4_lan_prefix
         if name == 'ipv6_lan_prefix':
             return self.ipv6_lan_prefix
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'filters', 'filter'])
@@ -10670,7 +10615,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker85 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
     mut def __init__(self, elements=[]):
@@ -10711,7 +10656,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker86 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(yang.adata.MNode):
     filter: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter
 
@@ -10722,7 +10667,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     def _get_attr(self, name: str) -> ?value:
         if name == 'filter':
             return iter(self.filter)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'filters'])
@@ -10738,7 +10682,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker87 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(yang.adata.MNode):
     vpn_id: str
     site_role: ?Identityref
@@ -10753,7 +10697,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.vpn_id
         if name == 'site_role':
             return self.site_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries', 'vpn'])
@@ -10766,7 +10709,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker88 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
     mut def __init__(self, elements=[]):
@@ -10809,7 +10752,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker89 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(yang.adata.MNode):
     id: str
     filters: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters
@@ -10828,7 +10771,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return self.filters
         if name == 'vpn':
             return iter(self.vpn)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy', 'entries'])
@@ -10841,7 +10783,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker90 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
     mut def __init__(self, elements=[]):
@@ -10882,7 +10824,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entr
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker91 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yang.adata.MNode):
     vpn_policy_id: str
     entries: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries
@@ -10897,7 +10839,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
             return self.vpn_policy_id
         if name == 'entries':
             return iter(self.entries)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies', 'vpn-policy'])
@@ -10910,7 +10851,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker92 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -10951,7 +10892,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(Itera
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker93 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
     vpn_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy
 
@@ -10962,7 +10903,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'vpn_policy':
             return iter(self.vpn_policy)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'vpn-policies'])
@@ -10978,7 +10918,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker94 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(yang.adata.MNode):
     af: str
     maximum_routes: ?u64
@@ -10993,7 +10933,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
             return self.af
         if name == 'maximum_routes':
             return self.maximum_routes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'maximum-routes', 'address-family'])
@@ -11006,7 +10945,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker95 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
     mut def __init__(self, elements=[]):
@@ -11049,7 +10988,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker96 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
     address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family
 
@@ -11060,7 +10999,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return iter(self.address_family)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'maximum-routes'])
@@ -11076,7 +11014,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker97 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adata.MNode):
 
     mut def __init__(self):
@@ -11097,7 +11035,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker98 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(yang.adata.MNode):
     profile_name: ?str
     algorithm: ?str
@@ -11116,7 +11054,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return self.algorithm
         if name == 'preshared_key':
             return self.preshared_key
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security', 'encryption', 'encryption-profile'])
@@ -11132,7 +11069,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker99 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MNode):
     enabled: ?bool
     layer: ?str
@@ -11151,7 +11088,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return self.layer
         if name == 'encryption_profile':
             return self.encryption_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security', 'encryption'])
@@ -11167,7 +11103,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker100 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
     authentication: ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication
     encryption: ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption
@@ -11182,7 +11118,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
             return self.authentication
         if name == 'encryption':
             return self.encryption
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__security')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'security'])
@@ -11198,7 +11133,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker101 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -11213,7 +11148,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-src-port-range'])
@@ -11229,7 +11163,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker102 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -11244,7 +11178,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-dst-port-range'])
@@ -11260,7 +11193,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker103 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
     dscp: ?u64
     dot1p: ?u64
@@ -11315,7 +11248,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.l4_dst_port_range
         if name == 'protocol_field':
             return self.protocol_field
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow'])
@@ -11331,7 +11263,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker104 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
     id: str
     match_flow: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow
@@ -11354,7 +11286,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return self.match_application
         if name == 'target_class_id':
             return self.target_class_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy', 'rule'])
@@ -11367,7 +11298,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker105 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
     mut def __init__(self, elements=[]):
@@ -11412,7 +11343,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classificati
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker106 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(yang.adata.MNode):
     rule: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule
 
@@ -11423,7 +11354,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     def _get_attr(self, name: str) -> ?value:
         if name == 'rule':
             return iter(self.rule)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-classification-policy'])
@@ -11439,7 +11369,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker107 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
     use_lowest_latency: ?bool
     latency_boundary: ?u64
@@ -11454,7 +11384,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.use_lowest_latency
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'latency'])
@@ -11470,7 +11399,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker108 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
     use_lowest_jitter: ?bool
     latency_boundary: ?u64
@@ -11485,7 +11414,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.use_lowest_jitter
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'jitter'])
@@ -11501,7 +11429,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker109 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
     guaranteed_bw_percent: ?Decimal
     end_to_end: ?bool
@@ -11516,7 +11444,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.guaranteed_bw_percent
         if name == 'end_to_end':
             return self.end_to_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class', 'bandwidth'])
@@ -11532,7 +11459,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker110 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(yang.adata.MNode):
     class_id: str
     direction: ?Identityref
@@ -11563,7 +11490,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return self.jitter
         if name == 'bandwidth':
             return self.bandwidth
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes', 'class'])
@@ -11576,7 +11502,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker111 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -11621,7 +11547,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__cla
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker112 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(yang.adata.MNode):
     class_: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class
 
@@ -11632,7 +11558,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     def _get_attr(self, name: str) -> ?value:
         if name == 'class_':
             return iter(self.class_)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile', 'classes'])
@@ -11648,7 +11573,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker113 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.adata.MNode):
     profile: ?str
     classes: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
@@ -11663,7 +11588,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
             return self.profile
         if name == 'classes':
             return self.classes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos', 'qos-profile'])
@@ -11679,7 +11603,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker114 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
     qos_classification_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy
     qos_profile: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile
@@ -11694,7 +11618,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
             return self.qos_classification_policy
         if name == 'qos_profile':
             return self.qos_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'qos'])
@@ -11710,7 +11633,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker115 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adata.MNode):
     signalling_type: ?str
 
@@ -11721,7 +11644,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
     def _get_attr(self, name: str) -> ?value:
         if name == 'signalling_type':
             return self.signalling_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'carrierscarrier'])
@@ -11737,7 +11659,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker116 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(yang.adata.MNode):
     ipv4: ?bool
     ipv6: ?bool
@@ -11752,7 +11674,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'multicast', 'multicast-address-family'])
@@ -11768,7 +11689,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker117 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNode):
     multicast_site_type: ?str
     multicast_address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family
@@ -11787,7 +11708,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
             return self.multicast_address_family
         if name == 'protocol_type':
             return self.protocol_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service', 'multicast'])
@@ -11803,7 +11723,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker118 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
     qos: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos
     carrierscarrier: ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier
@@ -11822,7 +11742,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return self.carrierscarrier
         if name == 'multicast':
             return self.multicast
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'service'])
@@ -11838,7 +11757,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker119 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNode):
     enabled: ?bool
 
@@ -11849,7 +11768,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
     def _get_attr(self, name: str) -> ?value:
         if name == 'enabled':
             return self.enabled
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'traffic-protection'])
@@ -11865,7 +11783,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker120 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
     target_site: str
     metric: ?u64
@@ -11880,7 +11798,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.target_site
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links', 'sham-link'])
@@ -11893,7 +11810,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker121 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
     mut def __init__(self, elements=[]):
@@ -11936,7 +11853,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker122 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(yang.adata.MNode):
     sham_link: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link
 
@@ -11947,7 +11864,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'sham_link':
             return iter(self.sham_link)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links'])
@@ -11963,7 +11879,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker123 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(yang.adata.MNode):
     address_family: list[str]
     area_address: ?str
@@ -11986,7 +11902,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.metric
         if name == 'sham_links':
             return self.sham_links
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'ospf'])
@@ -12005,7 +11920,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.copy()')
 
 
-_breaker = 1
+_breaker124 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
     autonomous_system: ?u64
     address_family: list[str]
@@ -12020,7 +11935,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.autonomous_system
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'bgp'])
@@ -12039,7 +11953,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.copy()')
 
 
-_breaker = 1
+_breaker125 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -12058,7 +11972,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv4-lan-prefixes'])
@@ -12071,7 +11984,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker126 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12117,7 +12030,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker127 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -12136,7 +12049,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv6-lan-prefixes'])
@@ -12149,7 +12061,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker128 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -12195,7 +12107,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker129 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(yang.adata.MNode):
     ipv4_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes
     ipv6_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes
@@ -12210,7 +12122,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return iter(self.ipv4_lan_prefixes)
         if name == 'ipv6_lan_prefixes':
             return iter(self.ipv6_lan_prefixes)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes'])
@@ -12226,7 +12137,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker130 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(yang.adata.MNode):
     cascaded_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes
 
@@ -12237,7 +12148,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'cascaded_lan_prefixes':
             return self.cascaded_lan_prefixes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'static'])
@@ -12256,7 +12166,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.copy()')
 
 
-_breaker = 1
+_breaker131 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(yang.adata.MNode):
     address_family: list[str]
 
@@ -12267,7 +12177,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'rip'])
@@ -12286,7 +12195,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.copy()')
 
 
-_breaker = 1
+_breaker132 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
     address_family: list[str]
 
@@ -12297,7 +12206,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol', 'vrrp'])
@@ -12316,7 +12224,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.copy()')
 
 
-_breaker = 1
+_breaker133 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: Identityref
     ospf: ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf
@@ -12393,7 +12301,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return self.rip
         if name == 'vrrp':
             return self.vrrp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols', 'routing-protocol'])
@@ -12406,7 +12313,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker134 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -12447,7 +12354,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_pro
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker135 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode):
     routing_protocol: ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol
 
@@ -12458,7 +12365,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
     def _get_attr(self, name: str) -> ?value:
         if name == 'routing_protocol':
             return iter(self.routing_protocol)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'routing-protocols'])
@@ -12474,7 +12380,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker136 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -12485,7 +12391,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'groups', 'group'])
@@ -12498,7 +12403,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker137 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -12539,7 +12444,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker138 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group
 
@@ -12550,7 +12455,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'groups'])
@@ -12566,7 +12470,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker139 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -12577,7 +12481,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'group_id':
             return self.group_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint', 'target', 'group'])
@@ -12590,7 +12493,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker140 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
     mut def __init__(self, elements=[]):
@@ -12631,7 +12534,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker141 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(yang.adata.MNode):
     group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group
     all_other_accesses: ?bool
@@ -12650,7 +12553,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.all_other_accesses
         if name == 'all_other_groups':
             return self.all_other_groups
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint', 'target'])
@@ -12666,7 +12568,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker142 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(yang.adata.MNode):
     constraint_type: Identityref
     target: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target
@@ -12681,7 +12583,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.constraint_type
         if name == 'target':
             return self.target
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints', 'constraint'])
@@ -12694,7 +12595,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker143 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -12735,7 +12636,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker144 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(yang.adata.MNode):
     constraint: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint
 
@@ -12746,7 +12647,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'constraint':
             return iter(self.constraint)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity', 'constraints'])
@@ -12762,7 +12662,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker145 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(yang.adata.MNode):
     groups: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups
     constraints: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints
@@ -12777,7 +12677,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.groups
         if name == 'constraints':
             return self.constraints
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'access-diversity'])
@@ -12793,7 +12692,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker146 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(yang.adata.MNode):
     requested_type: ?str
     strict: ?bool
@@ -12808,7 +12707,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.requested_type
         if name == 'strict':
             return self.strict
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'bearer', 'requested-type'])
@@ -12824,7 +12722,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker147 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(yang.adata.MNode):
     requested_type: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type
     always_on: ?bool
@@ -12843,7 +12741,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.always_on
         if name == 'bearer_reference':
             return self.bearer_reference
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'bearer'])
@@ -12859,7 +12756,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker148 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
     group_id: str
     start_address: ?str
@@ -12878,7 +12775,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.start_address
         if name == 'end_address':
             return self.end_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp', 'customer-addresses', 'address-group'])
@@ -12891,7 +12787,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker149 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
     mut def __init__(self, elements=[]):
@@ -12936,7 +12832,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker150 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(yang.adata.MNode):
     address_group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group
 
@@ -12947,7 +12843,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_group':
             return iter(self.address_group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp', 'customer-addresses'])
@@ -12963,7 +12858,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker151 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -12986,7 +12881,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.number_of_dynamic_address
         if name == 'customer_addresses':
             return self.customer_addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'provider-dhcp'])
@@ -13002,7 +12896,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker152 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
     server_ip_address: list[str]
 
@@ -13013,7 +12907,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'server_ip_address':
             return self.server_ip_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'dhcp-relay', 'customer-dhcp-servers'])
@@ -13029,7 +12922,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker153 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13048,7 +12941,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.prefix_length
         if name == 'customer_dhcp_servers':
             return self.customer_dhcp_servers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'dhcp-relay'])
@@ -13064,7 +12956,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker154 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(yang.adata.MNode):
     provider_address: ?str
     customer_address: ?str
@@ -13083,7 +12975,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.customer_address
         if name == 'prefix_length':
             return self.prefix_length
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4', 'addresses'])
@@ -13099,7 +12990,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker155 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(yang.adata.MNode):
     address_allocation_type: ?Identityref
     provider_dhcp: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp
@@ -13122,7 +13013,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.dhcp_relay
         if name == 'addresses':
             return self.addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv4'])
@@ -13138,7 +13028,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker156 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
     group_id: str
     start_address: ?str
@@ -13157,7 +13047,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.start_address
         if name == 'end_address':
             return self.end_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp', 'customer-addresses', 'address-group'])
@@ -13170,7 +13059,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker157 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
     mut def __init__(self, elements=[]):
@@ -13215,7 +13104,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker158 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(yang.adata.MNode):
     address_group: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group
 
@@ -13226,7 +13115,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_group':
             return iter(self.address_group)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp', 'customer-addresses'])
@@ -13242,7 +13130,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker159 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13265,7 +13153,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.number_of_dynamic_address
         if name == 'customer_addresses':
             return self.customer_addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'provider-dhcp'])
@@ -13281,7 +13168,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker160 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
     server_ip_address: list[str]
 
@@ -13292,7 +13179,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'server_ip_address':
             return self.server_ip_address
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'dhcp-relay', 'customer-dhcp-servers'])
@@ -13308,7 +13194,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker161 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(yang.adata.MNode):
     provider_address: ?str
     prefix_length: ?u64
@@ -13327,7 +13213,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.prefix_length
         if name == 'customer_dhcp_servers':
             return self.customer_dhcp_servers
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'dhcp-relay'])
@@ -13343,7 +13228,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker162 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(yang.adata.MNode):
     provider_address: ?str
     customer_address: ?str
@@ -13362,7 +13247,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.customer_address
         if name == 'prefix_length':
             return self.prefix_length
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6', 'addresses'])
@@ -13378,7 +13262,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker163 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(yang.adata.MNode):
     address_allocation_type: ?Identityref
     provider_dhcp: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp
@@ -13401,7 +13285,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.dhcp_relay
         if name == 'addresses':
             return self.addresses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'ipv6'])
@@ -13417,7 +13300,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker164 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(yang.adata.MNode):
     enabled: ?bool
     fixed_value: ?u64
@@ -13436,7 +13319,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.fixed_value
         if name == 'profile_name':
             return self.profile_name
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'oam', 'bfd'])
@@ -13452,7 +13334,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker165 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(yang.adata.MNode):
     bfd: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd
 
@@ -13463,7 +13345,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'bfd':
             return self.bfd
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection', 'oam'])
@@ -13479,7 +13360,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker166 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(yang.adata.MNode):
     ipv4: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4
     ipv6: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6
@@ -13498,7 +13379,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.ipv6
         if name == 'oam':
             return self.oam
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'ip-connection'])
@@ -13514,7 +13394,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker167 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(yang.adata.MNode):
 
     mut def __init__(self):
@@ -13535,7 +13415,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker168 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(yang.adata.MNode):
     profile_name: ?str
     algorithm: ?str
@@ -13554,7 +13434,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.algorithm
         if name == 'preshared_key':
             return self.preshared_key
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security', 'encryption', 'encryption-profile'])
@@ -13570,7 +13449,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker169 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(yang.adata.MNode):
     enabled: ?bool
     layer: ?str
@@ -13589,7 +13468,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.layer
         if name == 'encryption_profile':
             return self.encryption_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security', 'encryption'])
@@ -13605,7 +13483,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker170 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(yang.adata.MNode):
     authentication: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication
     encryption: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption
@@ -13620,7 +13498,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.authentication
         if name == 'encryption':
             return self.encryption
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'security'])
@@ -13636,7 +13513,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker171 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -13651,7 +13528,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-src-port-range'])
@@ -13667,7 +13543,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker172 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
     lower_port: ?u64
     upper_port: ?u64
@@ -13682,7 +13558,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.lower_port
         if name == 'upper_port':
             return self.upper_port
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow', 'l4-dst-port-range'])
@@ -13698,7 +13573,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker173 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
     dscp: ?u64
     dot1p: ?u64
@@ -13753,7 +13628,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.l4_dst_port_range
         if name == 'protocol_field':
             return self.protocol_field
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule', 'match-flow'])
@@ -13769,7 +13643,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker174 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
     id: str
     match_flow: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow
@@ -13792,7 +13666,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.match_application
         if name == 'target_class_id':
             return self.target_class_id
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy', 'rule'])
@@ -13805,7 +13678,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker175 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
     mut def __init__(self, elements=[]):
@@ -13850,7 +13723,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker176 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(yang.adata.MNode):
     rule: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule
 
@@ -13861,7 +13734,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'rule':
             return iter(self.rule)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-classification-policy'])
@@ -13877,7 +13749,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker177 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
     use_lowest_latency: ?bool
     latency_boundary: ?u64
@@ -13892,7 +13764,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.use_lowest_latency
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'latency'])
@@ -13908,7 +13779,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker178 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
     use_lowest_jitter: ?bool
     latency_boundary: ?u64
@@ -13923,7 +13794,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.use_lowest_jitter
         if name == 'latency_boundary':
             return self.latency_boundary
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'jitter'])
@@ -13939,7 +13809,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker179 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
     guaranteed_bw_percent: ?Decimal
     end_to_end: ?bool
@@ -13954,7 +13824,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.guaranteed_bw_percent
         if name == 'end_to_end':
             return self.end_to_end
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class', 'bandwidth'])
@@ -13970,7 +13839,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker180 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(yang.adata.MNode):
     class_id: str
     direction: ?Identityref
@@ -14001,7 +13870,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.jitter
         if name == 'bandwidth':
             return self.bandwidth
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes', 'class'])
@@ -14014,7 +13882,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker181 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -14059,7 +13927,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker182 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(yang.adata.MNode):
     class_: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class
 
@@ -14070,7 +13938,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'class_':
             return iter(self.class_)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile', 'classes'])
@@ -14086,7 +13953,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker183 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(yang.adata.MNode):
     profile: ?str
     classes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes
@@ -14101,7 +13968,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.profile
         if name == 'classes':
             return self.classes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos', 'qos-profile'])
@@ -14117,7 +13983,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker184 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(yang.adata.MNode):
     qos_classification_policy: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy
     qos_profile: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile
@@ -14132,7 +13998,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.qos_classification_policy
         if name == 'qos_profile':
             return self.qos_profile
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'qos'])
@@ -14148,7 +14013,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker185 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(yang.adata.MNode):
     signalling_type: ?str
 
@@ -14159,7 +14024,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'signalling_type':
             return self.signalling_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'carrierscarrier'])
@@ -14175,7 +14039,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker186 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(yang.adata.MNode):
     ipv4: ?bool
     ipv6: ?bool
@@ -14190,7 +14054,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'multicast', 'multicast-address-family'])
@@ -14206,7 +14069,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker187 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(yang.adata.MNode):
     multicast_site_type: ?str
     multicast_address_family: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family
@@ -14225,7 +14088,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.multicast_address_family
         if name == 'protocol_type':
             return self.protocol_type
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service', 'multicast'])
@@ -14241,7 +14103,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker188 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(yang.adata.MNode):
     svc_input_bandwidth: ?u64
     svc_output_bandwidth: ?u64
@@ -14272,7 +14134,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.carrierscarrier
         if name == 'multicast':
             return self.multicast
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'service'])
@@ -14288,7 +14149,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker189 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
     target_site: str
     metric: ?u64
@@ -14303,7 +14164,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.target_site
         if name == 'metric':
             return self.metric
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links', 'sham-link'])
@@ -14316,7 +14176,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker190 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
     mut def __init__(self, elements=[]):
@@ -14359,7 +14219,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker191 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(yang.adata.MNode):
     sham_link: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link
 
@@ -14370,7 +14230,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'sham_link':
             return iter(self.sham_link)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf', 'sham-links'])
@@ -14386,7 +14245,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker192 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(yang.adata.MNode):
     address_family: list[str]
     area_address: ?str
@@ -14409,7 +14268,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.metric
         if name == 'sham_links':
             return self.sham_links
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'ospf'])
@@ -14428,7 +14286,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.copy()')
 
 
-_breaker = 1
+_breaker193 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
     autonomous_system: ?u64
     address_family: list[str]
@@ -14443,7 +14301,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.autonomous_system
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'bgp'])
@@ -14462,7 +14319,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.copy()')
 
 
-_breaker = 1
+_breaker194 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -14481,7 +14338,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv4-lan-prefixes'])
@@ -14494,7 +14350,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker195 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -14540,7 +14396,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker196 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
     lan: str
     next_hop: str
@@ -14559,7 +14415,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.next_hop
         if name == 'lan_tag':
             return self.lan_tag
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes', 'ipv6-lan-prefixes'])
@@ -14572,7 +14427,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker197 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
     mut def __init__(self, elements=[]):
@@ -14618,7 +14473,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker198 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(yang.adata.MNode):
     ipv4_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes
     ipv6_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes
@@ -14633,7 +14488,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return iter(self.ipv4_lan_prefixes)
         if name == 'ipv6_lan_prefixes':
             return iter(self.ipv6_lan_prefixes)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static', 'cascaded-lan-prefixes'])
@@ -14649,7 +14503,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker199 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(yang.adata.MNode):
     cascaded_lan_prefixes: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes
 
@@ -14660,7 +14514,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'cascaded_lan_prefixes':
             return self.cascaded_lan_prefixes
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'static'])
@@ -14679,7 +14532,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.copy()')
 
 
-_breaker = 1
+_breaker200 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(yang.adata.MNode):
     address_family: list[str]
 
@@ -14690,7 +14543,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'rip'])
@@ -14709,7 +14561,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.copy()')
 
 
-_breaker = 1
+_breaker201 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
     address_family: list[str]
 
@@ -14720,7 +14572,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'address_family':
             return self.address_family
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol', 'vrrp'])
@@ -14739,7 +14590,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         raise Exception('Unreachable in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.copy()')
 
 
-_breaker = 1
+_breaker202 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: Identityref
     ospf: ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf
@@ -14816,7 +14667,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.rip
         if name == 'vrrp':
             return self.vrrp
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols', 'routing-protocol'])
@@ -14829,7 +14679,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker203 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -14870,7 +14720,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker204 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(yang.adata.MNode):
     routing_protocol: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol
 
@@ -14881,7 +14731,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'routing_protocol':
             return iter(self.routing_protocol)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'routing-protocols'])
@@ -14897,7 +14746,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker205 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(yang.adata.MNode):
     access_priority: ?u64
 
@@ -14908,7 +14757,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     def _get_attr(self, name: str) -> ?value:
         if name == 'access_priority':
             return self.access_priority
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'availability'])
@@ -14924,7 +14772,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker206 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(yang.adata.MNode):
     vpn_policy_id: ?str
     vpn_id: ?str
@@ -14943,7 +14791,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.vpn_id
         if name == 'site_role':
             return self.site_role
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access', 'vpn-attachment'])
@@ -14959,7 +14806,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker207 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(yang.adata.MNode):
     site_network_access_id: str
     site_network_access_type: ?Identityref
@@ -15014,7 +14861,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return self.availability
         if name == 'vpn_attachment':
             return self.vpn_attachment
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses', 'site-network-access'])
@@ -15027,7 +14873,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker208 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
     mut def __init__(self, elements=[]):
@@ -15074,7 +14920,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_ne
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker209 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.MNode):
     site_network_access: ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access
 
@@ -15085,7 +14931,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'site_network_access':
             return iter(self.site_network_access)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site', 'site-network-accesses'])
@@ -15101,7 +14946,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker210 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     site_id: str
     requested_site_start: ?str
@@ -15168,7 +15013,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
             return self.routing_protocols
         if name == 'site_network_accesses':
             return self.site_network_accesses
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites__site')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site'])
@@ -15181,7 +15025,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker211 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
     mut def __init__(self, elements=[]):
@@ -15228,7 +15072,7 @@ extension ietf_l3vpn_svc__l3vpn_svc__sites__site(Iterable[ietf_l3vpn_svc__l3vpn_
     def __iter__(self) -> Iterator[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker212 = None
 class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
     site: ietf_l3vpn_svc__l3vpn_svc__sites__site
 
@@ -15239,7 +15083,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'site':
             return iter(self.site)
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc__sites')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites'])
@@ -15255,7 +15098,7 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker213 = None
 class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
     vpn_profiles: ietf_l3vpn_svc__l3vpn_svc__vpn_profiles
     vpn_services: ietf_l3vpn_svc__l3vpn_svc__vpn_services
@@ -15274,7 +15117,6 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
             return self.vpn_services
         if name == 'sites':
             return self.sites
-        raise ValueError('Attribute {name} not found in ietf_l3vpn_svc__l3vpn_svc')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-l3vpn-svc:l3vpn-svc'])
@@ -15290,7 +15132,7 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
         return ietf_l3vpn_svc__l3vpn_svc.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker214 = None
 class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -15301,7 +15143,6 @@ class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra', 'router', 'feature-flags'])
@@ -15317,7 +15158,7 @@ class netinfra__netinfra__router__feature_flags(yang.adata.MNode):
         return netinfra__netinfra__router__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker215 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?u64
@@ -15356,7 +15197,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
             return self.approval_required
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra', 'router'])
@@ -15369,7 +15209,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker216 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -15422,7 +15262,7 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker217 = None
 class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     left_router: str
     left_interface: str
@@ -15449,7 +15289,6 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
             return self.right_interface
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__backbone_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra', 'backbone-link'])
@@ -15462,7 +15301,7 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__backbone_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker218 = None
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -15514,7 +15353,7 @@ extension netinfra__netinfra__backbone_link(Iterable[netinfra__netinfra__backbon
     def __iter__(self) -> Iterator[netinfra__netinfra__backbone_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker219 = None
 class netinfra__netinfra(yang.adata.MNode):
     router: netinfra__netinfra__router
     backbone_link: netinfra__netinfra__backbone_link
@@ -15529,7 +15368,6 @@ class netinfra__netinfra(yang.adata.MNode):
             return iter(self.router)
         if name == 'backbone_link':
             return iter(self.backbone_link)
-        raise ValueError('Attribute {name} not found in netinfra__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra'])
@@ -15545,7 +15383,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker220 = None
 class root(yang.adata.MNode):
     tmf_store: stratoweave_tmf__tmf_store
     l3vpn_svc: ietf_l3vpn_svc__l3vpn_svc
@@ -15564,7 +15402,6 @@ class root(yang.adata.MNode):
             return self.l3vpn_svc
         if name == 'netinfra':
             return self.netinfra
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/sorespo/layers/y_1.act
+++ b/src/sorespo/layers/y_1.act
@@ -823,7 +823,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
@@ -834,7 +834,6 @@ class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'router', 'feature-flags'])
@@ -850,7 +849,7 @@ class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
         return netinfra_inter__netinfra__router__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
     asn: u64
     ipv4_address: str
@@ -869,7 +868,6 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return self.ipv4_address
         if name == 'ipv6_address':
             return self.ipv6_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'router', 'base-config'])
@@ -885,7 +883,7 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
         return netinfra_inter__netinfra__router__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     vpn_id: str
     ebgp_customer_address: list[str]
@@ -900,7 +898,6 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
             return self.vpn_id
         if name == 'ebgp_customer_address':
             return self.ebgp_customer_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__l3vpn_vrf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'router', 'l3vpn-vrf'])
@@ -913,7 +910,7 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
     mut def __init__(self, elements=[]):
@@ -954,7 +951,7 @@ extension netinfra_inter__netinfra__router__l3vpn_vrf(Iterable[netinfra_inter__n
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__router__l3vpn_vrf_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: u64
@@ -997,7 +994,6 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
             return self.base_config
         if name == 'l3vpn_vrf':
             return iter(self.l3vpn_vrf)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'router'])
@@ -1010,7 +1006,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -1061,7 +1057,7 @@ extension netinfra_inter__netinfra__router(Iterable[netinfra_inter__netinfra__ro
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     left_router: str
     left_interface: str
@@ -1088,7 +1084,6 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
             return self.right_interface
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__backbone_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'backbone-link'])
@@ -1101,7 +1096,7 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__backbone_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker8 = None
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -1153,7 +1148,7 @@ extension netinfra_inter__netinfra__backbone_link(Iterable[netinfra_inter__netin
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__backbone_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker9 = None
 class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     name: str
     ipv4_address: str
@@ -1168,7 +1163,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
             return self.name
         if name == 'ipv4_address':
             return self.ipv4_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__ibgp_fullmesh__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'ibgp-fullmesh', 'router'])
@@ -1181,7 +1175,7 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker10 = None
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
     mut def __init__(self, elements=[]):
@@ -1223,7 +1217,7 @@ extension netinfra_inter__netinfra__ibgp_fullmesh__router(Iterable[netinfra_inte
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker11 = None
 class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     asn: u64
     authentication_key: str
@@ -1242,7 +1236,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
             return self.authentication_key
         if name == 'router':
             return iter(self.router)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__ibgp_fullmesh')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra', 'ibgp-fullmesh'])
@@ -1255,7 +1248,7 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__ibgp_fullmesh_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker12 = None
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
     mut def __init__(self, elements=[]):
@@ -1297,7 +1290,7 @@ extension netinfra_inter__netinfra__ibgp_fullmesh(Iterable[netinfra_inter__netin
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__ibgp_fullmesh_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker13 = None
 class netinfra_inter__netinfra(yang.adata.MNode):
     router: netinfra_inter__netinfra__router
     backbone_link: netinfra_inter__netinfra__backbone_link
@@ -1316,7 +1309,6 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return iter(self.backbone_link)
         if name == 'ibgp_fullmesh':
             return iter(self.ibgp_fullmesh)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra-inter:netinfra'])
@@ -1332,7 +1324,7 @@ class netinfra_inter__netinfra(yang.adata.MNode):
         return netinfra_inter__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
     as_number: u64
 
@@ -1343,7 +1335,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'as_number':
             return self.as_number
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn__endpoint__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn-inter:l3vpns', 'l3vpn', 'endpoint', 'bgp'])
@@ -1362,7 +1353,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
         raise Exception('Unreachable in l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.copy()')
 
 
-_breaker = 1
+_breaker15 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface: str
@@ -1410,7 +1401,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
             return self.ipv4_prefix_length
         if name == 'bgp':
             return self.bgp
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn__endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn-inter:l3vpns', 'l3vpn', 'endpoint'])
@@ -1423,7 +1413,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1473,7 +1463,7 @@ extension l3vpn_inter__l3vpns__l3vpn__endpoint(Iterable[l3vpn_inter__l3vpns__l3v
     def __iter__(self) -> Iterator[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1492,7 +1482,6 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
             return self.description
         if name == 'endpoint':
             return iter(self.endpoint)
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn-inter:l3vpns', 'l3vpn'])
@@ -1505,7 +1494,7 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn_inter__l3vpns__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker18 = None
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1548,7 +1537,7 @@ extension l3vpn_inter__l3vpns__l3vpn(Iterable[l3vpn_inter__l3vpns__l3vpn_entry])
     def __iter__(self) -> Iterator[l3vpn_inter__l3vpns__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker19 = None
 class l3vpn_inter__l3vpns(yang.adata.MNode):
     l3vpn: l3vpn_inter__l3vpns__l3vpn
 
@@ -1559,7 +1548,6 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l3vpn':
             return iter(self.l3vpn)
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn-inter:l3vpns'])
@@ -1575,7 +1563,7 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
         return l3vpn_inter__l3vpns.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker20 = None
 class root(yang.adata.MNode):
     netinfra: netinfra_inter__netinfra
     l3vpns: l3vpn_inter__l3vpns
@@ -1590,7 +1578,6 @@ class root(yang.adata.MNode):
             return self.netinfra
         if name == 'l3vpns':
             return self.l3vpns
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/src/sorespo/layers/y_1_loose.act
+++ b/src/sorespo/layers/y_1_loose.act
@@ -823,7 +823,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -834,7 +834,6 @@ class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'router', 'feature-flags'])
@@ -850,7 +849,7 @@ class netinfra_inter__netinfra__router__feature_flags(yang.adata.MNode):
         return netinfra_inter__netinfra__router__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
     asn: ?u64
     ipv4_address: ?str
@@ -869,7 +868,6 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return self.ipv4_address
         if name == 'ipv6_address':
             return self.ipv6_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'router', 'base-config'])
@@ -885,7 +883,7 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
         return netinfra_inter__netinfra__router__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     vpn_id: str
     ebgp_customer_address: list[str]
@@ -900,7 +898,6 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
             return self.vpn_id
         if name == 'ebgp_customer_address':
             return self.ebgp_customer_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router__l3vpn_vrf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'router', 'l3vpn-vrf'])
@@ -913,7 +910,7 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
     mut def __init__(self, elements=[]):
@@ -954,7 +951,7 @@ extension netinfra_inter__netinfra__router__l3vpn_vrf(Iterable[netinfra_inter__n
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__router__l3vpn_vrf_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?u64
@@ -997,7 +994,6 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
             return self.base_config
         if name == 'l3vpn_vrf':
             return iter(self.l3vpn_vrf)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'router'])
@@ -1010,7 +1006,7 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -1061,7 +1057,7 @@ extension netinfra_inter__netinfra__router(Iterable[netinfra_inter__netinfra__ro
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     left_router: str
     left_interface: str
@@ -1088,7 +1084,6 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
             return self.right_interface
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__backbone_link')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'backbone-link'])
@@ -1101,7 +1096,7 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__backbone_link_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker8 = None
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
     mut def __init__(self, elements=[]):
@@ -1153,7 +1148,7 @@ extension netinfra_inter__netinfra__backbone_link(Iterable[netinfra_inter__netin
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__backbone_link_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker9 = None
 class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     name: str
     ipv4_address: ?str
@@ -1168,7 +1163,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
             return self.name
         if name == 'ipv4_address':
             return self.ipv4_address
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__ibgp_fullmesh__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'ibgp-fullmesh', 'router'])
@@ -1181,7 +1175,7 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker10 = None
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
     mut def __init__(self, elements=[]):
@@ -1224,7 +1218,7 @@ extension netinfra_inter__netinfra__ibgp_fullmesh__router(Iterable[netinfra_inte
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker11 = None
 class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     asn: u64
     authentication_key: ?str
@@ -1243,7 +1237,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
             return self.authentication_key
         if name == 'router':
             return iter(self.router)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra__ibgp_fullmesh')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra', 'ibgp-fullmesh'])
@@ -1256,7 +1249,7 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra_inter__netinfra__ibgp_fullmesh_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker12 = None
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
     mut def __init__(self, elements=[]):
@@ -1299,7 +1292,7 @@ extension netinfra_inter__netinfra__ibgp_fullmesh(Iterable[netinfra_inter__netin
     def __iter__(self) -> Iterator[netinfra_inter__netinfra__ibgp_fullmesh_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker13 = None
 class netinfra_inter__netinfra(yang.adata.MNode):
     router: netinfra_inter__netinfra__router
     backbone_link: netinfra_inter__netinfra__backbone_link
@@ -1318,7 +1311,6 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return iter(self.backbone_link)
         if name == 'ibgp_fullmesh':
             return iter(self.ibgp_fullmesh)
-        raise ValueError('Attribute {name} not found in netinfra_inter__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra-inter:netinfra'])
@@ -1334,7 +1326,7 @@ class netinfra_inter__netinfra(yang.adata.MNode):
         return netinfra_inter__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
     as_number: ?u64
 
@@ -1345,7 +1337,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'as_number':
             return self.as_number
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn__endpoint__bgp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn-inter:l3vpns', 'l3vpn', 'endpoint', 'bgp'])
@@ -1364,7 +1355,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
         raise Exception('Unreachable in l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.copy()')
 
 
-_breaker = 1
+_breaker15 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface: str
@@ -1413,7 +1404,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
             return self.ipv4_prefix_length
         if name == 'bgp':
             return self.bgp
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn__endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn-inter:l3vpns', 'l3vpn', 'endpoint'])
@@ -1426,7 +1416,7 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1480,7 +1470,7 @@ extension l3vpn_inter__l3vpns__l3vpn__endpoint(Iterable[l3vpn_inter__l3vpns__l3v
     def __iter__(self) -> Iterator[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1499,7 +1489,6 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
             return self.description
         if name == 'endpoint':
             return iter(self.endpoint)
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns__l3vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn-inter:l3vpns', 'l3vpn'])
@@ -1512,7 +1501,7 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn_inter__l3vpns__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker18 = None
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1555,7 +1544,7 @@ extension l3vpn_inter__l3vpns__l3vpn(Iterable[l3vpn_inter__l3vpns__l3vpn_entry])
     def __iter__(self) -> Iterator[l3vpn_inter__l3vpns__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker19 = None
 class l3vpn_inter__l3vpns(yang.adata.MNode):
     l3vpn: l3vpn_inter__l3vpns__l3vpn
 
@@ -1566,7 +1555,6 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l3vpn':
             return iter(self.l3vpn)
-        raise ValueError('Attribute {name} not found in l3vpn_inter__l3vpns')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn-inter:l3vpns'])
@@ -1582,7 +1570,7 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
         return l3vpn_inter__l3vpns.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker20 = None
 class root(yang.adata.MNode):
     netinfra: netinfra_inter__netinfra
     l3vpns: l3vpn_inter__l3vpns
@@ -1597,7 +1585,6 @@ class root(yang.adata.MNode):
             return self.netinfra
         if name == 'l3vpns':
             return self.l3vpns
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/sorespo/layers/y_2.act
+++ b/src/sorespo/layers/y_2.act
@@ -1035,7 +1035,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1054,7 +1054,6 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address', 'initial-credentials'])
@@ -1067,7 +1066,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1114,7 +1113,7 @@ extension stratoweave_rfs__device__address__initial_credentials(Iterable[stratow
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     name: str
     address: str
@@ -1137,7 +1136,6 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
             return self.port
         if name == 'initial_credentials':
             return iter(self.initial_credentials)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address'])
@@ -1150,7 +1148,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -1194,7 +1192,7 @@ extension stratoweave_rfs__device__address(Iterable[stratoweave_rfs__device__add
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
@@ -1209,7 +1207,6 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
             return self.key
         if name == 'private_key':
             return self.private_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials__key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials', 'key'])
@@ -1222,7 +1219,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -1265,7 +1262,7 @@ extension stratoweave_rfs__device__credentials__key(Iterable[stratoweave_rfs__de
     def __iter__(self) -> Iterator[stratoweave_rfs__device__credentials__key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_rfs__device__credentials(yang.adata.MNode):
     username: str
     password: ?str
@@ -1284,7 +1281,6 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return self.password
         if name == 'key':
             return iter(self.key)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials'])
@@ -1300,7 +1296,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1319,7 +1315,6 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'initial-credentials'])
@@ -1332,7 +1327,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1379,7 +1374,7 @@ extension stratoweave_rfs__device__initial_credentials(Iterable[stratoweave_rfs_
     def __iter__(self) -> Iterator[stratoweave_rfs__device__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: str
@@ -1402,7 +1397,6 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
             return self.revision
         if name == 'feature':
             return self.feature
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock__module')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock', 'module'])
@@ -1415,7 +1409,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -1459,7 +1453,7 @@ extension stratoweave_rfs__device__mock__module(Iterable[stratoweave_rfs__device
     def __iter__(self) -> Iterator[stratoweave_rfs__device__mock__module_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_rfs__device__mock(yang.adata.MNode):
     enabled: bool
     preset: list[str]
@@ -1478,7 +1472,6 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return self.preset
         if name == 'module':
             return iter(self.module)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock'])
@@ -1494,7 +1487,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: bool
 
@@ -1505,7 +1498,6 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'connection':
             return self.connection
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__debug')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'debug'])
@@ -1521,7 +1513,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
@@ -1532,7 +1524,6 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'feature-flags'])
@@ -1548,7 +1539,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1595,7 +1586,6 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
             return self.debug
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device'])
@@ -1608,7 +1598,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1656,7 +1646,7 @@ extension stratoweave_rfs__device(Iterable[stratoweave_rfs__device_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     role: ?str
     ipv4_address: str
@@ -1683,7 +1673,6 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
             return self.asn
         if name == 'ibgp_authentication_key':
             return self.ibgp_authentication_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:base-config'])
@@ -1699,7 +1688,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
     device: str
     interface: str
@@ -1714,7 +1703,6 @@ class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return self.device
         if name == 'interface':
             return self.interface
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface__remote')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface', 'remote'])
@@ -1730,7 +1718,7 @@ class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
         return stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
     pps: ?u64
 
@@ -1741,7 +1729,6 @@ class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'pps':
             return self.pps
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface__dynstate')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface', 'dynstate'])
@@ -1757,7 +1744,7 @@ class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
         return stratoweave_rfs__rfs__backbone_interface__dynstate.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     name: str
     ipv4_address: ?str
@@ -1766,9 +1753,8 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     ipv6_prefix_length: ?u64
     remote: stratoweave_rfs__rfs__backbone_interface__remote
     monitor_traffic: bool
-    dynstate: stratoweave_rfs__rfs__backbone_interface__dynstate
 
-    mut def __init__(self, name: str, remote: stratoweave_rfs__rfs__backbone_interface__remote, ipv4_address: ?str, ipv4_prefix_length: ?u64=None, ipv6_address: ?str, ipv6_prefix_length: ?u64, monitor_traffic: ?bool=None, dynstate: ?stratoweave_rfs__rfs__backbone_interface__dynstate=None):
+    mut def __init__(self, name: str, remote: stratoweave_rfs__rfs__backbone_interface__remote, ipv4_address: ?str, ipv4_prefix_length: ?u64=None, ipv6_address: ?str, ipv6_prefix_length: ?u64, monitor_traffic: ?bool=None):
         self._ns = 'http://example.com/sorespo-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
@@ -1777,7 +1763,6 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
         self.ipv6_prefix_length = ipv6_prefix_length
         self.remote = remote
         self.monitor_traffic = monitor_traffic if monitor_traffic is not None else False
-        self.dynstate = dynstate if dynstate is not None else stratoweave_rfs__rfs__backbone_interface__dynstate()
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
@@ -1794,22 +1779,19 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
             return self.remote
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        if name == 'dynstate':
-            return self.dynstate
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs__backbone_interface_entry:
-        return stratoweave_rfs__rfs__backbone_interface_entry(name=n.get_str(yang.gdata.Id(NS_sorespo_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-address')), ipv4_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-prefix-length')), ipv6_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-address')), ipv6_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-prefix-length')), remote=stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(n.get_cnt(yang.gdata.Id(NS_sorespo_rfs, 'remote'))), monitor_traffic=n.get_opt_bool(yang.gdata.Id(NS_sorespo_rfs, 'monitor-traffic')), dynstate=stratoweave_rfs__rfs__backbone_interface__dynstate.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_sorespo_rfs, 'dynstate'))))
+        return stratoweave_rfs__rfs__backbone_interface_entry(name=n.get_str(yang.gdata.Id(NS_sorespo_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-address')), ipv4_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-prefix-length')), ipv6_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-address')), ipv6_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-prefix-length')), remote=stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(n.get_cnt(yang.gdata.Id(NS_sorespo_rfs, 'remote'))), monitor_traffic=n.get_opt_bool(yang.gdata.Id(NS_sorespo_rfs, 'monitor-traffic')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__backbone_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__backbone_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1861,7 +1843,7 @@ extension stratoweave_rfs__rfs__backbone_interface(Iterable[stratoweave_rfs__rfs
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__backbone_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     address: str
     asn: u64
@@ -1880,7 +1862,6 @@ class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
             return self.asn
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__ibgp_neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:ibgp-neighbor'])
@@ -1893,7 +1874,7 @@ class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__ibgp_neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker23 = None
 class stratoweave_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__ibgp_neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -1936,7 +1917,7 @@ extension stratoweave_rfs__rfs__ibgp_neighbor(Iterable[stratoweave_rfs__rfs__ibg
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__ibgp_neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker24 = None
 class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1963,7 +1944,6 @@ class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
             return self.router_id
         if name == 'asn':
             return self.asn
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__vrf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:vrf'])
@@ -1976,7 +1956,7 @@ class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__vrf_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker25 = None
 class stratoweave_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -2022,7 +2002,7 @@ extension stratoweave_rfs__rfs__vrf(Iterable[stratoweave_rfs__rfs__vrf_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__vrf_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker26 = None
 class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -2049,7 +2029,6 @@ class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
             return self.ipv4_address
         if name == 'ipv4_prefix_length':
             return self.ipv4_prefix_length
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__vrf_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:vrf-interface'])
@@ -2062,7 +2041,7 @@ class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__vrf_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class stratoweave_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__vrf_interface_entry]
     mut def __init__(self, elements=[]):
@@ -2110,7 +2089,7 @@ extension stratoweave_rfs__rfs__vrf_interface(Iterable[stratoweave_rfs__rfs__vrf
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__vrf_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     vrf: str
     address: str
@@ -2141,7 +2120,6 @@ class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
             return self.description
         if name == 'authentication_key':
             return self.authentication_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__ebgp_customer')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:ebgp-customer'])
@@ -2154,7 +2132,7 @@ class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__ebgp_customer_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker29 = None
 class stratoweave_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2203,7 +2181,7 @@ extension stratoweave_rfs__rfs__ebgp_customer(Iterable[stratoweave_rfs__rfs__ebg
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__ebgp_customer_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker30 = None
 class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     name: str
     base_config: stratoweave_rfs__rfs__base_config
@@ -2238,7 +2216,6 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
             return iter(self.vrf_interface)
         if name == 'ebgp_customer':
             return iter(self.ebgp_customer)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs'])
@@ -2251,7 +2228,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2293,7 +2270,7 @@ extension stratoweave_rfs__rfs(Iterable[stratoweave_rfs__rfs_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -2308,7 +2285,6 @@ class root(yang.adata.MNode):
             return iter(self.device)
         if name == 'rfs':
             return iter(self.rfs)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/src/sorespo/layers/y_2_loose.act
+++ b/src/sorespo/layers/y_2_loose.act
@@ -1035,7 +1035,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1054,7 +1054,6 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'address', 'initial-credentials'])
@@ -1067,7 +1066,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1114,7 +1113,7 @@ extension stratoweave_rfs__device__address__initial_credentials(Iterable[stratow
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     name: str
     address: ?str
@@ -1137,7 +1136,6 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
             return self.port
         if name == 'initial_credentials':
             return iter(self.initial_credentials)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'address'])
@@ -1150,7 +1148,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -1195,7 +1193,7 @@ extension stratoweave_rfs__device__address(Iterable[stratoweave_rfs__device__add
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
@@ -1210,7 +1208,6 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
             return self.key
         if name == 'private_key':
             return self.private_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials__key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'credentials', 'key'])
@@ -1223,7 +1220,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -1266,7 +1263,7 @@ extension stratoweave_rfs__device__credentials__key(Iterable[stratoweave_rfs__de
     def __iter__(self) -> Iterator[stratoweave_rfs__device__credentials__key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_rfs__device__credentials(yang.adata.MNode):
     username: ?str
     password: ?str
@@ -1285,7 +1282,6 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return self.password
         if name == 'key':
             return iter(self.key)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'credentials'])
@@ -1301,7 +1297,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1320,7 +1316,6 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'initial-credentials'])
@@ -1333,7 +1328,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1380,7 +1375,7 @@ extension stratoweave_rfs__device__initial_credentials(Iterable[stratoweave_rfs_
     def __iter__(self) -> Iterator[stratoweave_rfs__device__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: ?str
@@ -1403,7 +1398,6 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
             return self.revision
         if name == 'feature':
             return self.feature
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock__module')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'module'])
@@ -1416,7 +1410,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -1461,7 +1455,7 @@ extension stratoweave_rfs__device__mock__module(Iterable[stratoweave_rfs__device
     def __iter__(self) -> Iterator[stratoweave_rfs__device__mock__module_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_rfs__device__mock(yang.adata.MNode):
     enabled: ?bool
     preset: list[str]
@@ -1480,7 +1474,6 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return self.preset
         if name == 'module':
             return iter(self.module)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock'])
@@ -1496,7 +1489,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: ?bool
 
@@ -1507,7 +1500,6 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'connection':
             return self.connection
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__debug')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'debug'])
@@ -1523,7 +1515,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1534,7 +1526,6 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'feature-flags'])
@@ -1550,7 +1541,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1597,7 +1588,6 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
             return self.debug
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device'])
@@ -1610,7 +1600,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1657,7 +1647,7 @@ extension stratoweave_rfs__device(Iterable[stratoweave_rfs__device_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     role: ?str
     ipv4_address: ?str
@@ -1684,7 +1674,6 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
             return self.asn
         if name == 'ibgp_authentication_key':
             return self.ibgp_authentication_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:base-config'])
@@ -1700,7 +1689,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
     device: ?str
     interface: ?str
@@ -1715,7 +1704,6 @@ class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return self.device
         if name == 'interface':
             return self.interface
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface__remote')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface', 'remote'])
@@ -1731,7 +1719,7 @@ class stratoweave_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
         return stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
     pps: ?u64
 
@@ -1742,7 +1730,6 @@ class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'pps':
             return self.pps
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface__dynstate')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface', 'dynstate'])
@@ -1758,7 +1745,7 @@ class stratoweave_rfs__rfs__backbone_interface__dynstate(yang.adata.MNode):
         return stratoweave_rfs__rfs__backbone_interface__dynstate.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     name: str
     ipv4_address: ?str
@@ -1767,9 +1754,8 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     ipv6_prefix_length: ?u64
     remote: stratoweave_rfs__rfs__backbone_interface__remote
     monitor_traffic: ?bool
-    dynstate: stratoweave_rfs__rfs__backbone_interface__dynstate
 
-    mut def __init__(self, name: str, ipv4_address: ?str, ipv4_prefix_length: ?u64, ipv6_address: ?str, ipv6_prefix_length: ?u64, remote: ?stratoweave_rfs__rfs__backbone_interface__remote=None, monitor_traffic: ?bool, dynstate: ?stratoweave_rfs__rfs__backbone_interface__dynstate=None):
+    mut def __init__(self, name: str, ipv4_address: ?str, ipv4_prefix_length: ?u64, ipv6_address: ?str, ipv6_prefix_length: ?u64, remote: ?stratoweave_rfs__rfs__backbone_interface__remote=None, monitor_traffic: ?bool):
         self._ns = 'http://example.com/sorespo-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
@@ -1778,7 +1764,6 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
         self.ipv6_prefix_length = ipv6_prefix_length
         self.remote = remote if remote is not None else stratoweave_rfs__rfs__backbone_interface__remote()
         self.monitor_traffic = monitor_traffic
-        self.dynstate = dynstate if dynstate is not None else stratoweave_rfs__rfs__backbone_interface__dynstate()
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
@@ -1795,22 +1780,19 @@ class stratoweave_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
             return self.remote
         if name == 'monitor_traffic':
             return self.monitor_traffic
-        if name == 'dynstate':
-            return self.dynstate
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__backbone_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:backbone-interface'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs__backbone_interface_entry:
-        return stratoweave_rfs__rfs__backbone_interface_entry(name=n.get_str(yang.gdata.Id(NS_sorespo_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-address')), ipv4_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-prefix-length')), ipv6_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-address')), ipv6_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-prefix-length')), remote=stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_sorespo_rfs, 'remote'))), monitor_traffic=n.get_opt_bool(yang.gdata.Id(NS_sorespo_rfs, 'monitor-traffic')), dynstate=stratoweave_rfs__rfs__backbone_interface__dynstate.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_sorespo_rfs, 'dynstate'))))
+        return stratoweave_rfs__rfs__backbone_interface_entry(name=n.get_str(yang.gdata.Id(NS_sorespo_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-address')), ipv4_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv4-prefix-length')), ipv6_address=n.get_opt_str(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-address')), ipv6_prefix_length=n.get_opt_u64(yang.gdata.Id(NS_sorespo_rfs, 'ipv6-prefix-length')), remote=stratoweave_rfs__rfs__backbone_interface__remote.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_sorespo_rfs, 'remote'))), monitor_traffic=n.get_opt_bool(yang.gdata.Id(NS_sorespo_rfs, 'monitor-traffic')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__backbone_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__backbone_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1861,7 +1843,7 @@ extension stratoweave_rfs__rfs__backbone_interface(Iterable[stratoweave_rfs__rfs
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__backbone_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     address: str
     asn: ?u64
@@ -1880,7 +1862,6 @@ class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
             return self.asn
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__ibgp_neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:ibgp-neighbor'])
@@ -1893,7 +1874,7 @@ class stratoweave_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__ibgp_neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker23 = None
 class stratoweave_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__ibgp_neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -1938,7 +1919,7 @@ extension stratoweave_rfs__rfs__ibgp_neighbor(Iterable[stratoweave_rfs__rfs__ibg
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__ibgp_neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker24 = None
 class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1965,7 +1946,6 @@ class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
             return self.router_id
         if name == 'asn':
             return self.asn
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__vrf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:vrf'])
@@ -1978,7 +1958,7 @@ class stratoweave_rfs__rfs__vrf_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__vrf_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker25 = None
 class stratoweave_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -2027,7 +2007,7 @@ extension stratoweave_rfs__rfs__vrf(Iterable[stratoweave_rfs__rfs__vrf_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__vrf_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker26 = None
 class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -2054,7 +2034,6 @@ class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
             return self.ipv4_address
         if name == 'ipv4_prefix_length':
             return self.ipv4_prefix_length
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__vrf_interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:vrf-interface'])
@@ -2067,7 +2046,7 @@ class stratoweave_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__vrf_interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class stratoweave_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__vrf_interface_entry]
     mut def __init__(self, elements=[]):
@@ -2116,7 +2095,7 @@ extension stratoweave_rfs__rfs__vrf_interface(Iterable[stratoweave_rfs__rfs__vrf
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__vrf_interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     vrf: str
     address: str
@@ -2147,7 +2126,6 @@ class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
             return self.description
         if name == 'authentication_key':
             return self.authentication_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__ebgp_customer')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'sorespo-rfs:ebgp-customer'])
@@ -2160,7 +2138,7 @@ class stratoweave_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__ebgp_customer_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker29 = None
 class stratoweave_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2212,7 +2190,7 @@ extension stratoweave_rfs__rfs__ebgp_customer(Iterable[stratoweave_rfs__rfs__ebg
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__ebgp_customer_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker30 = None
 class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     name: str
     base_config: stratoweave_rfs__rfs__base_config
@@ -2247,7 +2225,6 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
             return iter(self.vrf_interface)
         if name == 'ebgp_customer':
             return iter(self.ebgp_customer)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs'])
@@ -2260,7 +2237,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2301,7 +2278,7 @@ extension stratoweave_rfs__rfs(Iterable[stratoweave_rfs__rfs_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -2316,7 +2293,6 @@ class root(yang.adata.MNode):
             return iter(self.device)
         if name == 'rfs':
             return iter(self.rfs)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/sorespo/layers/y_3.act
+++ b/src/sorespo/layers/y_3.act
@@ -123,7 +123,7 @@ NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'
 NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
@@ -138,7 +138,6 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
             return self.name
         if name == 'modset_id':
             return self.modset_id
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-device:devices', 'device'])
@@ -151,7 +150,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -194,7 +193,7 @@ extension stratoweave_device__devices__device(Iterable[stratoweave_device__devic
     def __iter__(self) -> Iterator[stratoweave_device__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
@@ -205,7 +204,6 @@ class stratoweave_device__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-device:devices'])
@@ -221,7 +219,7 @@ class stratoweave_device__devices(yang.adata.MNode):
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
@@ -232,7 +230,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'devices':
             return self.devices
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/src/sorespo/layers/y_3_loose.act
+++ b/src/sorespo/layers/y_3_loose.act
@@ -123,7 +123,7 @@ NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'
 NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
@@ -138,7 +138,6 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
             return self.name
         if name == 'modset_id':
             return self.modset_id
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-device:devices', 'device'])
@@ -151,7 +150,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -194,7 +193,7 @@ extension stratoweave_device__devices__device(Iterable[stratoweave_device__devic
     def __iter__(self) -> Iterator[stratoweave_device__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
@@ -205,7 +204,6 @@ class stratoweave_device__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-device:devices'])
@@ -221,7 +219,7 @@ class stratoweave_device__devices(yang.adata.MNode):
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
@@ -232,7 +230,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'devices':
             return self.devices
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)


### PR DESCRIPTION
acton-yang: Regen adata to avoid redefining module constants (_breaker*).
acton-yang: Reorder top-level module docstrings
stratoweave: Filter out dynstate/memory attributes from transform adata