### PR TITLE
Upgrade stratoweave dependency

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -16,8 +16,8 @@ dependencies = {
     ),
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/d310a044061087716f553e1eb44b2a8ab716ad57.zip",
-        hash="N-V-__8AAAyCPADtr3nBUWTfIRg23FmBv3cfjxtaemur5F6M"
+        url="https://github.com/stratoweave/stratoweave/archive/8ec9d51b26cf4c39b2de01297007e0e76337853d.zip",
+        hash="N-V-__8AAN-CPAARiMJOk4nJAaLXkRvIWBYHLk39Sg5yOmZh"
     ),
     "timeseries": (
         repo_url="https://github.com/stratoweave/timeseries",
@@ -26,8 +26,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d71016a3eb2b3a344287bdceaf424ea02e0f1d48.zip",
-        hash="N-V-__8AAGvNJgAzbhqqVATLR5TyP1w1fvW7gw68In9IbpEZ"
+        url="https://github.com/stratoweave/acton-yang/archive/d8d20ea812c7d75843dc44aa05ad97225df70df8.zip",
+        hash="N-V-__8AABj8JgD2jjfBCV3uHrzeIxH6lg9eMMK6yk372ykG"
     )
 }
 zig_dependencies = {}

--- a/spec/Build.act
+++ b/spec/Build.act
@@ -3,18 +3,18 @@ fingerprint = 0xcb43a968b1316986
 dependencies = {
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/d310a044061087716f553e1eb44b2a8ab716ad57.zip",
-        hash="N-V-__8AAAyCPADtr3nBUWTfIRg23FmBv3cfjxtaemur5F6M"
+        url="https://github.com/stratoweave/stratoweave/archive/8ec9d51b26cf4c39b2de01297007e0e76337853d.zip",
+        hash="N-V-__8AAN-CPAARiMJOk4nJAaLXkRvIWBYHLk39Sg5yOmZh"
     ),
     "tmf": (
         repo_url="https://github.com/stratoweave/actmf",
-        url="https://github.com/stratoweave/actmf/archive/5903031420157140d216ef5dc023cf18defef87a.zip",
-        hash="N-V-__8AAPrlBQD3svwCXzHu7mAYkT8pksVMdEmks4d-Ppif"
+        url="https://github.com/stratoweave/actmf/archive/63413d0450dded6fbf8468011b35858eea5625f6.zip",
+        hash="N-V-__8AAPDlBQBd4ILasHDbt0RbaXgSz4au9_H1q7yGVcwy"
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d71016a3eb2b3a344287bdceaf424ea02e0f1d48.zip",
-        hash="N-V-__8AAGvNJgAzbhqqVATLR5TyP1w1fvW7gw68In9IbpEZ"
+        url="https://github.com/stratoweave/acton-yang/archive/d8d20ea812c7d75843dc44aa05ad97225df70df8.zip",
+        hash="N-V-__8AABj8JgD2jjfBCV3uHrzeIxH6lg9eMMK6yk372ykG"
     )
 }
 zig_dependencies = {}


### PR DESCRIPTION
Refreshes Acton package pins after stratoweave/stratoweave@8ec9d51b26cf4c39b2de01297007e0e76337853d landed on main.

This pull request is updated in place when newer stratoweave changes land.