### PR TITLE
Upgrade stratoweave dependency

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -16,8 +16,8 @@ dependencies = {
     ),
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/3980e4b9a3d287c3b35e5a5c6f9343ef3d10c7ad.zip",
-        hash="N-V-__8AAChCPQDTznpYvuAaKFuYLpNyfC0SuZY-7YUDOFiu"
+        url="https://github.com/stratoweave/stratoweave/archive/3264592a58639b206be14253d7ffe69843630905.zip",
+        hash="N-V-__8AANazPQAB06-in1sqFZHQk5qR2pfdi2TWkATiNtgH"
     ),
     "timeseries": (
         repo_url="https://github.com/stratoweave/timeseries",
@@ -26,8 +26,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/880d949ee84b57c93b252547eb725eb1c133d0b8.zip",
-        hash="N-V-__8AAIj_JgDo7AD4YhnwecwNLIXUvCdo_lfgF9yVQJpo"
+        url="https://github.com/stratoweave/acton-yang/archive/c00115cd07db0ee062c85090d4c85f32ef805baa.zip",
+        hash="N-V-__8AACP5JgBjkphmkpC0_Doep_M_Ji8P-z3_5_exsKvl"
     )
 }
 zig_dependencies = {}

--- a/spec/Build.act
+++ b/spec/Build.act
@@ -3,18 +3,18 @@ fingerprint = 0xcb43a968b1316986
 dependencies = {
     "stratoweave": (
         repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/3980e4b9a3d287c3b35e5a5c6f9343ef3d10c7ad.zip",
-        hash="N-V-__8AAChCPQDTznpYvuAaKFuYLpNyfC0SuZY-7YUDOFiu"
+        url="https://github.com/stratoweave/stratoweave/archive/3264592a58639b206be14253d7ffe69843630905.zip",
+        hash="N-V-__8AANazPQAB06-in1sqFZHQk5qR2pfdi2TWkATiNtgH"
     ),
     "tmf": (
         repo_url="https://github.com/stratoweave/actmf",
-        url="https://github.com/stratoweave/actmf/archive/a82d80abbec73149c4a58a12d080392349b79bb0.zip",
-        hash="N-V-__8AAPDlBQDvZcQ509LAraUT9tuavIfZyKrvL7tIIIV2"
+        url="https://github.com/stratoweave/actmf/archive/a36d1be13fc4edfcc3bde36a0123a1abe6345fa6.zip",
+        hash="N-V-__8AAPDlBQCZ20nxAr09B4Ig6qAJlO5chv1MoHMv0ZAk"
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/880d949ee84b57c93b252547eb725eb1c133d0b8.zip",
-        hash="N-V-__8AAIj_JgDo7AD4YhnwecwNLIXUvCdo_lfgF9yVQJpo"
+        url="https://github.com/stratoweave/acton-yang/archive/c00115cd07db0ee062c85090d4c85f32ef805baa.zip",
+        hash="N-V-__8AACP5JgBjkphmkpC0_Doep_M_Ji8P-z3_5_exsKvl"
     )
 }
 zig_dependencies = {}


### PR DESCRIPTION
Refreshes Acton package pins after stratoweave/stratoweave@3264592a58639b206be14253d7ffe69843630905 landed on main.

This pull request is updated in place when newer stratoweave changes land.