### PR TITLE
Upgrade stratoweave dependency

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -16,8 +16,8 @@ dependencies = {
     ),
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/8ec9d51b26cf4c39b2de01297007e0e76337853d.zip",
-        hash="N-V-__8AAN-CPAARiMJOk4nJAaLXkRvIWBYHLk39Sg5yOmZh"
+        url="https://github.com/stratoweave/stratoweave/archive/b623e7c30400e3916f73e32e4830ab4bc1e99648.zip",
+        hash="N-V-__8AABDePACbQQJom1G9ucDECNe5pBPDWkDl4PRng94U"
     ),
     "timeseries": (
         repo_url="https://github.com/stratoweave/timeseries",

--- a/spec/Build.act
+++ b/spec/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0xcb43a968b1316986
 dependencies = {
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/8ec9d51b26cf4c39b2de01297007e0e76337853d.zip",
-        hash="N-V-__8AAN-CPAARiMJOk4nJAaLXkRvIWBYHLk39Sg5yOmZh"
+        url="https://github.com/stratoweave/stratoweave/archive/b623e7c30400e3916f73e32e4830ab4bc1e99648.zip",
+        hash="N-V-__8AABDePACbQQJom1G9ucDECNe5pBPDWkDl4PRng94U"
     ),
     "tmf": (
         repo_url="https://github.com/stratoweave/actmf",

--- a/src/sorespo/sysspec.act
+++ b/src/sorespo/sysspec.act
@@ -3,9 +3,9 @@
 # WARNING WARNING WARNING WARNING WARNING
 
 import logging
-import lmdb
 
 import stratoweave.app as swapp
+import stratoweave.db as swdb
 import stratoweave.device as swdev
 import stratoweave.adapters.netconf as swna
 import stratoweave.ttt as ttt
@@ -27,7 +27,7 @@ import sorespo.devices.JuniperCRPD_24_4R1_9_oper as dev_JuniperCRPD_24_4R1_9_ope
 import sorespo.devices.NokiaSRLinux_25_3_2 as dev_NokiaSRLinux_25_3_2
 import sorespo.devices.NokiaSRLinux_25_3_2_oper as dev_NokiaSRLinux_25_3_2_oper
 
-def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?lmdb.Db=None):
+def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?swdb.Store=None):
     layer3 = ttt.Layer('3', t_3.get_ttt(None, dev_registry, log_handler), None, db)
     layer2 = ttt.Layer('2', t_2.get_ttt(layer3, dev_registry, log_handler), layer3, db)
     layer1 = ttt.Layer('1', t_1.get_ttt(layer2, dev_registry, log_handler), layer2, db)


### PR DESCRIPTION
Refreshes Acton package pins after stratoweave/stratoweave@b623e7c30400e3916f73e32e4830ab4bc1e99648 landed on main.

This pull request is updated in place when newer stratoweave changes land.