### PR TITLE
Running apt in non-interactive mode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
 FROM ghcr.io/srl-labs/containerlab/devcontainer-dood-slim:0.76.1
 
 RUN sudo apt-get update \
- && sudo apt-get install -qy git-lfs gdb
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy git-lfs gdb
 RUN sudo install -m 0755 -d /etc/apt/keyrings \
  && sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg \
  && sudo chmod a+r /etc/apt/keyrings/acton.asc \
  && echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=$(dpkg --print-architecture)] http://aptip.acton-lang.io/ tip main" | sudo tee -a /etc/apt/sources.list.d/acton.list \
  && sudo apt-get update \
- && sudo apt-get install -qy acton
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy acton

--- a/.devcontainer/docker-in-docker/Dockerfile
+++ b/.devcontainer/docker-in-docker/Dockerfile
@@ -1,10 +1,10 @@
 FROM ghcr.io/srl-labs/containerlab/devcontainer-dind-slim:0.76.1
 
 RUN sudo apt-get update \
- && sudo apt-get install -qy git-lfs gdb
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy git-lfs gdb
 RUN sudo install -m 0755 -d /etc/apt/keyrings \
  && sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg \
  && sudo chmod a+r /etc/apt/keyrings/acton.asc \
  && echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=$(dpkg --print-architecture)] http://aptip.acton-lang.io/ tip main" | sudo tee -a /etc/apt/sources.list.d/acton.list \
  && sudo apt-get update \
- && sudo apt-get install -qy acton
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy acton

--- a/test/common/Dockerfile.sweave
+++ b/test/common/Dockerfile.sweave
@@ -3,4 +3,4 @@ ARG http_proxy=${http_proxy}
 ARG https_proxy=${https_proxy}
 
 RUN apt-get update \
- && apt-get install -qy ssh sshpass gdb
+ && DEBIAN_FRONTEND=noninteractive apt-get install -qy ssh sshpass gdb

--- a/test/quicklab-notconf/Dockerfile.otron
+++ b/test/quicklab-notconf/Dockerfile.otron
@@ -1,4 +1,4 @@
 FROM debian
 
 RUN apt-get update \
- && apt-get install -qy ssh sshpass gdb
+ && DEBIAN_FRONTEND=noninteractive apt-get install -qy ssh sshpass gdb


### PR DESCRIPTION
It removes many warning messages when building the containers