### PR TITLE
Fix colima (macOS) context override

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/containerlab/devcontainer-dood-slim:0.76.1
+FROM ghcr.io/srl-labs/containerlab/devcontainer-dood-slim:0.78.0
 
 RUN sudo apt-get update \
  && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy git-lfs gdb

--- a/.devcontainer/docker-in-docker/Dockerfile
+++ b/.devcontainer/docker-in-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/containerlab/devcontainer-dind-slim:0.76.1
+FROM ghcr.io/srl-labs/containerlab/devcontainer-dind-slim:0.78.0
 
 RUN sudo apt-get update \
  && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy git-lfs gdb

--- a/test/common/clab.mk
+++ b/test/common/clab.mk
@@ -12,15 +12,19 @@ else
 
 CLAB_VERSION?=0.76.1
 CLAB_CONTAINER_IMAGE?=ghcr.io/srl-labs/clab:$(CLAB_VERSION)
+# ${HOME}/.docker is mounted (read-only) for registry credentials. On macOS
+# (colima) it may also pick up the colima context from config.json, so we
+# override it with "default" explicitly.
 CLAB_BIN:=docker run --rm $(INTERACTIVE) --privileged \
     --network host \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /var/run/netns:/var/run/netns \
     -v /etc/hosts:/etc/hosts \
     -v /var/lib/docker/containers:/var/lib/docker/containers \
-	-v ${HOME}/.docker:/root/.docker \
+	-v ${HOME}/.docker:/root/.docker:ro \
     --pid="host" \
     -v $(PROJECT_DIR):$(PROJECT_DIR) \
+    -e DOCKER_CONTEXT=default \
     -e IMAGE_PATH=$(IMAGE_PATH) \
     -e WEBUI_IMAGE=$(WEBUI_IMAGE) \
     -e WEBUI_PORT=$(WEBUI_PORT) \

--- a/test/common/clab.mk
+++ b/test/common/clab.mk
@@ -10,7 +10,7 @@ else ifeq (true,$(CODESPACES))
 CLAB_BIN:=containerlab
 else
 
-CLAB_VERSION?=0.76.1
+CLAB_VERSION?=0.78.0
 CLAB_CONTAINER_IMAGE?=ghcr.io/srl-labs/clab:$(CLAB_VERSION)
 # ${HOME}/.docker is mounted (read-only) for registry credentials. On macOS
 # (colima) it may also pick up the colima context from config.json, so we


### PR DESCRIPTION
On macOS + colima the `${HOME}/.docker/config.json` file is set up to use
the "colima" context. We bind mount the same file into the containerlab
container so that containerlab gets access to the registry credentials.
To avoid using the DOCKER_HOST from colima context, we pin to the
default context.