### PR TITLE
Bump containerlab to 0.76.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/containerlab/devcontainer-dood-slim:0.69.3
+FROM ghcr.io/srl-labs/containerlab/devcontainer-dood-slim:0.76.1
 
 RUN sudo apt-get update \
  && sudo apt-get install -qy git-lfs gdb

--- a/.devcontainer/docker-in-docker/Dockerfile
+++ b/.devcontainer/docker-in-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/containerlab/devcontainer-dind-slim:0.69.3
+FROM ghcr.io/srl-labs/containerlab/devcontainer-dind-slim:0.76.1
 
 RUN sudo apt-get update \
  && sudo apt-get install -qy git-lfs gdb

--- a/test/common/clab.mk
+++ b/test/common/clab.mk
@@ -8,7 +8,7 @@ else ifeq (true,$(CODESPACES))
 CLAB_BIN:=containerlab
 else
 
-CLAB_VERSION?=0.69.3
+CLAB_VERSION?=0.76.1
 CLAB_CONTAINER_IMAGE?=ghcr.io/srl-labs/clab:$(CLAB_VERSION)
 CLAB_BIN:=docker run --rm $(INTERACTIVE) --privileged \
     --network host \


### PR DESCRIPTION
Also fixes Codespaces, where an outdated base image couldn't `apt-get update` due to expired keys.